### PR TITLE
Conan 0.16.0 requires node-semver

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -69,12 +69,13 @@ The easiest way is using **pacaur** tool:
 
 Or you can also use ``makepkg`` and install it following the `AUR docs: installing packages <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_.   
 
-Just remember to install three conan dependencies first. They are not in the official 
+Just remember to install four conan dependencies first. They are not in the official 
 repositories but there are in **AUR** repository too:
 
 - python-patch 
 - python-monotonic
 - python-fasteners
+- python-node-semver
 
 
 


### PR DESCRIPTION
Since version 0.16.0 conan requires the python port of node-semver. For Arch Linux it is packaged on AUR as python-node-semver.