### PR TITLE
fixed minimun cmake

### DIFF
--- a/examples/boost.rst
+++ b/examples/boost.rst
@@ -60,7 +60,7 @@ This is the project's ``CMakeLists.txt``:
 .. code-block:: cmake
 
    project(MyRegex)
-   cmake_minimum_required(VERSION 2.8)
+   cmake_minimum_required(VERSION 2.8.12)
 
    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
    conan_basic_setup()

--- a/examples/openssl.rst
+++ b/examples/openssl.rst
@@ -62,7 +62,7 @@ This is the project's ``CMakeLists.txt``:
 .. code-block:: cmake
 
     project(ExampleOpenSSL)
-    cmake_minimum_required(VERSION 2.8)
+    cmake_minimum_required(VERSION 2.8.12)
     
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup()
@@ -75,7 +75,7 @@ You can also use the classic CMake way by calling **find_package(OpenSSL)**:
 .. code-block:: cmake
 
     project(ExampleOpenSSL)
-    cmake_minimum_required(VERSION 2.8)
+    cmake_minimum_required(VERSION 2.8.12)
     
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup()

--- a/getting_started.rst
+++ b/getting_started.rst
@@ -118,7 +118,7 @@ that we should create inside our example folder:
 .. code-block:: cmake
 
    project(FoundationTimer)
-   cmake_minimum_required(VERSION 2.8)
+   cmake_minimum_required(VERSION 2.8.12)
 
    include(conanbuildinfo.cmake)
    conan_basic_setup()

--- a/integrations/cmake.rst
+++ b/integrations/cmake.rst
@@ -30,7 +30,7 @@ This is the ``CMakeLists.txt`` file we used in the :ref:`Getting started<getting
 .. code-block:: cmake
 
    project(FoundationTimer)
-   cmake_minimum_required(VERSION 2.8)
+   cmake_minimum_required(VERSION 2.8.12)
 
    include(conanbuildinfo.cmake)
    conan_basic_setup()
@@ -140,7 +140,7 @@ So, you can use **find_package** normally:
 .. code-block:: cmake
 
     project(MyHello)
-    cmake_minimum_required(VERSION 2.8)
+    cmake_minimum_required(VERSION 2.8.12)
     
     include(conanbuildinfo.cmake)
     conan_basic_setup()

--- a/manage_deps/conanfile_py.rst
+++ b/manage_deps/conanfile_py.rst
@@ -407,7 +407,7 @@ So let's use this option in our CMakeLists.txt
 .. code-block:: cmake
 
    project(FoundationTimer)
-   cmake_minimum_required(VERSION 2.8)
+   cmake_minimum_required(VERSION 2.8.12)
    
    include(conanbuildinfo.cmake)
    conan_basic_setup()

--- a/packaging/testing.rst
+++ b/packaging/testing.rst
@@ -64,7 +64,7 @@ Finally, the **CMakeLists.txt** is totally equivalent to what we have seen befor
 .. code-block:: cmake
 
    project(MyHello)
-   cmake_minimum_required(VERSION 2.8)
+   cmake_minimum_required(VERSION 2.8.12)
    
    include(conanbuildinfo.cmake)
    conan_basic_setup()


### PR DESCRIPTION
Cmake <2.8.12 fails in conanbuildinfo.cmake. It was probably undetected because even if we declare minimum 2.8, in practice we always use at least 2.8.12. @maitesin realized it was failing in travis, cause travis is cmake 2.8.7. 

I dont think we should change to support such old cmake syntax, so I have updated the minimum in the docs.