### PR TITLE
#233 Update Gitlab integration

### DIFF
--- a/integrations/gitlab.rst
+++ b/integrations/gitlab.rst
@@ -1,5 +1,9 @@
+.. _gitlab_integration:
 
-|gitlab_logo| Gitlab 
+
+.. _gitlab:
+
+|gitlab_logo| Gitlab
 =============================
 
 You can use `Gitlab CI`_ cloud or local service to automatically build and test your project in Linux/OSX/Windows environments.
@@ -26,7 +30,7 @@ Clone the project from github:
    $ git clone https://github.com/lasote/conan-gtest-example
 
 
-Create a ``.gitlab-ci.yml`` file and paste this code in it: 
+Create a ``.gitlab-ci.yml`` file and paste this code in it:
 
 
 .. code-block:: text
@@ -49,12 +53,29 @@ Gitlab CI will install the **conan** tool and will execute the **conan install**
 Then, the **script** section creates the build folder, compiles the project with **cmake** and runs the **tests**.
 
 
-Creating and testing conan package binaries
----------------------------------------------------------
+Creating, testing and uploading conan package binaries
+------------------------------------------------------
 You can use Gitlab CI to automate the building of binary packages, which will be created in the
-cloud after pushing to Gitlab. You can probably setup your own way, but it is recommended
-to use :ref:`conan tools for package creators <package_tools>`
+cloud after pushing to Gitlab. You can probably setup your own way, but conan has some utilities to help in the process.
 
+The command ``conan new`` has arguments to create a default working ``.gitlab-ci.yml`` file.
+Other setups might be possible, but for this example we are assuming that you are using github and also uploading your final packages to Bintray.
+You could follow these steps:
+
+#. First, create an empty gitlab repository, lets call it "hello", for creating a "hello world" package. Gitlab allows to create it with a Readme, license and .gitignore.
+#. Get the credentials User and API Key (remember, Bintray uses the API key as "password", not your main Bintray account password)
+#. Create a conan repository in Bintray under your user or organization, and get its URL ("Set me up"). We will call it ``UPLOAD_URL``
+#. Under your project page, *Settings -> Pipelines -> Add a variable*, add the ``CONAN_PASSWORD`` environment variable with the Bintray API Key. If your Bintray user is different from the package user, you can define your Bintray username too, defining the environment variable ``CONAN_LOGIN_USERNAME``
+#. Clone the repo: ``$ git clone <your_repo/hello> && cd hello``
+#. Create the package: ``$ conan new Hello/0.1@<user>/testing -t -s -ciglg -ciglc -cis -ciu=UPLOAD_URL`` where ``user`` is your Bintray username
+#. You can inspect the created files: both ``.gitlab-ci.yml`` and the ``build.py`` script, that is used by ``conan-package-tools`` utility to split different builds with different configurations in different GitLab CI jobs.
+#. You can test locally, before pushing, with ``$ conan test_package`` or by GitLab Runner
+#. Add the changes, commit and push: ``$ git add . && git commit -m "first commit" && git push``
+#. Go to Pipelines page and see the pipeline, with the different jobs.
+#. When it finish, go to your Bintray repository, you should see there the uploaded packages for different configurations
+#. Check locally, searching in Bintray: ``$ conan search Hello/0.1@<user>/testing -r=mybintray``
+
+If something fails, please report an issue in the ``conan-package-tools`` github repository: https://github.com/conan-io/conan-package-tools
 
 .. |gitlab_logo| image:: ../images/gitlab_logo.png
 .. _`Gitlab CI`: https://gitlab.com/

--- a/packaging/bintray/conan_center_guide.rst
+++ b/packaging/bintray/conan_center_guide.rst
@@ -87,8 +87,8 @@ CI Integration
     - **Mac OSX:** Two latest versions of apple-clang, e.j (8.0, 8.1) or newer.
     - **Windows:** Visual Studio 12, 14 and 15 (or newer)
 
-- The easiest way to provide the CI integration (with Appveyor for Windows builds and Travis.ci for Linux and OSX) is to
-  use the :ref:`conan new<conan_new>` command. Take a look to the options to generate a library layout with the needed appveyor/travis.
+- The easiest way to provide the CI integration (with Appveyor for Windows builds, Travis.ci for Linux and OSX, and Gitlab for Linux) is to
+  use the :ref:`conan new<conan_new>` command. Take a look to the options to generate a library layout with the needed appveyor/travis/gitlab.
 
   You can also copy the following files from this `zlib Conan package repository`_ and adapt them:
 
@@ -96,7 +96,7 @@ CI Integration
     - ``.travis.yml`` file. Adjust your username, library reference etc
     - ``appveyor.yml`` file. Adjust your username, library reference etc
 
-- Take a look to the :ref:`Travis CI<travis_integration>` and :ref:`Appveyor<appveyor_ci>` integration guides.
+- Take a look to the :ref:`Travis CI<travis_integration>`, :ref:`Appveyor<appveyor_ci>` and :ref:`GitLab CI<gitlab_integration>` integration guides.
 
 
 

--- a/reference/commands/new.rst
+++ b/reference/commands/new.rst
@@ -7,7 +7,7 @@ conan new
 .. code-block:: bash
 
    $ conan new [-h] [-t] [-i] [-c] [-s] [-b] [-cis] [-cilg] [-cilc] [-cio]
-               [-ciw] [-gi] [-ciu CI_UPLOAD_URL]
+               [-ciw] [-ciglg] [-ciglc] [-gi] [-ciu CI_UPLOAD_URL]
                name
 
 
@@ -32,13 +32,15 @@ package testing files.
      -b, --bare     Create the minimum package recipe, without build() or
                     package()methods. Useful in combination with "package_files"
                     command
-     -cis, --ci_shared        Package will have a "shared" option to be used in CI
-     -cilg, --ci_travis_gcc   Generate travis-ci files for linux gcc
-     -cilc, --ci_travis_clang Generate travis-ci files for linux clang
-     -cio, --ci_travis_osx    Generate travis-ci files for OSX apple-clang
-     -ciw, --ci_appveyor_win  Generate appveyor files for Appveyor Visual Studio
-     -gi, --gitignore         Generate a .gitignore with the known patterns to
-                              excluded
+     -cis, --ci_shared           Package will have a "shared" option to be used in CI
+     -cilg, --ci_travis_gcc      Generate travis-ci files for linux gcc
+     -cilc, --ci_travis_clang    Generate travis-ci files for linux clang
+     -cio, --ci_travis_osx       Generate travis-ci files for OSX apple-clang
+     -ciw, --ci_appveyor_win     Generate appveyor files for Appveyor Visual Studio
+     -ciglg, --ci_gitlab_gcc     Generate GitLab files for linux gcc
+     -ciglc, --ci_gitlab_clang   Generate GitLab files for linux clang
+     -gi, --gitignore            Generate a .gitignore with the known patterns to
+                                 excluded
      -ciu CI_UPLOAD_URL, --ci_upload_url CI_UPLOAD_URL Define URL of the repository to upload
 
 **Examples**:
@@ -64,3 +66,8 @@ package testing files.
 
    $ conan new mypackage/1.0@myuser/stable -t -cilg -cio -ciw
 
+- Create files for gitlab (linux) Continuous integration and set upload conan server:
+
+.. code-block:: bash
+
+  $ conan new mypackage/1.0@myuser/stable -t -ciglg -ciglc -ciu https://api.bintray.com/conan/myuser/myrepo


### PR DESCRIPTION
This PR includes:

* Updated `conan new` reference to support Gitlab CI.
* Added step-by-step how to create a new Conan project in Gitlab.