### PR TITLE
Add python-distro to the list of AUR dependencies

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -60,13 +60,14 @@ The easiest way is using **pacaur** tool:
 
 Or you can also use ``makepkg`` and install it following the `AUR docs: installing packages <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_.   
 
-Just remember to install four conan dependencies first. They are not in the official 
+Just remember to install five conan dependencies first. They are not in the official 
 repositories but there are in **AUR** repository too:
 
 - python-patch 
 - python-monotonic
 - python-fasteners
 - python-node-semver
+- python-distro
 
 
 Install the binaries


### PR DESCRIPTION
python-distro was missing from the list of AUR dependencies for Arch Linux, add it to the instructions.