### PR TITLE
Added note about Win10 long paths feature only working with Python3.6

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -508,6 +508,7 @@ This attribute will not have any effect in other OS, it will be discarded.
 
 From Windows 10 (ver. 10.0.14393), it is possible to opt-in disabling the path limits. Check `this link
 <https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath>`_ for more info. Latest python installers might offer to enable this while installing python. With this limit removed, the ``short_paths`` functionality is totally unnecessary.
+Please note that this only works with Python 3.6 and newer.
 
 
 no_copy_source

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -263,4 +263,5 @@ Specify the base folder to be used with the :ref:`short paths<short_paths_refere
 marked as `short_paths` will be stored in the `C:\\.conan` (or the current drive letter).
 
 If the variable is set to "None" will disable the `short_paths` feature in Windows,
-for modern Windows that enable long paths at the system level.
+for modern Windows that enable long paths at the system level. 
+Please note that this only works with Python 3.6 and newer.


### PR DESCRIPTION
After some experimentation and research I found that earlier Python versions can't take advantage of the long paths feature in newer Windows 10 builds. First version to support it is Python 3.6. I think it's important to note this in the docs.

https://stackoverflow.com/questions/46488118/win32-long-paths-from-python/46489473#46489473

https://docs.python.org/3/using/windows.html#removing-the-max-path-limitation