### PR TITLE
adding PkgName prefix to all options

### DIFF
--- a/mastering/scopes.rst
+++ b/mastering/scopes.rst
@@ -44,7 +44,7 @@ First, we are going to see how to control the tests build with an **option** (ge
    endif()
 
 
-Then we could use ``conan install -o build_test=False/True`` to activate or deactivate the tests launch.
+Then we could use ``conan install -o Poco:build_test=False/True`` to activate or deactivate the tests launch.
 
 
 But, what happens if we are creating a conan package?

--- a/reference/commands/info.rst
+++ b/reference/commands/info.rst
@@ -57,7 +57,7 @@ to update them.
                             look in the specified remote server
       --options OPTIONS, -o OPTIONS
                             Options to build the package, overwriting the
-                            defaults. e.g., -o with_qt=true
+                            defaults. e.g., -o PkgName:with_qt=true
       --settings SETTINGS, -s SETTINGS
                             Settings to build the package, overwriting the
                             defaults. e.g., -s compiler=gcc

--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -63,7 +63,7 @@ If no binary package is found you can build the package from sources using the `
                             look in the specified remote server
       --options OPTIONS, -o OPTIONS
                             Options to build the package, overwriting the
-                            defaults. e.g., -o with_qt=true
+                            defaults. e.g., -o PkgName:with_qt=true
       --settings SETTINGS, -s SETTINGS
                             Settings to build the package, overwriting the
                             defaults. e.g., -s compiler=gcc
@@ -89,7 +89,7 @@ If no binary package is found you can build the package from sources using the `
 
 .. code-block:: bash
 
-    $ conan install . -o use_debug_mode=on -s compiler=clang
+    $ conan install . -o PkgName:use_debug_mode=on -s compiler=clang
 
 
 .. note::

--- a/reference/commands/package_files.rst
+++ b/reference/commands/package_files.rst
@@ -28,7 +28,7 @@ Creates a package binary from given precompiled artifacts in user folder, skippi
       --profile PROFILE, -pr PROFILE
                             Profile for this package
       --options OPTIONS, -o OPTIONS
-                            Options for this package. e.g., -o with_qt=true
+                            Options for this package. e.g., -o PkgName:with_qt=true
       --settings SETTINGS, -s SETTINGS
                             Settings for this package e.g., -s compiler=gcc
       -f, --force           Overwrite existing package if existing

--- a/reference/commands/test_package.rst
+++ b/reference/commands/test_package.rst
@@ -68,7 +68,7 @@ You can use the ``conan new`` command with the ``-t`` option to generate a ``tes
                             look in the specified remote server
       --options OPTIONS, -o OPTIONS
                             Options to build the package, overwriting the
-                            defaults. e.g., -o with_qt=true
+                            defaults. e.g., -o PkgName:with_qt=true
       --settings SETTINGS, -s SETTINGS
                             Settings to build the package, overwriting the
                             defaults. e.g., -s compiler=gcc


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/issues/1076#issuecomment-307995115

This ensures the command line is always identical for both ```test_package`` and ``install``