### PR TITLE
Fix warnings in bash code blocks

### DIFF
--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -70,9 +70,9 @@ concrete recipe/package specifying a reference in the "path" parameter.
                             binary is not built with the current recipe or when
                             missing binary package. --build=[pattern] Build always
                             these packages from source, but never build the
-                            others. Allows multiple --build parameters. 'pattern'
+                            others. Allows multiple --build parameters. "pattern"
                             is a fnmatch file pattern of a package name. Default
-                            behavior: If you don't specify anything, it will be
+                            behavior: If you dont specify anything, it will be
                             similar to --build=never, but package recipes can
                             override it and decide to build with "build_policy"
 

--- a/reference/commands/creator/create.rst
+++ b/reference/commands/creator/create.rst
@@ -68,9 +68,9 @@ created correctly. Check the 'conan test' command to know more about the
                             binary is not built with the current recipe or when
                             missing binary package. --build=[pattern] Build always
                             these packages from source, but never build the
-                            others. Allows multiple --build parameters. 'pattern'
+                            others. Allows multiple --build parameters. "pattern"
                             is a fnmatch file pattern of a package name. Default
-                            behavior: If you don't specify anything, it will be
+                            behavior: If you dont specify anything, it will be
                             similar to --build=never, but package recipes can
                             override it and decide to build with "build_policy"
 

--- a/reference/commands/creator/test.rst
+++ b/reference/commands/creator/test.rst
@@ -47,9 +47,9 @@ create`` command.
                             binary is not built with the current recipe or when
                             missing binary package. --build=[pattern] Build always
                             these packages from source, but never build the
-                            others. Allows multiple --build parameters. 'pattern'
+                            others. Allows multiple --build parameters. "pattern"
                             is a fnmatch file pattern of a package name. Default
-                            behavior: If you don't specify anything, it will be
+                            behavior: If you dont specify anything, it will be
                             similar to --build=never, but package recipes can
                             override it and decide to build with "build_policy"
 


### PR DESCRIPTION
**Do not use ' in bash code blocks**

Fixes warning generarintg docs: `WARNING: Could not lex literal_block as "bash". Highlighting skipped.`