### PR TITLE
Remove python-fasteners from AUR dependencies

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -62,11 +62,10 @@ The easiest way is using **pacaur** tool:
 
 Or you can also use ``makepkg`` and install it following the `AUR docs: installing packages <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_.   
 
-Just remember to install five conan dependencies first. They are not in the official 
+Just remember to install four conan dependencies first. They are not in the official 
 repositories but there are in **AUR** repository too:
 
 - python-patch 
-- python-monotonic
 - python-node-semver
 - python-distro
 - python-pluginbase

--- a/installation.rst
+++ b/installation.rst
@@ -62,12 +62,11 @@ The easiest way is using **pacaur** tool:
 
 Or you can also use ``makepkg`` and install it following the `AUR docs: installing packages <https://wiki.archlinux.org/index.php/Arch_User_Repository>`_.   
 
-Just remember to install six conan dependencies first. They are not in the official 
+Just remember to install five conan dependencies first. They are not in the official 
 repositories but there are in **AUR** repository too:
 
 - python-patch 
 - python-monotonic
-- python-fasteners
 - python-node-semver
 - python-distro
 - python-pluginbase


### PR DESCRIPTION
python-fasteners was moved from AUR to the official Arch Linux community repo. It can now be fetched automatically by pacman and makepkg.