### PR TITLE
Fix name of Qbs - it's now just "Qbs"

### DIFF
--- a/integrations/qbs.rst
+++ b/integrations/qbs.rst
@@ -1,10 +1,10 @@
 .. _qbs:
 
 
-Qt Build Suite (qbs)
+Qbs
 _____________________
 
-As of version 0.7 of conan, a Qt Build Suite (qbs) generator is available
+As of version 0.7 of conan, a Qbs generator is available
 that can be configured as follows:
 
 **conanfile.txt**


### PR DESCRIPTION
We internally decided not to call it "Qt build suite" anymore.

See https://codereview.qt-project.org/#/c/161228/ and https://doc.qt.io/qbs/