### PR TITLE
Reestructured commands and added missings docs

### DIFF
--- a/reference/commands.rst
+++ b/reference/commands.rst
@@ -10,29 +10,52 @@ conan export
 
 .. code-block:: bash
 
-	$ conan export [--path PATH] user/channel
+	$ conan export [-h] [--path PATH] [--keep-source] user
 
+Copies the package recipe (conanfile.py and associated files) to your local cache,
+where it can be shared and reused in other projects.
+From the local cache, it can be uploaded to a remote with the ``upload`` command.
+        
+ 
+.. code-block:: bash   
+    
+	       
+	positional arguments:
+	  user                  user_name[/channel]. By default, channel is "testing",
+	                        e.g., phil or phil/stable
+	
+	optional arguments:
+	  --path PATH, -p PATH  Optional. Folder with a conanfile.py. Default current
+	                        directory.
+	  --keep-source, -k     Optional. Do not remove the source folder in the local
+	                        cache. Use for testing purposes only
+	 
 
-Export a package recipe under the specified user_name/channel.
-A **conanfile.py** file has to be located in the specified path.
-By default, the path is the current directory and the channel is ``testing``.
 
 
 **Examples**
 
 
-Export a package recipe from the current directory, under the ``fenix/testing`` user:
+- Export a recipe from the current directory, under the ``fenix/testing`` user:
 
 .. code-block:: bash
 
 	$ conan export fenix
 
 
-Export a package recipe from any folder directory, under the ``fenix/stable`` user:
+- Export a recipe from any folder directory, under the ``fenix/stable`` user:
 
 .. code-block:: bash
 
 	$ conan export ./folder_name fenix/stable
+
+
+- Export a recipe without removing the source folder in the local cache:
+
+.. code-block:: bash
+
+	$ conan export fenix/stable -k
+	
 
 
 conan install
@@ -40,16 +63,73 @@ conan install
 
 .. code-block:: bash
 
-	$ conan install [package_recipe_ref] [--remote REMOTE] [--options OPTIONS] [--settings SETTINGS] [--scope SCOPE] [--profile PROFILE] [--update, -u] [--env ENV]
+	$ conan install [-h] [--package PACKAGE] [--all] [--file FILE] [--update]
+                        [--scope SCOPE] [--profile PROFILE]
+                        [--generator GENERATOR] [--werror]
+                        [--manifests [MANIFESTS]]
+                        [--manifests-interactive [MANIFESTS_INTERACTIVE]]
+                        [--verify [VERIFY]] [--no-imports] [-r REMOTE]
+                        [--options OPTIONS] [--settings SETTINGS] [--env ENV]
+                        [--build [BUILD [BUILD ...]]]
+                        [reference]
 
 
 
-Install a package recipe and a remote package that matches with the specified settings.
-It can be done specifying a ``package_recipe_ref`` (Hello/0.1@demo/testing) or installing the requirements defined in a ``conanfile.py`` or ``conanfile.txt``.
+Installs the requirements specified in a ``conanfile.py`` or ``conanfile.txt``.
+It can also be used to install a concrete recipe/package specified by the ``reference`` parameter.
+If the recipe is not found in the local cache it will retrieve the recipe from the remotes sequentially.
+When the recipe has been downloaded it will try to download a binary package matching the specified settings.
+If no binary package is found you can build the package from sources using the ``--build`` option.
+
+
+.. code-block:: bash
+
+
+	positional arguments:
+	  reference             package recipe referencee.g., MyPackage/1.2@user/channel or ./my_project/
+	
+	optional arguments:
+	  --package PACKAGE, -p PACKAGE
+	                        Force install specified package ID (ignore settings/options)
+	  --all                 Install all packages from the specified package recipe
+	  --file FILE, -f FILE  specify conanfile filename
+	  --update, -u          update with new upstream packages, overriding the local cache if needed.
+	  --scope SCOPE, -sc SCOPE
+	                        Use the specified scope in the install command
+	  --profile PROFILE, -pr PROFILE
+	                        Apply the specified profile to the install command
+	  --generator GENERATOR, -g GENERATOR
+	                        Generators to use
+	  --werror              Error instead of warnings for graph inconsistencies
+	  --manifests [MANIFESTS], -m [MANIFESTS]
+	                        Install dependencies manifests in folder for later verify. Default folder is .conan_manifests, but can be changed
+	  --manifests-interactive [MANIFESTS_INTERACTIVE], -mi [MANIFESTS_INTERACTIVE]
+	                        Install dependencies manifests in folder for later verify, asking user for confirmation. Default folder is .conan_manifests, but can be changed
+	  --verify [VERIFY], -v [VERIFY]
+	                        Verify dependencies manifests against stored ones
+	  --no-imports          Install specified packages but avoid running imports
+	  -r REMOTE, --remote REMOTE
+	                        look in the specified remote server
+	  --options OPTIONS, -o OPTIONS
+	                        Options to build the package, overriding the defaults. e.g., -o with_qt=true
+	  --settings SETTINGS, -s SETTINGS
+	                        Settings to build the package, overriding the defaults. e.g., -s compiler=gcc
+	  --env ENV, -e ENV     Environment variables that will be set during the package build, -e CXX=/usr/bin/clang++
+	  --build [BUILD [BUILD ...]], -b [BUILD [BUILD ...]]
+	                        Optional, use it to choose if you want to build from sources:
+	                        
+	                        --build            Build all from sources, do not use binary packages.
+	                        --build=never      Default option. Never build, use binary packages or fail if a binary package is not found.
+	                        --build=missing    Build from code if a binary package is not found.
+	                        --build=outdated   Build from code if the binary is not built with the current recipe or when missing binary package.
+	                        --build=[pattern]  Build always these packages from source, but never build the others. Allows multiple --build parameters.
+		
+	
+
 
 **Examples**
 
-Install a package requirement from a ``conanfile.txt``, saved in your current directory with one option and setting:
+- Install a package requirement from a ``conanfile.txt``, saved in your current directory with one option and setting:
 
 .. code-block:: bash
 
@@ -69,14 +149,14 @@ Install a package requirement from a ``conanfile.txt``, saved in your current di
    don't specify them again in the command line.
    
 
-Install the **OpenCV/2.4.10@lasote/testing** reference with its default options and settings:
+- Install the **OpenCV/2.4.10@lasote/testing** reference with its default options and settings:
 
 .. code-block:: bash
 
 	$ conan install opencv/2.4.10@lasote/testing
    
    
-Install the **OpenCV/2.4.10@lasote/testing** reference updating the recipe and the binary package if new upstream versions are available:
+- Install the **OpenCV/2.4.10@lasote/testing** reference updating the recipe and the binary package if new upstream versions are available:
 
 .. code-block:: bash
 
@@ -139,62 +219,37 @@ See :ref:`using options section <usingoptions>` for more information.
    You can use :ref:`profiles <profiles>` files to create predefined sets of **settings**, **options**, **environment variables** and **scopes**
 
 
-
-conan build
------------
-Utility command to run your current project **conanfile.py** ``build()`` method. It doesn't
-work for **conanfile.txt**. It is convenient for automatic translation of conan settings and options,
-for example to CMake syntax, as it can be done by the CMake helper. It is also a good starting point
-if you would like to create a package from your current project.
-
-
-conan test_package
-------------------
-
-The **test_package** (previously named **test**) command looks for a ``test_package`` subfolder in the current directory, and builds the
-project that is in it. It will typically be a project with a single requirement, pointing to
-the **conanfile.py** being developed in the current directory.
-
-This is intended to do a test of the package, not to run unit or integrations tests on the package
-being created. Those tests could be launched if desired in the ``build()`` method.
-
-The command line arguments are exactly the same as the settings, options, and build parameters
-for the **install** command, with one small difference.
-
-In conan test, by default, the **--build=CurrentPackage** pattern is automatically apended for the
-current tested package. You can always manually specify other build options, like **--build=never**,
-if you just want to check that the current existing package works for the test subproject, without
-re-building it.
-
-If you want to use a different folder name than **test_package**, just use it and pass it to the ``-f folder``
-command line option
-
-.. code-block:: bash
-
-    $ conan test_package --f my_test_folder
-
-
-This command will run the equivalent to ``conan export <user>/<channel>`` where ``user`` and ``channel``
-will be deduced from the values of the requirement in the ``conanfile.py`` inside the test subfolder.
-This is very convenient, as if you are running a package test it is extremely likely that you have
-just edited the package recipe. If the package recipe is locally modified, it has to be exported again,
-otherwise, the package will be tested with the old recipe. If you want to inhibit this ``export``,
-you can use the ``-ne, --no-export`` parameter.
-
-
 conan search
 ------------
-
-Conan search can search both for package recipes and package binaries. If you provide a pattern,
-then it will search for existing package recipes matching that pattern:
 
 .. code-block:: bash
 
 	$ conan search [-r REMOTE] [pattern]
 
-Get complete information about the specified package recipe reference pattern.
-You can use it on remote or local storage, if nothing is specified, the local conan cache is
-assumed:
+Search both package recipes and package binaries in the local cache or a remote server.
+If you provide a pattern, then it will search for existing package recipes matching that pattern.
+
+You can search in a remote or in the local cache, if nothing is specified, the local conan cache is
+assumed.
+
+.. code-block:: bash
+
+	positional arguments:
+	  pattern               Pattern name, e.g. openssl/* or package recipe
+	                        reference if "-q" is used. e.g.
+	                        MyPackage/1.2@user/channel
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  --case-sensitive      Make a case-sensitive search
+	  -r REMOTE, --remote REMOTE
+	                        Remote origin
+	  -q QUERY, --query QUERY
+	                        Packages query: "os=Windows AND (arch=x86 OR
+	                        compiler=gcc)". The "pattern" parameter has to be a
+	                        package recipe reference: MyPackage/1.2@user/channel
+
+**Examples**
 
 
 .. code-block:: bash
@@ -232,7 +287,6 @@ If you specify a query filter for a setting and the package recipe is not restri
     
     
 The query above will find all the MyRecipe binary packages, because the recipe doesn't declare "os" as a setting.
-   
 
 
 conan info
@@ -240,15 +294,43 @@ conan info
 
 .. code-block:: bash
 
-   $ conan info [package or path] [--update, -u]
+   $ usage: conan info [-h] [--file FILE] [-r REMOTE] [--options OPTIONS]
+                  [--settings SETTINGS] [--only ONLY] [--update]
+                  [--build_order BUILD_ORDER] [--build [BUILD [BUILD ...]]]
+                  [--scope SCOPE]
+                  [reference]
 
-Get complete information about the specified package recipe pattern or path. 
+Prints information about a package recipe's dependency tree. 
 You can use it for your current project (just point to the path if you want), or for any
 existing package in your local cache.
+
 
 The ``--update`` option will check if there is any new recipe/package available in remotes. Use ``conan install -u``
 to update them.
 
+
+.. code-block:: bash
+
+	positional arguments:
+	  reference             reference name or path to conanfile file, e.g., MyPackage/1.2@user/channel or ./my_project/
+	
+	optional arguments:
+	  --file FILE, -f FILE  specify conanfile filename
+	  -r REMOTE, --remote REMOTE
+	                        look in the specified remote server
+	  --options OPTIONS, -o OPTIONS
+	                        Options to build the package, overriding the defaults. e.g., -o with_qt=true
+	  --settings SETTINGS, -s SETTINGS
+	                        Settings to build the package, overriding the defaults. e.g., -s compiler=gcc
+	  --only ONLY, -n ONLY  show fields only
+	  --update, -u          check updates exist from upstream remotes
+	  --build_order BUILD_ORDER, -bo BUILD_ORDER
+	                        given a modified reference, return an ordered list to build (CI)
+	  --build [BUILD [BUILD ...]], -b [BUILD [BUILD ...]]
+	                        given a build policy (same install command "build" parameter), return an ordered list of packages that would be built from sources in install command
+	  --scope SCOPE, -sc SCOPE
+	                        Define scopes for packages
+	
 
 **Examples**:
 
@@ -294,15 +376,215 @@ changed (most likely due to a git push on that package):
 Note the result is a list of lists. When there is more than one element in one of the lists, it means
 that they are decoupled projects and they can be built in parallel by the CI system.
 
+Also you can get a list of nodes that would be built (simulation) in an install command specifying a build policy with the ``--build`` parameter:
+
+e.g., If I try to install ``Boost/1.60.0@lasote/stable`` recipe with ``--build missing`` build policy and arch=x86, Which libraries will be build?
+
+.. code-block:: bash
+
+	$ conan info Boost/1.60.0@lasote/stable --build missing -s arch=x86
+	bzip2/1.0.6@lasote/stable, zlib/1.2.8@lasote/stable, Boost/1.60.0@lasote/stable
+	
+	
+
+
+conan remote
+------------
+
+.. code-block:: bash
+
+   $ conan remote [-h] {list,add,remove,update,list_ref,add_ref,remove_ref,update_ref}
+   
+
+Handles the remote list and the package recipes associated to a remote.
+
+   
+.. code-block:: bash
+
+	positional arguments:
+	  {list,add,remove,update,list_ref,add_ref,remove_ref,update_ref}
+	                        sub-command help
+	    list                list current remotes
+	    add                 add a remote
+	    remove              remove a remote
+	    update              update the remote url
+	    list_ref            list the package recipes and its associated remotes
+	    add_ref             associate a recipe's reference to a remote
+	    remove_ref          dissociate a recipe's reference and its remote
+	    update_ref          update the remote associated with a package recipe
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+		
+
+**Examples**
+
+- List remotes:
+
+.. code-block:: bash
+
+   $ conan remote list
+   
+   conan.io: https://server.conan.io [Verify SSL: True]
+   local: http://localhost:9300 [Verify SSL: True]
+   
+   
+
+- Add a new remote:
+
+.. code-block:: bash
+
+   $ conan remote add remote_name remote_url [verify_ssl]
+   
+ 
+Verify SSL option can be True or False (default True). Conan client will verify the SSL certificates.
+
+
+- Remove a remote:
+
+.. code-block:: bash
+
+   $ conan remote remove remote_name
+
+
+- Update a remote:
+
+.. code-block:: bash
+
+   $ conan remote update remote_name new_url [verify_ssl]
+   
+
+- List the package recipes and its associated remotes:
+
+.. code-block:: bash
+
+   $ conan remote list_ref
+
+   bzip2/1.0.6@lasote/stable: conan.io
+   Boost/1.60.0@lasote/stable: conan.io
+   zlib/1.2.8@lasote/stable: conan.io
+   
+   
+- Associate a recipe's reference to a remote:
+
+
+.. code-block:: bash
+
+   $ conan remote add_ref package_recipe_ref remote_name
+   
+   
+- Update the remote associated with a package recipe:
+
+.. code-block:: bash
+
+   $ conan remote update_ref package_recipe_ref new_remote_name
+
+
+
+
+conan profile
+-------------
+
+.. code-block:: bash
+
+	$ conan profile [-h] {list,show} ...
+	
+	
+List all the profiles existing in the ``.conan/profiles`` folder, or show details for a given profile.
+The ``list`` subcommand will always use the default user ``.conan/profiles`` folder. But the 
+``show`` subcommand is able to resolve absolute and relative paths, as well as to map names to 
+``.conan/profiles`` folder, in the same way as the ``--profile`` install argument. 
+
+	
+.. code-block:: bash
+
+	positional arguments:
+	  {list,show}  sub-command help
+	    list       list current profiles
+	    show       show the values defined for a profile. Can be a path (relative
+	               or absolute) to a profile file in any location.
+
+
+**Examples**
+
+- List the profiles:
+
+.. code-block:: bash
+
+   $ conan profile list
+   > myprofile1
+   > myprofile2
+   
+- Print profile contents:
+
+.. code-block:: bash
+
+   $ conan profile show myprofile1
+   Profile myprofile1
+   [settings]
+   ...
+   
+- Print profile contents (in the standard directory ``.conan/profiles``):
+
+.. code-block:: bash
+
+   $ conan profile show myprofile1
+   Profile myprofile1
+   [settings]
+   ...
+   
+- Print profile contents (in a custom directory):
+
+.. code-block:: bash
+
+   $ conan profile show /path/to/myprofile1
+   Profile myprofile1
+   [settings]
+   ...
+
+
 
 conan upload
 ------------
 
 .. code-block:: bash
 
-	$ conan upload [--package PACKAGE] [--remote REMOTE] [--all] [--force]
+	$ conan upload [-h] [--package PACKAGE] [--remote REMOTE] [--all]
+                    [--force] [--confirm] [--retry RETRY]
+                    [--retry_wait RETRY_WAIT]
+                    pattern
 
-Uploads packages from your local to remote storage. If you use the ``--force`` variable, it wiil not check the package date. It will override the remote with the local package.
+Uploads recipes and binary packages from your local cache to a remote server.
+
+If you use the ``--force`` variable, it won't check the package date. It will override the remote with the local package.
+
+If you use a pattern instead of a conan recipe reference you can use the ``-c`` or ``--confirm`` option to upload all the matching recipes.
+
+If you use the ``--retry`` option you can specify how many times should conan try to upload the packages in case of fail. The default is 2.
+With ``--retry_wait`` you can specify the seconds to wait between upload attempts.
+
+
+.. code-block:: bash
+
+	positional arguments:
+	  pattern               Pattern or package recipe reference, e.g.,
+	                        "openssl/*", "MyPackage/1.2@user/channel"
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  --package PACKAGE, -p PACKAGE
+	                        package ID to upload
+	  --remote REMOTE, -r REMOTE
+	                        upload to this specific remote
+	  --all                 Upload both package recipe and packages
+	  --force               Do not check conan recipe date, override remote with
+	                        local
+	  --confirm, -c         If pattern is given upload all matching recipes
+	                        without confirmation
+	  --retry RETRY         In case of fail it will retry the upload again N times
+	  --retry_wait RETRY_WAIT
+	                        Waits specified seconds before retry again
+		
 
 **Examples**:
 
@@ -319,20 +601,72 @@ Uploads a package recipe and all the generated packages to a specified remote:
 	$ conan upload OpenCV/1.4.0@lasote/stable --all -r my_remote
 
 
+Uploads all recipes and packages from our local cache to my_remote without confirmation:
+
+.. code-block:: bash
+
+   $ conan upload "*" --all -r my_remote -c
+   
+Upload all local packages and recipes begining with "Op" retrying 3 times and waiting 10 seconds between upload attempts:
+
+.. code-block:: bash
+
+   $ conan upload "Op*" --all -r my_remote -c --retry 3 --retry_wait 10
+
 conan remove
 ------------
 
 .. code-block:: bash
 
-	$ conan remove [-p [PACKAGES]] [-b [BUILDS]] [-f] [-r REMOTE] pattern
+	$ conan remove [-h] [-p [PACKAGES]] [-b [BUILDS]] [-s] [-f] [-r REMOTE]
+                    pattern
+
 
 Remove any package recipe folders matching a pattern, or their packages and/or build folders.
 
-**Example**:
+
+.. code-block:: bash
+
+	positional arguments:
+	  pattern               Pattern name, e.g., openssl/*
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  -p [PACKAGES], --packages [PACKAGES]
+	                        By default, remove all the packages or select one,
+	                        specifying the SHA key
+	  -b [BUILDS], --builds [BUILDS]
+	                        By default, remove all the build folders or select
+	                        one, specifying the SHA key
+	  -s, --src             Remove source folders
+	  -f, --force           Remove without requesting a confirmation
+	  -r REMOTE, --remote REMOTE
+	                        Will remove from the specified remote
+
+
+**Examples**:
+
+- Remove only the packages from all the recipes matching ``OpenSSL/*`` pattern:
+
 
 .. code-block:: bash
 
 	$ conan remove OpenSSL/* --packages
+	
+
+- Remove the build folders from all the recipes matching ``OpenSSL/*`` pattern without request confirmation:
+	
+.. code-block:: bash
+
+	$ conan remove OpenSSL/* --builds --force
+
+
+- Remove the recipe and the packages from a specific remote:
+	
+.. code-block:: bash
+
+	$ conan remove OpenSSL/1.0.2@lasote/stable -r myremote
+
 
 
 conan user
@@ -340,171 +674,101 @@ conan user
 
 .. code-block:: bash
 
-	$ conan user [-p PASSWORD] [--remote REMOTE] [name]
+	$ conan user [-h] [-p PASSWORD] [--remote REMOTE] [-c] [name]
 
 Update your cached user name [and password] to avoid it being requested later, e.g. while you're uploading a package.
-You can have more than one user, and locally manage all your packages from your different accounts,
-without having to change user. Just **conan export user/channel** the conanfiles, and develop.
-Changing the user, or introducing the password is only necessary for uploading to the servers.
-
-
-conan remote
-------------
-
-Handles the remote list and the package recipes associated to a remote.
-
+You can have more than one user (one per remote). Changing the user, or introducing the password is only necessary to upload 
+packages to a remote.
 
 .. code-block:: bash
 
-   $ conan remote  {list,add,remove,update,list_ref,add_ref,remove_ref,update_ref}
+	positional arguments:
+	  name                  Username you want to use. If no name is provided it
+	                        will show the current user.
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  -p PASSWORD, --password PASSWORD
+	                        User password. Use double quotes if password with
+	                        spacing, and escape quotes if existing
+	  --remote REMOTE, -r REMOTE
+	                        look in the specified remote server
+	  -c, --clean           Remove user and tokens for all remotes
 
 
-* List remotes:
 
-.. code-block:: bash
+**Examples**:
 
-   $ conan remote list
-   
-   conan.io: https://server.conan.io [Verify SSL: True]
-   local: http://localhost:9300 [Verify SSL: True]
-   
-   
-
-* Add a new remote:
-
-.. code-block:: bash
-
-   $ conan remote add remote_name remote_url [verify_ssl]
-   
- 
-Verify SSL option can be True or False (default True). Conan client will verify the SSL certificates.
-
-
-* Remove a remote:
+- List my user for each remote:
 
 .. code-block:: bash
 
-   $ conan remote remove remote_name
-
-
-* Update a remote:
-
-.. code-block:: bash
-
-   $ conan remote update remote_name new_url [verify_ssl]
-   
-
-* List the package recipes and its associated remotes:
+	$ conan user
+	
+	
+- Change **conan.io** remote user to **foo**:
 
 .. code-block:: bash
 
-   $ conan remote list_ref
+	$ conan user foo -r conan.io
 
-   bzip2/1.0.6@lasote/stable: conan.io
-   Boost/1.60.0@lasote/stable: conan.io
-   zlib/1.2.8@lasote/stable: conan.io
-   
-   
-* Associate a recipe's reference to a remote:
-
+- Change **conan.io** remote user to **foo** checking and storing the password:
 
 .. code-block:: bash
 
-   $ conan remote add_ref package_recipe_ref remote_name
-   
-   
-* Update the remote associated with a package recipe:
-
-.. code-block:: bash
-
-   $ conan remote update_ref package_recipe_ref new_remote_name
-   
-conan source
-------------
-
-The ``source`` command executes a conanfile.py ``source()`` method, retrieving source code as
-defined in the method, both locally, in user space or for a package in the local cache.
-
-Positional arguments:
-
-* **reference**   Package recipe reference name. e.g. openssl/1.0.2@lasote/testing or local path, e.g. ./myproject
-
-Optional arguments:
-
-* **-f, --force**  In the case of local cache, force the removal of the source folder, then the execution and
-  retrieval of the source code. Otherwise, if the code has already been retrieved, it will do nothing.
+	$ conan user foo -r conan.io -p mypassword
 
 
-In user space, the command will execute a local conanfile.py ``source()`` method, in the current
-directory.
 
-.. code-block:: bash
-
-   $ conan source ../mysource_folder
-
-
-In the conan local cache, it will execute the recipe ``source()`` , in the corresponding ``source``
-folder, as defined by the local cache layout. This command is useful for retrieving such source
-code before launching multiple concurrent package builds, that could otherwise collide in the
-source code retrieval process.
-
-.. code-block:: bash
-
-   $ conan source Pkg/0.2@user/channel
-
-
-conan package
--------------
-
-Intended for package creators, for regenerating a package without recompiling the source. That is,
-it is just an optimization. Most likely **command not needed** for most use cases.
-Calls your conanfile.py ``package()`` method. 
-It is necessary that the package has already been built locally.
-
-.. code-block:: bash
-
-   $ conan package [-h] reference [package]
-
-
-Positional arguments:
-
- * **reference**    Package recipe reference name. e.g. openssl/1.0.2@lasote/testing, or path, e.g. ../build_folder
- * **package**      Package ID to regenerate. e.g.9cf83afd07b678d38a9c1645f605875400847ff3. This
-   optional parameter is only used for the local conan cache.
-
-
-This command also works locally, in the user space, and it will copy artifacts from the provided
-folder to the current one.
-
-.. code-block:: bash
-
-   $ conan package ../build
-
-This local command is useful for extracting artifacts locally from a build (without being a real
-conan package), or to test things before actually creating a conan package.
+.. note::
+	
+	The password is not stored in the client machine at any moment. Conan uses JWT, with this system conan
+	will get a token (expirable) checking the password against a remote. If the password is correct, then will store that 
+	token in the client. For any further interaction with the remotes, Conan client will only use the JWT token.
 
 
 conan copy
 ----------
 
-Copy conan recipes and packages to another user/channel. Useful to promote packages (e.j. from "beta" to "stable"). 
+.. code-block:: bash
+
+   $ conan copy package_recipe_ref otheruser/otherchannel
+
+
+Copy conan recipes and packages to another user/channel. Useful to promote packages (e.g. from "beta" to "stable"). 
 Also for moving packages from an user to another.
 
 
 .. code-block:: bash
 
-   $ conan copy package_recipe_ref otheruser/otherchannel
+    positional arguments:
+	  reference             package recipe referencee.g.,
+	                        MyPackage/1.2@user/channel
+	  user_channel          Destination user/channele.g., lasote/testing
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  --package PACKAGE, -p PACKAGE
+	                        copy specified package ID
+	  --all                 Copy all packages from the specified package recipe
+	  --force               Override destination packages and the package recipe
+	    
+	    
+**Examples**
 
-Positional arguments:
+- Promote a package to **stable** from **beta**:
 
- * **package_recipe_ref**   Package recipe reference name. e.g. openssl/1.0.2@lasote/testing
- * **user_channel**         Destination user/channel. e.g. lasote/stable
+.. code-block:: bash
 
-Optional arguments:
+    $ conan copy OpenSSL/1.0.2i@lasote/beta lasote/stable
+    
+    
+- Change a package's username:
 
-  * **-p** Specify a package to copy. e.g. -p 9cf83afd07b678d38a9c1645f605875400847ff3
-  * **--force** Override destination packages and the package recipe.
-  * **--all**   Copy all packages from the specified package recipe
+.. code-block:: bash
+
+    $ conan copy OpenSSL/1.0.2i@lasote/beta foo/beta
+
 
 
 conan new
@@ -512,31 +776,251 @@ conan new
 
 .. code-block:: bash
 
-   $ conan new package/version@user/channel
+   $ conan new [-h] [-t] [-i] [-c] name
 
 
 Creates a new ``conanfile.py`` file from a template.
 
+.. code-block:: bash
 
- * **-t, --test**              Create test_package skeleton to test_package command.
- * **-i, --header**            Create a headers only package template.
- * **-c, --pure_c**            Create a C language package only package (non-headers).
+	positional arguments:
+	  name          Package name, e.g.: Poco/1.7.3@user/testing
+	
+	optional arguments:
+	  -h, --help    show this help message and exit
+	  -t, --test    Create test_package skeleton to test package
+	  -i, --header  Create a headers only package template
+	  -c, --pure_c  Create a C language package only package, 
+	                deleting "self.settings.compiler.libcxx" setting in the configure method
 
-**Examples**
+
+**Examples**:
 
 
-Create a new ``conanfile.py`` for a new package **mypackage/1.0@myuser/stable**
+- Create a new ``conanfile.py`` for a new package **mypackage/1.0@myuser/stable**
 
 .. code-block:: bash
 
    $ conan new mypackage/1.0@myuser/stable
 
 
-Create also a test_package folder skeleton:
+- Create also a test_package folder skeleton:
 
 .. code-block:: bash
 
    $ conan new mypackage/1.0@myuser/stable -t
+
+
+
+
+conan test_package
+------------------
+
+.. code-block:: bash
+
+	$ conan test_package [-h] [-ne] [-f FOLDER] [--scope SCOPE]
+	                          [--keep-source] [--update] [--profile PROFILE]
+	                          [-r REMOTE] [--options OPTIONS]
+	                          [--settings SETTINGS] [--env ENV]
+	                          [--build [BUILD [BUILD ...]]]
+	                          [path]
+
+
+
+The **test_package** (previously named **test**) command looks for a ``test_package`` subfolder in the current directory, and builds the
+project that is in it. It will typically be a project with a single requirement, pointing to
+the **conanfile.py** being developed in the current directory.
+
+This is intended to do a test of the package, not to run unit or integrations tests on the package
+being created. Those tests could be launched if desired in the ``build()`` method.
+
+The command line arguments are exactly the same as the settings, options, and build parameters
+for the **install** command, with one small difference.
+
+In conan test, by default, the **--build=CurrentPackage** pattern is automatically apended for the
+current tested package. You can always manually specify other build options, like **--build=never**,
+if you just want to check that the current existing package works for the test subproject, without
+re-building it.
+
+You can use the ``conan new`` command with the ``-t`` option to generate a test_package skeleton.
+
+
+.. code-block:: bash
+
+	positional arguments:
+	  path                  path to conanfile file, e.g. /my_project/
+	
+	optional arguments:
+	  -ne, --not-export     Do not export the conanfile before test execution
+	  -f FOLDER, --folder FOLDER
+	                        alternative test folder name
+	  --scope SCOPE, -sc SCOPE
+	                        Use the specified scope in the install command
+	  --keep-source, -k     Optional. Do not remove the source folder in local cache. Use for testing purposes only
+	  --update, -u          update with new upstream packages, overriding the local cache if needed.
+	  --profile PROFILE, -pr PROFILE
+	                        Apply the specified profile to the install command
+	  -r REMOTE, --remote REMOTE
+	                        look in the specified remote server
+	  --options OPTIONS, -o OPTIONS
+	                        Options to build the package, overriding the defaults. e.g., -o with_qt=true
+	  --settings SETTINGS, -s SETTINGS
+	                        Settings to build the package, overriding the defaults. e.g., -s compiler=gcc
+	  --env ENV, -e ENV     Environment variables that will be set during the package build, -e CXX=/usr/bin/clang++
+	  --build [BUILD [BUILD ...]], -b [BUILD [BUILD ...]]
+	                        Optional, use it to choose if you want to build from sources:
+	                        
+	                        --build            Build all from sources, do not use binary packages.
+	                        --build=never      Default option. Never build, use binary packages or fail if a binary package is not found.
+	                        --build=missing    Build from code if a binary package is not found.
+	                        --build=outdated   Build from code if the binary is not built with the current recipe or when missing binary package.
+	                        --build=[pattern]  Build always these packages from source, but never build the others. Allows multiple --build parameters.
+		
+
+
+If you want to use a different folder name than **test_package**, just use it and pass it to the ``-f folder``
+command line option
+
+.. code-block:: bash
+
+    $ conan test_package --f my_test_folder
+
+
+This command will run the equivalent to ``conan export <user>/<channel>`` where ``user`` and ``channel``
+will be deduced from the values of the requirement in the ``conanfile.py`` inside the test subfolder.
+This is very convenient, as if you are running a package test it is extremely likely that you have
+just edited the package recipe. If the package recipe is locally modified, it has to be exported again,
+otherwise, the package will be tested with the old recipe. If you want to inhibit this ``export``,
+you can use the ``-ne, --no-export`` parameter.
+
+
+conan source
+------------
+
+.. code-block:: bash
+
+   $ conan source [-h] [-f] [reference]
+
+
+The ``source`` command executes a conanfile.py ``source()`` method, retrieving source code as
+defined in the method, both locally, in user space or for a package in the local cache.
+
+
+.. code-block:: bash
+
+	positional arguments:
+	  reference    package recipe reference. e.g., MyPackage/1.2@user/channel or
+	               ./my_project/
+	
+	optional arguments:
+	  -h, --help   show this help message and exit
+	  -f, --force  In the case of local cache, force the removal of the source
+	               folder, then the execution and retrieval of the source code.
+	               Otherwise, if the code has already been retrieved, it will do
+	               nothing.
+		
+
+
+**Examples**:
+
+- Call a local recipe's source method: In user space, the command will execute a local conanfile.py 
+  ``source()`` method, in the current directory.
+
+.. code-block:: bash
+
+   $ conan source ../mysource_folder
+
+
+- Call a cached recipe's source method: In the conan local cache, it will execute the recipe ``source()`` , 
+  in the corresponding ``source`` folder, as defined by the local cache layout. 
+  This command is useful for retrieving such source code before launching multiple concurrent package builds, 
+  that could otherwise collide in the source code retrieval process.
+
+.. code-block:: bash
+
+   $ conan source Pkg/0.2@user/channel
+   
+   
+
+conan build
+-----------
+
+
+.. code-block:: bash
+
+	$ conan build [-h] [--file FILE] [--profile PROFILE] [path]
+
+Utility command to run your current project **conanfile.py** ``build()`` method. It doesn't
+work for **conanfile.txt**. It is convenient for automatic translation of conan settings and options,
+for example to CMake syntax, as it can be done by the CMake helper. It is also a good starting point
+if you would like to create a package from your current project.
+
+
+
+.. code-block:: bash
+
+	positional arguments:
+	  path                  path to conanfile.py, e.g., conan build .
+	
+	optional arguments:
+	  --file FILE, -f FILE  specify conanfile filename
+	  --profile PROFILE, -pr PROFILE Apply a profile
+	
+
+conan package
+-------------
+
+.. code-block:: bash
+
+   $ conan package [-h] reference [package]
+
+
+Calls your conanfile.py "package" method for a specific package recipe.
+Intended for package creators, for regenerating a package without recompiling
+the source, i.e. for troubleshooting, and fixing the package() method, not
+normal operation. 
+
+It requires the package has been built locally, it won't
+re-package otherwise. When used in a user space project, it
+will execute from the build folder specified as parameter, and the current
+directory. This is useful while creating package recipes or just for
+extracting artifacts from the current project, without even being a package
+
+This command also works locally, in the user space, and it will copy artifacts from the provided
+folder to the current one.
+
+.. code-block:: bash
+
+    positional arguments:
+	  reference   package recipe reference e.g. MyPkg/0.1@user/channel, or local
+	              path to the build folder (relative or absolute)
+	  package     Package ID to regenerate. e.g.,
+	              9cf83afd07b678d38a9c1645f605875400847ff3 This optional parameter
+	              is only used for the local conan cache.
+
+
+**Examples**
+
+
+- Copy artifacts from the provided ``build`` folder to the current one:
+
+.. code-block:: bash
+
+   $ conan package ../build
+
+
+- Copy the artifacts from the build directory to package directory in the local cache:
+
+
+.. code-block:: bash
+
+	$ conan package MyPackage/1.2@user/channel 9cf83afd07b678da9c1645f605875400847ff3 
+
+
+.. note:: 
+
+    Conan package command won't create a new package, use 'install' or 'test_package' instead for
+    creating packages in the conan local cache, or `build' for conanfile.py in user space.
 
 
 
@@ -545,64 +1029,60 @@ conan imports
 
 .. code-block:: bash
 
-   $ conan imports
+   $ conan imports [-h] [--file FILE] [-d DEST] [-u] [reference]
 
 
-Execute the ``imports`` stage of a conanfile.txt or a conanfile.py
 
-Positional arguments:
+Execute the ``imports`` stage of a conanfile.txt or a conanfile.py. It requires
+to have been previously installed it and have a conanbuildinfo.txt generated file.
 
- * **reference**   Specify the location of the folder containing the conanfile.
-   By default it will be the current directory. It can also use a full reference e.g. openssl/1.0.2@lasote/testing
-   and the recipe ``imports()`` for that package in the local conan cache will be used
-
-Optional arguments:
-
-
- * **-u, --undo**              Undo imports. Remove imported files
- * **-f, --file**              Use another filename, e.g.: ``conan imports -f=conanfile2.py``
- * **-d, --dest**              Directory to copy the artifacts to. By default it will be the current
-   directory.
-
-
-The ``imports`` functionality needs the existence of the file ``conanbuildinfo.txt``, so it has
-to be generated in the previous ``conan install``, either specifying it in the conanfile, or as
-a command line parameter:
-
-**Examples**
+The ``imports`` functionality needs a ``conanbuildinfo.txt`` file, so it has
+to be generated with a previous ``conan install`` either specifying it in the conanfile, or as
+a command line parameter. It will generate a manifest file called ``conan_imports_manifests.txt``
+with the files that have been copied from conan local cache to user space. 
 
 
 .. code-block:: bash
 
-   $ conan install --no-imports -g txt
+	positional arguments:
+	  reference             Specify the location of the folder containing the
+	                        conanfile. By default it will be the current directory.
+	                        It can also use a full reference e.g.
+	                        MyPackage/1.2@user/channel and the recipe
+	                        'imports()' for that package in the local conan cache
+	                        will be used
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  --file FILE, -f FILE  Use another filename, e.g.: conan imports
+	                        -f=conanfile2.py
+	  -d DEST, --dest DEST  Directory to copy the artifacts to. By default it will
+	                        be the current directory
+	  -u, --undo            Undo imports. Remove imported files
+
+
+
+**Examples**
+
+- Execute the imports method for a package in the local cache:
+
+
+.. code-block:: bash
+
+   $ conan imports MyPackage/1.2@user/channel
+   
+   
+- Import files from a current conanfile in current directory:
+
+.. code-block:: bash
+
+   $ conan install --no-imports -g txt # Creates the conanbuildinfo.txt
    $ conan imports
    
 
-The ``imports`` functionality will generate a manifest file called ``conan_imports_manifests.txt``
-of the files that have been copied from conan local cache to user space. This manifest can be used
-to automatically remove this file, with the command:
+- Remove the copied files (undo the import):
+
 
 .. code-block:: bash
 
    $ conan imports --undo
-
-
-conan profile
-----------------
-
-.. code-block:: bash
-
-   $ conan profile list
-   > myprofile1
-   > myprofile2
-   $ conan profile show myprofile1
-   Profile myprofile1
-   [settings]
-   ...
-
-
-List all the profiles existing in the ``.conan/profiles`` folder, or show details for a given profile.
-
-The ``list`` subcommand will always use the default user ``.conan/profiles`` folder. But the 
-``show`` subcommand is able to resolve absolute and relative paths, as well as to map names to 
-``.conan/profiles`` folder, in the same way as the ``--profile`` install argument. 

--- a/reference/commands.rst
+++ b/reference/commands.rst
@@ -93,7 +93,7 @@ If no binary package is found you can build the package from sources using the `
 	                        Force install specified package ID (ignore settings/options)
 	  --all                 Install all packages from the specified package recipe
 	  --file FILE, -f FILE  specify conanfile filename
-	  --update, -u          update with new upstream packages, overriding the local cache if needed.
+	  --update, -u          update with new upstream packages, overwriting the local cache if needed.
 	  --scope SCOPE, -sc SCOPE
 	                        Use the specified scope in the install command
 	  --profile PROFILE, -pr PROFILE
@@ -111,9 +111,9 @@ If no binary package is found you can build the package from sources using the `
 	  -r REMOTE, --remote REMOTE
 	                        look in the specified remote server
 	  --options OPTIONS, -o OPTIONS
-	                        Options to build the package, overriding the defaults. e.g., -o with_qt=true
+	                        Options to build the package, overwriting the defaults. e.g., -o with_qt=true
 	  --settings SETTINGS, -s SETTINGS
-	                        Settings to build the package, overriding the defaults. e.g., -s compiler=gcc
+	                        Settings to build the package, overwriting the defaults. e.g., -s compiler=gcc
 	  --env ENV, -e ENV     Environment variables that will be set during the package build, -e CXX=/usr/bin/clang++
 	  --build [BUILD [BUILD ...]], -b [BUILD [BUILD ...]]
 	                        Optional, use it to choose if you want to build from sources:
@@ -319,9 +319,9 @@ to update them.
 	  -r REMOTE, --remote REMOTE
 	                        look in the specified remote server
 	  --options OPTIONS, -o OPTIONS
-	                        Options to build the package, overriding the defaults. e.g., -o with_qt=true
+	                        Options to build the package, overwriting the defaults. e.g., -o with_qt=true
 	  --settings SETTINGS, -s SETTINGS
-	                        Settings to build the package, overriding the defaults. e.g., -s compiler=gcc
+	                        Settings to build the package, overwriting the defaults. e.g., -s compiler=gcc
 	  --only ONLY, -n ONLY  show fields only
 	  --update, -u          check updates exist from upstream remotes
 	  --build_order BUILD_ORDER, -bo BUILD_ORDER
@@ -622,7 +622,7 @@ conan remove
                     pattern
 
 
-Remove any package recipe folders matching a pattern, or their packages and/or build folders.
+Remove any package recipe folders matching a pattern, or their package and/or build folders.
 
 
 .. code-block:: bash
@@ -857,15 +857,15 @@ You can use the ``conan new`` command with the ``-t`` option to generate a test_
 	  --scope SCOPE, -sc SCOPE
 	                        Use the specified scope in the install command
 	  --keep-source, -k     Optional. Do not remove the source folder in local cache. Use for testing purposes only
-	  --update, -u          update with new upstream packages, overriding the local cache if needed.
+	  --update, -u          update with new upstream packages, overwriting the local cache if needed.
 	  --profile PROFILE, -pr PROFILE
 	                        Apply the specified profile to the install command
 	  -r REMOTE, --remote REMOTE
 	                        look in the specified remote server
 	  --options OPTIONS, -o OPTIONS
-	                        Options to build the package, overriding the defaults. e.g., -o with_qt=true
+	                        Options to build the package, overwriting the defaults. e.g., -o with_qt=true
 	  --settings SETTINGS, -s SETTINGS
-	                        Settings to build the package, overriding the defaults. e.g., -s compiler=gcc
+	                        Settings to build the package, overwriting the defaults. e.g., -s compiler=gcc
 	  --env ENV, -e ENV     Environment variables that will be set during the package build, -e CXX=/usr/bin/clang++
 	  --build [BUILD [BUILD ...]], -b [BUILD [BUILD ...]]
 	                        Optional, use it to choose if you want to build from sources:
@@ -996,7 +996,8 @@ folder to the current one.
 	              path to the build folder (relative or absolute)
 	  package     Package ID to regenerate. e.g.,
 	              9cf83afd07b678d38a9c1645f605875400847ff3 This optional parameter
-	              is only used for the local conan cache.
+	              is only used for the local conan cache. If not specified, ALL binaries 
+	              for this recipe are re-packaged
 
 
 **Examples**

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -60,3 +60,30 @@ that will be checked when using ``self.user`` or ``self.channel`` in ``conanfile
 in user space, where a user/channel has not been assigned yet (it is assigned when exported in the local cache)
 
 Read more about it in :ref:`user_channel`
+
+
+CONAN_ENV_XXXX_YYYY
+-------------------
+You can override the default settings (located in your ``~/.conan/conan.conf`` directory) with environment variables.
+
+The ``XXXX`` is the setting name upper-case, and the ``YYYY`` (optional) is the sub-setting name.
+
+**Examples**:
+
+- Override the default compiler:
+
+.. code-block:: bash
+
+	CONAN_ENV_COMPILER = "Visual Studio"
+
+- Override the default compiler version:
+
+.. code-block:: bash
+
+	CONAN_ENV_COMPILER_VERSION = "14"
+
+- Override the architecture:
+
+.. code-block:: bash
+
+	CONAN_ENV_ARCH = "x86"

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -89,6 +89,8 @@ download()
 ----------
 Retrieves a file from a given URL into a file with a given filename. It uses certificates from a
 list of known verifiers for https downloads, but this can be optionally disabled.
+You can also specify the number of retries in case of fail with ``retry`` parameter and the seconds to wait before download attempts
+with ``retry_wait``.
 
 .. code-block:: python
 
@@ -97,6 +99,8 @@ list of known verifiers for https downloads, but this can be optionally disabled
     tools.download("http://someurl/somefile.zip", "myfilename.zip")
     # to disable verification:
     tools.download("http://someurl/somefile.zip", "myfilename.zip", verify=False)
+    # to retry the download 2 times waiting 5 seconds between them
+    tools.download("http://someurl/somefile.zip", "myfilename.zip", retry=2, retry_wait=5)
     
     
 replace_in_file()


### PR DESCRIPTION
Every command following the same structure:

- Command execution line help
- Command explanation
- Command complete parameter help
- Command examples

And unified with conan command help messages.
Changed command order, first the consumer commands, then the package creator commands and the conanfile methods invocation (package, imports, build) less used than others.