### PR TITLE
AUR - also install python-monotonic

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -69,10 +69,11 @@ The easiest way is using **pacaur** tool:
 
 Or you can also use ``makepkg`` and install it following the `AUR docs: installing packages <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_.   
 
-Just remember to install two conan dependencies first. They are not in the official 
+Just remember to install three conan dependencies first. They are not in the official 
 repositories but there are in **AUR** repository too:
 
 - python-patch 
+- python-monotonic
 - python-fasteners
 
 


### PR DESCRIPTION
When installing conan manually from AUR, a user reports needing to install python-monotonic (see comments in https://aur.archlinux.org/packages/conan/) which is an AUR dependency of python-fasteners. It would be good to have this documented explicitly.