### PR TITLE
Updating note on remote prioritization

### DIFF
--- a/uploading_packages/bintray/uploading_bintray.rst
+++ b/uploading_packages/bintray/uploading_bintray.rst
@@ -56,17 +56,16 @@ repositories in the following order of priority:
   2. `conan-transit`_
   3. Your own repository
 
-If you want to have your own repository prioritized, please remove the ``conan-transit`` and
-``conan-center`` repository, then add yours first, then the others:
-
+If you want to have your own repository prioritized, please use the --insert command line option 
+when adding it
 .. code-block:: bash
 
-    $ conan remote remove conan-center
-    $ conan remote remove conan-transit
-    $ conan remote add <your_remote <your_url>
-    $ conan remote add conan-center https://conan.bintray.com
-    $ conan remote add conan-transit https://conan-transit.bintray.com
-
+    $ conan remote add <your_remote> <your_url> --insert
+    $ conan list
+      <your remote>: <your_url> [Verify SSL: True]
+      conan-center: https://conan.bintray.com [Verify SSL: True]
+      conan-transit: https://conan-transit.bintray.com [Verify SSL: True]
+    
 .. tip::
 
     Check the full reference of :ref:`$ conan remote<conan_remote>` command.


### PR DESCRIPTION
Saw that it said to get your repo to the top of the priority order you have to remove conan-center and conan-transit and then add the remote and re-add them.  Much simpler to just use --insert.