### PR TITLE
This needs to be called "requires" in conan 0.7.2

### DIFF
--- a/examples/zmq_protobuf.rst
+++ b/examples/zmq_protobuf.rst
@@ -161,7 +161,7 @@ If not created, then create also a ``conanfile.txt`` with the following content:
 
 .. code-block:: text
 
-   [requirements]
+   [requires]
    zmqcpp/4.1.1@memsharded/testing
    Protobuf/2.6.1@memsharded/testing
    


### PR DESCRIPTION
I tried the example and had problems. Turns out that the option block needs to be named "requires" instead of "requirements"