### PR TITLE
Change AppVeyor install to use python-pip

### DIFF
--- a/integrations/appveyor.rst
+++ b/integrations/appveyor.rst
@@ -39,9 +39,9 @@ Create an ``appveyor.yml`` file and paste this code in it:
 	
 	install:
 	  - cmd: echo "Downloading conan..."
-	  - ps: wget http://downloads.conan.io/latest_windows -OutFile conan_installer.exe
-	  - cmd: conan_installer.exe /VERYSILENT
-	  - cmd: set PATH=%PATH%;C:\Program Files (x86)\Conan\conan
+	  - cmd: set PATH=%PATH%;%PYTHON%/Scripts/
+	  - cmd: pip.exe install conan
+	  - cmd: conan user # Create the conan data directory
 	  - cmd: conan --version
 	
 	build_script:


### PR DESCRIPTION
## In brief
* Change AppVeyor install instructions to use ```python-pip``` instead of Windows installer
  * Improves reliability and generally works better
  * Lack of Python won't be an issue in AppVeyor

See https://github.com/conan-io/conan/issues/706#issuecomment-263323890