### PR TITLE
Formatted MSBuild helper in reference

### DIFF
--- a/reference/build_helpers/msbuild.rst
+++ b/reference/build_helpers/msbuild.rst
@@ -35,9 +35,9 @@ You can adjust all the information from the requirements accessing to the ``buil
 
         def build(self):
             msbuild = MSBuild(self)
-            msbuild.env_build.include_paths.append("mycustom/directory/to/headers")
-            msbuild.env_build.lib_paths.append("mycustom/directory/to/libs")
-            msbuild.env_build.link_flags = []
+            msbuild.build_env.include_paths.append("mycustom/directory/to/headers")
+            msbuild.build_env.lib_paths.append("mycustom/directory/to/libs")
+            msbuild.build_env.link_flags = []
 
             msbuild.build("MyProject.sln")
 

--- a/reference/build_helpers/msbuild.rst
+++ b/reference/build_helpers/msbuild.rst
@@ -1,6 +1,5 @@
 .. _msbuild:
 
-
 MSBuild
 =======
 
@@ -8,16 +7,14 @@ Calls Visual Studio ``msbuild`` command to build a ``sln`` project:
 
 .. code-block:: python
 
-   from conans import ConanFile, MSBuild
+    from conans import ConanFile, MSBuild
 
-   class ExampleConan(ConanFile):
+    class ExampleConan(ConanFile):
+        ...
 
-       ...
-
-       def build(self):
-          msbuild = MSBuild(self)
-          msbuild.build("MyProject.sln")
-
+        def build(self):
+            msbuild = MSBuild(self)
+            msbuild.build("MyProject.sln")
 
 Internally the ``MSBuild`` build helper uses:
 
@@ -25,31 +22,56 @@ Internally the ``MSBuild`` build helper uses:
       environment variables with all the information from the requirements: include directories, library names, flags etc.
     - :ref:`tools.msvc_build_command<msvc_build_command>` to call msbuild.
 
-
-You can adjust all the information from the requirements accessing to the ``env_build`` that it is a
+You can adjust all the information from the requirements accessing to the ``build_env`` that it is a
 :ref:`VisualStudioBuildEnvironment<visual_studio_build_environment>` object:
 
 .. code-block:: python
-   :emphasize-lines: 3, 4, 5
+   :emphasize-lines: 8, 9, 10
 
-      def build(self):
-          msbuild = MSBuild(self)
-          msbuild.env_build.include_paths.append("mycustom/directory/to/headers")
-          msbuild.env_build.lib_paths.append("mycustom/directory/to/libs")
-          msbuild.env_build.link_flags = []
+    from conans import ConanFile, MSBuild
 
-          msbuild.build("MyProject.sln")
+    class ExampleConan(ConanFile):
+        ...
+
+        def build(self):
+            msbuild = MSBuild(self)
+            msbuild.env_build.include_paths.append("mycustom/directory/to/headers")
+            msbuild.env_build.lib_paths.append("mycustom/directory/to/libs")
+            msbuild.env_build.link_flags = []
+
+            msbuild.build("MyProject.sln")
+
+Constructor
+-----------
+
+.. code-block:: python
+
+    class MSBuild(object):
+
+        def __init__(self, conanfile)
+
+Parameters:
+    - **conanfile** (Required): ConanFile object. Usually ``self`` in a ``conanfile.py``.
 
 Methods
 -------
 
-* **build(self, project_file, targets=None, upgrade_project=True, build_type=None, arch=None, parallel=True, force_vcvars=False, toolset=None)**:
+build()
++++++++
 
-   - **project_file**: Path to the ``sln`` file.
-   - **targets**: Optional. Defaulted to None. You can specify a specific target name.
-   - **upgrade_project**: Optional. Defaulted to True. Will call ``devenv`` to upgrade the solution to your current Visual Studio.
-   - **build_type**: Optional. Defaulted to None, will use the ``settings.build_type``
-   - **arch**: Optional. Defaulted to None, will use ``settings.arch``
-   - **force_vcvars**: Optional. Defaulted to False. Will ignore if the environment is already set for a different Visual Studio version.
-   - **parallel**: Optional. Defaulted to True, will use the configured number of cores in the :ref:`conan.conf<conan_conf>` file (``cpu_count``).
-   - **toolset**: Specify a toolset. Will append a ``/p:PlatformToolset`` option.
+.. code-block:: python
+
+    def build(self, project_file, targets=None, upgrade_project=True, build_type=None, arch=None,
+              parallel=True, force_vcvars=False, toolset=None)
+
+Builds Visual Studio project with the given parameters. It will call ``tools.msvc_build_command()``.
+
+Parameters:
+    - **project_file** (Required): Path to the ``sln`` file.
+    - **targets** (Optional, Defaulted to ``None``): List of targets to build.
+    - **upgrade_project** (Optional, Defaulted to ``True``): Will call ``devenv`` to upgrade the solution to your current Visual Studio.
+    - **build_type** (Optional, Defaulted to ``None``): Optional. Defaulted to None, will use the ``settings.build_type``
+    - **arch** (Optional, Defaulted to ``None``): Optional. Defaulted to None, will use ``settings.arch``
+    - **force_vcvars** (Optional, Defaulted to ``False``): Will ignore if the environment is already set for a different Visual Studio version.
+    - **parallel** (Optional, Defaulted to ``True``): Will use the configured number of cores in the :ref:`conan.conf<conan_conf>` file (``cpu_count``).
+    - **toolset** (Optional, Defaulted to ``None``): Specify a toolset. Will append a ``/p:PlatformToolset`` option.


### PR DESCRIPTION
- Constructor section
- Methods and Constructor signature
- Defaulted values in properties
- Fix `build_env `variable
- Adds build description