### PR TITLE
Fix build_dir and  source_dir in meson and cmake

### DIFF
--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -28,7 +28,7 @@ Using the helper methods:
    def build(self):
       cmake = CMake(self)
       cmake.configure()
-      # same as cmake.configure(source_folder=self.source_folder, build_folder="./")
+      # same as cmake.configure(source_folder=self.source_folder, build_folder=self.build_folder)
       cmake.build()
       cmake.install()
 
@@ -134,8 +134,10 @@ Methods
 
     - **args**: A list of additional arguments to be passed to the ``cmake`` command. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **definitions**: A dict that will be converted to a list of CMake command line variable definitions of the form ``-DKEY=VALUE``. Each value will be escaped according to the current shell and can be either ``str``, ``bool`` or of numeric type
-    - **source_folder**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``build`` folder if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified). Relative paths are allowed and will be relative to ``build_folder``
-    - **build_folder**: CMake's output directory. The default value is the package ``build`` root folder if ``None`` is specified. The ``CMake`` object will store ``build_folder`` internally for subsequent calls to ``build()``
+    - **source_folder**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``self.source_folder`` if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified).
+      Relative paths are allowed and will be relative to ``self.source_folder``.
+    - **build_folder**: CMake's output directory. The default value is the ``self.build_folder`` if ``None`` is specified.
+      The ``CMake`` object will store ``build_folder`` internally for subsequent calls to ``build()``.
     - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
       This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_folder** when working in the local cache.
       See :ref:`self.in_local_cache<in_local_cache>`.

--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -28,7 +28,7 @@ Using the helper methods:
    def build(self):
       cmake = CMake(self)
       cmake.configure()
-      # same as cmake.configure(source_dir=self.source_folder, build_dir="./")
+      # same as cmake.configure(source_dir=self.source_folder, build_folder="./")
       cmake.build()
       cmake.install()
 
@@ -130,23 +130,23 @@ Attributes
 Methods
 -------
 
-- **configure** (args=None, defs=None, source_dir=None, build_dir=None)
+- **configure** (args=None, defs=None, source_dir=None, build_folder=None)
 
     - **args**: A list of additional arguments to be passed to the ``cmake`` command. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **definitions**: A dict that will be converted to a list of CMake command line variable definitions of the form ``-DKEY=VALUE``. Each value will be escaped according to the current shell and can be either ``str``, ``bool`` or of numeric type
-    - **source_dir**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``build`` folder if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified). Relative paths are allowed and will be relative to ``build_dir``
-    - **build_dir**: CMake's output directory. The default value is the package ``build`` root folder if ``None`` is specified. The ``CMake`` object will store ``build_dir`` internally for subsequent calls to ``build()``
-    - **cache_build_dir**: Use the given subfolder as build folder when building the package in the local cache.
-      This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_dir** when working in the local cache.
+    - **source_dir**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``build`` folder if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified). Relative paths are allowed and will be relative to ``build_folder``
+    - **build_folder**: CMake's output directory. The default value is the package ``build`` root folder if ``None`` is specified. The ``CMake`` object will store ``build_folder`` internally for subsequent calls to ``build()``
+    - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
+      This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_folder** when working in the local cache.
       See :ref:`self.in_local_cache<in_local_cache>`.
 
 - **build** (args=None, build_dir=None, target=None)
 
     - **args**: A list of additional arguments to be passed to the ``cmake`` command. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
-    - **build_dir**: CMake's output directory. If ``None`` is specified the ``build_dir`` from ``configure()`` will be used.
+    - **build_dir**: CMake's output directory. If ``None`` is specified the ``build_folder`` from ``configure()`` will be used.
     - **target**: Specifies the target to execute. The default *all* target will be built if ``None`` is specified. ``"install"`` can be used to relocate files to aid packaging
 
 - **install** (args=None, build_dir=None, target=None)
 
     - **args**: A list of additional arguments to be passed to the ``cmake`` command. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
-    - **build_dir**: CMake's output directory. If ``None`` is specified the ``build_dir`` from ``configure()`` will be used.
+    - **build_dir**: CMake's output directory. If ``None`` is specified the ``build_folder`` from ``configure()`` will be used.

--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -134,7 +134,7 @@ Methods
 
     - **args**: A list of additional arguments to be passed to the ``cmake`` command. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **definitions**: A dict that will be converted to a list of CMake command line variable definitions of the form ``-DKEY=VALUE``. Each value will be escaped according to the current shell and can be either ``str``, ``bool`` or of numeric type
-    - **source_folder**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``self.source_folder`` if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified).
+    - **source_folder**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``self.source_folder``.
       Relative paths are allowed and will be relative to ``self.source_folder``.
     - **build_folder**: CMake's output directory. The default value is the ``self.build_folder`` if ``None`` is specified.
       The ``CMake`` object will store ``build_folder`` internally for subsequent calls to ``build()``.

--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -28,7 +28,7 @@ Using the helper methods:
    def build(self):
       cmake = CMake(self)
       cmake.configure()
-      # same as cmake.configure(source_dir=self.source_folder, build_folder="./")
+      # same as cmake.configure(source_folder=self.source_folder, build_folder="./")
       cmake.build()
       cmake.install()
 
@@ -130,11 +130,11 @@ Attributes
 Methods
 -------
 
-- **configure** (args=None, defs=None, source_dir=None, build_folder=None)
+- **configure** (args=None, defs=None, source_folder=None, build_folder=None)
 
     - **args**: A list of additional arguments to be passed to the ``cmake`` command. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **definitions**: A dict that will be converted to a list of CMake command line variable definitions of the form ``-DKEY=VALUE``. Each value will be escaped according to the current shell and can be either ``str``, ``bool`` or of numeric type
-    - **source_dir**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``build`` folder if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified). Relative paths are allowed and will be relative to ``build_folder``
+    - **source_folder**: CMake's source directory where ``CMakeLists.txt`` is located. The default value is the ``build`` folder if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified). Relative paths are allowed and will be relative to ``build_folder``
     - **build_folder**: CMake's output directory. The default value is the package ``build`` root folder if ``None`` is specified. The ``CMake`` object will store ``build_folder`` internally for subsequent calls to ``build()``
     - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
       This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_folder** when working in the local cache.

--- a/reference/build_helpers/meson.rst
+++ b/reference/build_helpers/meson.rst
@@ -29,14 +29,14 @@ Methods
     - **backend**: Specify a backend to be used, otherwise it will use "Ninja".
     - **build_type**: Force to use a build type, ignoring the read from the settings.
 
-- **configure** (args=None, defs=None, source_dir=None, build_dir=None, pkg_config_paths=None)
+- **configure** (args=None, defs=None, source_dir=None, build_folder=None, pkg_config_paths=None)
 
     - **args**: A list of additional arguments to be passed to the ``configure`` script. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **defs**: A list of definitions
     - **source_dir**: Default conanfile.source_folder.
-    - **build_dir**: Default conanfile.build_folder
+    - **build_folder**: Default conanfile.build_folder
     - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
-      This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_dir** when working in the local cache.
+      This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_folder** when working in the local cache.
       See :ref:`self.in_local_cache<in_local_cache>`.
     - **pkg_config_paths**: A list containing paths to locate the pkg-config files (\*.pc). Default conanfile.build_folder.
 
@@ -66,7 +66,7 @@ A typical usage of the Meson build helper, if you want to be able to both execut
         def build(self):
             meson = Meson(self)
             meson.configure(source_dir="%s/src" % self.source_folder, 
-                            build_dir="build")
+                            build_folder="build")
             meson.build()
 
         def package(self):

--- a/reference/build_helpers/meson.rst
+++ b/reference/build_helpers/meson.rst
@@ -33,8 +33,10 @@ Methods
 
     - **args**: A list of additional arguments to be passed to the ``configure`` script. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **defs**: A list of definitions
-    - **source_folder**: Default conanfile.source_folder.
-    - **build_folder**: Default conanfile.build_folder
+    - **source_folder**: Meson's source directory where ``meson.build`` is located. The default value is the ``self.source_folder`` if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified).
+      Relative paths are allowed and will be relative to ``self.source_folder``.
+    - **build_folder**: Meson's output directory. The default value is the ``self.build_folder`` if ``None`` is specified.
+      The ``Meson`` object will store ``build_folder`` internally for subsequent calls to ``build()``.
     - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
       This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_folder** when working in the local cache.
       See :ref:`self.in_local_cache<in_local_cache>`.

--- a/reference/build_helpers/meson.rst
+++ b/reference/build_helpers/meson.rst
@@ -15,7 +15,7 @@ Meson
 
        def build(self):
            meson = Meson(self)
-           meson.configure(cache_build_dir="build")
+           meson.configure(cache_build_folder="build")
            meson.build()
 
 
@@ -35,7 +35,7 @@ Methods
     - **defs**: A list of definitions
     - **source_dir**: Default conanfile.source_folder.
     - **build_dir**: Default conanfile.build_folder
-    - **cache_build_dir**: Use the given subfolder as build folder when building the package in the local cache.
+    - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
       This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_dir** when working in the local cache.
       See :ref:`self.in_local_cache<in_local_cache>`.
     - **pkg_config_paths**: A list containing paths to locate the pkg-config files (\*.pc). Default conanfile.build_folder.

--- a/reference/build_helpers/meson.rst
+++ b/reference/build_helpers/meson.rst
@@ -33,7 +33,7 @@ Methods
 
     - **args**: A list of additional arguments to be passed to the ``configure`` script. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **defs**: A list of definitions
-    - **source_folder**: Meson's source directory where ``meson.build`` is located. The default value is the ``self.source_folder`` if ``None`` is specified (or the ``source`` folder if ``no_copy_source`` is specified).
+    - **source_folder**: Meson's source directory where ``meson.build`` is located. The default value is the ``self.source_folder``.
       Relative paths are allowed and will be relative to ``self.source_folder``.
     - **build_folder**: Meson's output directory. The default value is the ``self.build_folder`` if ``None`` is specified.
       The ``Meson`` object will store ``build_folder`` internally for subsequent calls to ``build()``.

--- a/reference/build_helpers/meson.rst
+++ b/reference/build_helpers/meson.rst
@@ -29,11 +29,11 @@ Methods
     - **backend**: Specify a backend to be used, otherwise it will use "Ninja".
     - **build_type**: Force to use a build type, ignoring the read from the settings.
 
-- **configure** (args=None, defs=None, source_dir=None, build_folder=None, pkg_config_paths=None)
+- **configure** (args=None, defs=None, source_folder=None, build_folder=None, pkg_config_paths=None)
 
     - **args**: A list of additional arguments to be passed to the ``configure`` script. Each argument will be escaped according to the current shell. No extra arguments will be added if ``args=None``
     - **defs**: A list of definitions
-    - **source_dir**: Default conanfile.source_folder.
+    - **source_folder**: Default conanfile.source_folder.
     - **build_folder**: Default conanfile.build_folder
     - **cache_build_folder**: Use the given subfolder as build folder when building the package in the local cache.
       This argument doesn't have effect when the package is being built in user folder with ``conan build`` but overrides **build_folder** when working in the local cache.
@@ -65,7 +65,7 @@ A typical usage of the Meson build helper, if you want to be able to both execut
 
         def build(self):
             meson = Meson(self)
-            meson.configure(source_dir="%s/src" % self.source_folder, 
+            meson.configure(source_folder="%s/src" % self.source_folder, 
                             build_folder="build")
             meson.build()
 


### PR DESCRIPTION
- Renamed `cache_build_dir` to `cache_build_folder`
- Changed `build_dir` to `build_folder` in meson and cmake configures
- Changed `source_dir` to `source_folder` in meson and cmake configures