### PR TITLE
Review of methods page in reference

### DIFF
--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -164,7 +164,7 @@ values if necessary.
 
 .. seealso::
 
-    Check the :ref:`package_id() method reference<package_id>` too see the available helper methods
+    Check the :ref:`package_id() method reference<method_package_id>` too see the available helper methods
     to change the package_id() behavior, for example to:
 
         - Adjust our package recipe as a **header only**

--- a/creating_packages/package_approaches.rst
+++ b/creating_packages/package_approaches.rst
@@ -2,7 +2,7 @@ Packaging approaches
 ====================
 
 Package recipes have three methods to control the package's binary compatibility and to implement
-different packaging approaches: :ref:`package_id`, :ref:`build_id` and :ref:`package_info`.
+different packaging approaches: :ref:`method_package_id`, :ref:`method_build_id` and :ref:`method_package_info`.
 
 This methods provide package creators with the posibility to follow different packages approaches
 and chose the best one for each library.
@@ -71,7 +71,7 @@ distribution mistakes. For example, debug artifacts might contain symbols or sou
 could help or directly provide means for reverse engineering. So distributing debug artifacts by
 mistake could be a very risky issue.
 
-Read more about this in :ref:`package_info`.
+Read more about this in :ref:`method_package_info`.
 
 N configs -> 1 package
 ----------------------
@@ -250,4 +250,4 @@ every configuration (architecture, compiler version, etc). So if we just have De
 types, and we’re producing N packages for N different configurations, we’ll have N/2 build folders,
 saving half of the build time.
 
-Read more about this in :ref:`build_id`.
+Read more about this in :ref:`method_build_id`.

--- a/integrations/git.rst
+++ b/integrations/git.rst
@@ -36,7 +36,7 @@ If you are creating a **conan** package:
   external package recipe, this url should point to the package recipe repository **not** to the
   external source origin.
   If a **github** repository is detected, the conan website will link your github issues page from your conan's package page.
-- You can use **git** to :ref:`obtain your sources<retrieve_source>` (requires the git client in the path)
+- You can use **git** to :ref:`obtain your sources<method_source>` (requires the git client in the path)
   when creating external package recipes.
 
 .. |git_logo| image:: ../images/git_logo.png

--- a/integrations/other.rst
+++ b/integrations/other.rst
@@ -39,7 +39,7 @@ Just specify the **txt** generator in your conanfile:
       txt
 
 And a file is generated, with the same information as in the case of CMake and gcc, only in a generic, text format,
-containing the information from the ``deps_cpp_info`` and ``deps_user_info``. Check the conanfile :ref:`package_info<package_info>`
+containing the information from the ``deps_cpp_info`` and ``deps_user_info``. Check the conanfile :ref:`package_info<method_package_info>`
 method to know more about these objects:
 
 .. code-block:: text

--- a/integrations/visual_studio.rst
+++ b/integrations/visual_studio.rst
@@ -101,7 +101,7 @@ The toolset can be also specified manually in these build helpers with the ``too
 
 By default, Conan will not generate a new binary package if
 the specified ``compiler.toolset`` matches an already generated package for the corresponding
-``compiler.version``. Check the :ref:`package_id()<package_id>` reference to know more.
+``compiler.version``. Check the :ref:`package_id()<method_package_id>` reference to know more.
 
 
 

--- a/mastering/conditional.rst
+++ b/mastering/conditional.rst
@@ -40,4 +40,4 @@ Here is an example of what we could do in our **configure method**:
              self.requires("OpenSSL/1.0.2d@lasote/stable")
 
 
-.. seealso:: Check the section :ref:`Reference/conanfile.py/configure(), config_options() <configure_config_options>` to find out more.
+.. seealso:: Check the section :ref:`Reference/conanfile.py/configure(), config_options() <method_configure_config_options>` to find out more.

--- a/mastering/envvars.rst
+++ b/mastering/envvars.rst
@@ -47,7 +47,7 @@ Automatic environment variables inheritance
 
 If your dependencies define some ``env_info`` variables in the ``package_info`` method they will be automatically
 applied before calling the consumer conanfile.py methods ``source``, ``build``, ``package`` and ``imports``. You can read
-more about ``env_info`` object :ref:`here <environment_information>`.
+more about ``env_info`` object :ref:`here <method_package_info_env_info>`.
 
 For example, if you are creating a package for a tool, you can define the variable ``PATH``
 

--- a/mastering/virtualenv.rst
+++ b/mastering/virtualenv.rst
@@ -6,7 +6,7 @@ Virtual Environments
 
 Conan offer three special conan generators to create virtual environments:
 
-- ``virtualenv``:  Declares the :ref:`self.env_info<environment_information>` variables of the requirements.
+- ``virtualenv``:  Declares the :ref:`self.env_info<method_package_info_env_info>` variables of the requirements.
 - ``virtualbuildenv``: Special build environment variables for autotools/visual studio.
 - ``virtualrunenv``: Special environment variables to locate executables and shared libraries in the requirements.
 
@@ -21,7 +21,7 @@ and shared libraries.
 Virtualenv generator
 --------------------
 
-Conan provides a **virtualenv** generator, able to read from each dependency the :ref:`self.env_info<environment_information>` 
+Conan provides a **virtualenv** generator, able to read from each dependency the :ref:`self.env_info<method_package_info_env_info>`
 variables declared in the ``package_info()`` method and generate two scripts "activate" and "deactivate". These scripts set/unset all env variables in the current shell.
 
 **Example**:

--- a/reference/conanfile.rst
+++ b/reference/conanfile.rst
@@ -3,7 +3,7 @@
 conanfile.py
 ============
 
-Reference for `conanfile.py`: fields, methods, etc
+Reference for `conanfile.py`: attributes, methods, etc.
 
 Contents:
 

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -573,7 +573,7 @@ package:
 
 .. seealso::
 
-    Read :ref:`package_info() method docs <package_info>` for more info.
+    Read :ref:`package_info() method docs <method_package_info>` for more info.
 
 
 deps_cpp_info
@@ -626,7 +626,7 @@ The ``self.env_info`` object can be filled with the environment variables to be 
 
 .. seealso::
 
-    Read :ref:`package_info() method docs <package_info>` for more info.
+    Read :ref:`package_info() method docs <method_package_info>` for more info.
 
 deps_env_info
 -------------
@@ -658,8 +658,8 @@ you want to access to the variable declared by some specific requirement you can
 info
 ----
 
-Object used in the :ref:`package_id()<package_id>` method to control the unique ID for a package.
-Check the :ref:`package_id()<package_id>` to see the details of the ``self.info`` object
+Object used to control the unique ID for a package. Check the :ref:`package_id() <method_package_id>` to see the details of the ``self.info``
+object.
 
 
 apply_env

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -27,9 +27,9 @@ control. But if the source code is available in a repository, you can directly g
             # You can also change branch, commit or whatever
             # self.run("cd hello && git checkout 2fe5...")
 
-This will work, as long as ``$ git`` is in your current path (so in Win you probably want to run things in msysgit, cmder, etc).
-You can also use another VCS or direct download/unzip. For that purpose, we have provided some helpers,
-but you can use your own code or origin as well. This is a snippet of the conanfile of the POCO libray:
+This will work, as long as git is in your current path (so in Win you probably want to run things in msysgit, cmder, etc). You can also use
+another VCS or direct download/unzip. For that purpose, we have provided some helpers, but you can use your own code or origin as well. This
+is a snippet of the conanfile of the Poco library:
 
 ..  code-block:: python
 
@@ -117,7 +117,7 @@ Nothing special is required here. We can just launch the tests from the last com
         cmake.configure()
         cmake.build()
         # here you can run CTest, launch your binaries, etc
-        self.run("ctest")
+        cmake.test()
 
 .. _method_package:
 

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -1,17 +1,18 @@
+.. _methods:
+
 Methods
 =======
 
-.. _retrieve_source:
+.. _method_source:
 
 source()
 --------
 
-The other way is to let conan retrieve the source code from any other external origin, github, or
-just a regular download. This can be done in the ``source()`` method.
+The other way is to let conan retrieve the source code from any other external origin, github, or just a regular download. This can be done
+in the ``source()`` method.
 
-For example, in the previous section, we "exported" the source code files, together with the **conanfile.py** file,
-which can be handy if the source code is not under version control. But if the source code is available in a repository,
-you can directly get it from there:
+For example, in the previous section, we "exported" the source code files, together with the *conanfile.py* file, which can be handy if the
+source code is not under version control. But if the source code is available in a repository, you can directly get it from there:
 
 .. code-block:: python
 
@@ -85,12 +86,12 @@ You can use these classes to prepare your build system's command invocation:
 - **CMake**: Prepares the invocation of cmake command with your settings.
 - **AutoToolsBuildEnvironment**: If you are using configure/Makefile to build your project you can use this helper.
   Read more: :ref:`Building with Autotools <autotools_reference>`.
-- **MSBuild**: If you are using Visual Studio compiler directly to build your project you can use this helper :ref:`MSBuild() <msbuild>`. For lower level control, the **VisualStudioBuildEnvironment** can also be used: :ref:`VisualStudioBuildEnvironment <visual_studio_build>`
-  
-
+- **MSBuild**: If you are using Visual Studio compiler directly to build your project you can use this helper :ref:`MSBuild() <msbuild>`.
+  For lower level control, the **VisualStudioBuildEnvironment** can also be used: :ref:`VisualStudioBuildEnvironment <visual_studio_build>`.
 
 (Unit) Testing your library
 +++++++++++++++++++++++++++
+
 We have seen how to run package tests with conan, but what if we want to run full unit tests on
 our library before packaging, so that they are run for every build configuration?
 Nothing special is required here. We can just launch the tests from the last command in our
@@ -105,9 +106,11 @@ Nothing special is required here. We can just launch the tests from the last com
         # here you can run CTest, launch your binaries, etc
         self.run("ctest")
 
+.. _method_package:
 
 package()
 ---------
+
 The actual creation of the package, once that it is built, is done in the ``package()`` method.
 Using the ``self.copy()`` method, artifacts are copied from the build folder to the package folder.
 The syntax of copy is as follows:
@@ -148,7 +151,7 @@ And it will copy the lib to the package folder *lib/Mylib.lib*, which can be lin
 
 The ``package()`` method will be called twice if the attribute ``no_copy_source`` is defined and True. One will copy from the ``source`` folder (typically packaging the headers and other data files), and the other will copy from the ``build`` folder, packaging the libraries and other binary artifacts. Also, when the local ``conan package`` command is issued with ``--source-folder`` and ``--build-folder``, it will execute two times, one in each folder, in the same way.
 
-.. _package_info:
+.. _method_package_info:
 
 package_info()
 --------------
@@ -229,8 +232,7 @@ If your recipe has requirements, you can access to your requirements ``cpp_info`
     Please take into account that defining ``self.cpp_info.bindirs`` directories, does not have any effect on system paths, PATH environment variable, nor will be directly accessible by consumers. ``self.cpp_info`` information is translated to build-systems information via generators, for example for CMake, it will be a variable in ``conanbuildinfo.cmake``.
     If you want a package to make accessible its executables to its consumers, you have to specify it with ``self.env_info`` as described in next section.
 
-
-.. _environment_information:
+.. _method_package_info_env_info:
 
 env_info
 ++++++++
@@ -272,7 +274,7 @@ If your recipe has requirements, you can access to your requirements ``env_info`
             self.output.warn(self.deps_env_info["MyLib"].othervar)
 
 
-.. _user_info:
+.. _method_package_info_user_info:
 
 user_info
 +++++++++
@@ -308,8 +310,7 @@ If your recipe has requirements, you can access to your requirements ``user_info
         def build(self):
             self.out.warn(self.deps_user_info["MyLib"].var1)
 
-
-.. _configure_config_options:
+.. _method_configure_config_options:
 
 configure(), config_options()
 -----------------------------
@@ -408,7 +409,7 @@ This method is useful for defining conditional build requirements, for example:
 
 Read more: :ref:`Build requirements <build_requires>`
 
-.. _system_requirements:
+.. _method_system_requirements:
 
 system_requirements()
 ---------------------
@@ -494,9 +495,11 @@ have the same system requirements, just add the following line to your method:
         self.global_system_requirements=True
         if ...
 
+.. _method_imports:
 
 imports()
 ---------
+
 Importing files copies files from the local store to your project. This feature is handy
 for copying shared libraries (dylib in Mac, dll in Win) to the directory of your executable, so that you don't have
 to mess with your PATH to run them. But there are other use cases:
@@ -556,12 +559,7 @@ When a conanfile recipe has an ``imports()`` method and it builds from sources, 
 
 You can use the :ref:`keep_imports <keep_imports>`. attribute to keep the imported artifacts, and maybe :ref:`repackage <repackage>` them.
 
-conan_info()
-------------
-
-Deprecated, use ``package_id()`` method instead.
-
-.. _package_id:
+.. _method_package_id:
 
 package_id()
 ------------
@@ -663,7 +661,7 @@ or ``arch_build``.
         self.info.discard_build_settings()
         # self.info.include_build_settings()
 
-.. _build_id:
+.. _method_build_id:
 
 build_id()
 ----------
@@ -709,7 +707,6 @@ Other information like custom package options can also be changed:
         self.info_build.options.myoption = 'MyValue' # any value possible
         self.info_build.options.fullsource = 'Always'
 
-
 deploy()
 --------
 
@@ -723,11 +720,10 @@ The ``deploy()`` method is of the form:
         self.copy("*.exe")  # copy from current package
         self.copy_deps("*.dll") # copy from dependencies
 
-
 Where:
 
-- ``self.copy_deps()`` is the same as ``self.copy()`` method inside ``imports()`` method, read: imports()_.
-- ``self.copy()`` is the ``self.copy()`` method executed inside ``package()`` method, read: package()_. 
+- ``self.copy_deps()`` is the same as ``self.copy()`` method inside :ref:`imports() method <method_imports>`.
+- ``self.copy()`` is the ``self.copy()`` method executed inside :ref:`package() method <method_package>`.
 
 Both methods allow the definition of absolute paths (to install in the system), in the ``dst`` argument.
 By default, the ``dst`` destionation folder will be the current one.
@@ -740,7 +736,6 @@ The ``deploy()`` method is designed to work on a package that is installed direc
     > ...
     > Pkg/0.1@user/testing deploy(): Copied 1 '.dll' files: mylib.dll
     > Pkg/0.1@user/testing deploy(): Copied 1 '.exe' files: myexe.exe
-
 
 All other packages and dependencies, even transitive dependencies of "Pkg/0.1@user/testing" will not be deployed,
 it is the responsibility of the installed package to deploy what it needs from its dependencies.

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -8,11 +8,10 @@ Methods
 source()
 --------
 
-The other way is to let conan retrieve the source code from any other external origin, github, or just a regular download. This can be done
-in the ``source()`` method.
+Method used to retrieve the source code from any other external origin like github using ``$ git clone`` or just a regular download.
 
-For example, in the previous section, we "exported" the source code files, together with the *conanfile.py* file, which can be handy if the
-source code is not under version control. But if the source code is available in a repository, you can directly get it from there:
+For example, "exporting" the source code files, together with the *conanfile.py* file, can be handy if the source code is not under version
+control. But if the source code is available in a repository, you can directly get it from there:
 
 .. code-block:: python
 
@@ -28,7 +27,7 @@ source code is not under version control. But if the source code is available in
             # You can also change branch, commit or whatever
             # self.run("cd hello && git checkout 2fe5...")
 
-This will work, as long as ``git`` is in your current path (so in Win you probably want to run things in msysgit, cmder, etc).
+This will work, as long as ``$ git`` is in your current path (so in Win you probably want to run things in msysgit, cmder, etc).
 You can also use another VCS or direct download/unzip. For that purpose, we have provided some helpers,
 but you can use your own code or origin as well. This is a snippet of the conanfile of the POCO libray:
 
@@ -58,11 +57,15 @@ to retrieve source code from any origin. You can even create packages for pre-co
 you already have, even if you don't have the source code. You can download the binaries, skip
 the ``build()`` method and define your ``package()`` and ``package_info()`` accordingly.
 
-You can also use **check_md5**, **check_sha1** and **check_sha256** from the **tools** module to verify that a package is downloaded correctly.
+You can also use ``check_md5()``, ``check_sha1()`` and ``check_sha256()`` from the :ref:`tools <tools_check_with_algorithm_sum>` module to
+verify that a package is downloaded correctly.
 
 .. note::
 
-    It is very important to recall that the ``source()`` method will be executed just once, and the source code will be shared for all the package builds. So it is not a good idea to conditionally use settings or options to make changes or patches on the source code. Maybe the only setting that makes sense is the OS ``self.settings.os``, if not doing cross-building, for example to retrieve different sources:
+    It is very important to recall that the ``source()`` method will be executed just once, and the source code will be shared for all the
+    package builds. So it is not a good idea to conditionally use settings or options to make changes or patches on the source code. Maybe
+    the only setting that makes sense is the OS ``self.settings.os``, if not doing cross-building, for example to retrieve different
+    sources:
 
     .. code-block:: python
 
@@ -72,11 +75,21 @@ You can also use **check_md5**, **check_sha1** and **check_sha256** from the **t
                 else:
                     # download sources from Nix systems in a tgz
 
-    If you need to patch the source code or build scripts differently for different variants of your packages, you can do it in the ``build()`` method, which uses a different folder and source code copy for each variant.
-
+    If you need to patch the source code or build scripts differently for different variants of your packages, you can do it in the
+    ``build()`` method, which uses a different folder and source code copy for each variant.
 
 build()
 -------
+
+This method is used to build the source code of the recipe using the desired commands. You can use your command line tools to invoke your
+build system or any of the build helpers provided with Conan.
+
+.. code-block:: python
+
+    def build(self):
+        cmake = CMake(self)
+        self.run("cmake . %s" % (cmake.command_line))
+        self.run("cmake --build . %s" % cmake.build_config)
 
 Build helpers
 +++++++++++++
@@ -84,8 +97,8 @@ Build helpers
 You can use these classes to prepare your build system's command invocation:
 
 - **CMake**: Prepares the invocation of cmake command with your settings.
-- **AutoToolsBuildEnvironment**: If you are using configure/Makefile to build your project you can use this helper.
-  Read more: :ref:`Building with Autotools <autotools_reference>`.
+- **AutoToolsBuildEnvironment**: If you are using configure/Makefile to build your project you can use this helper. Read more:
+  :ref:`Building with Autotools <autotools_reference>`.
 - **MSBuild**: If you are using Visual Studio compiler directly to build your project you can use this helper :ref:`MSBuild() <msbuild>`.
   For lower level control, the **VisualStudioBuildEnvironment** can also be used: :ref:`VisualStudioBuildEnvironment <visual_studio_build>`.
 
@@ -101,8 +114,8 @@ Nothing special is required here. We can just launch the tests from the last com
 
     def build(self):
         cmake = CMake(self)
-        self.run("cmake . %s" % (cmake.command_line))
-        self.run("cmake --build . %s" % cmake.build_config)
+        cmake.configure()
+        cmake.build()
         # here you can run CTest, launch your binaries, etc
         self.run("ctest")
 
@@ -111,45 +124,51 @@ Nothing special is required here. We can just launch the tests from the last com
 package()
 ---------
 
-The actual creation of the package, once that it is built, is done in the ``package()`` method.
-Using the ``self.copy()`` method, artifacts are copied from the build folder to the package folder.
-The syntax of copy is as follows:
+The actual creation of the package, once that it is built, is done in the ``package()`` method. Using the ``self.copy()`` method, artifacts
+are copied from the build folder to the package folder. The syntax of copy is as follows:
 
 .. code-block:: python
 
     self.copy(pattern, dst, src, keep_path=True, symlinks=None, excludes=None, ignore_case=False)
 
-
-- ``pattern`` is a pattern following fnmatch syntax of the files you want to copy, from the *build* to the *package* folders. Typically something like ``*.lib`` or ``*.h``.
-- ``dst`` is the destination folder in the package. They will typically be ``include`` for headers, ``lib`` for libraries and so on, though you can use any convention you like.
-- ``src`` is the folder where you want to search the files in the *build* folder. If you know that your libraries when you build your package will be in *build/lib*, you will typically use ``build/lib`` in this parameter. Leaving it empty means the root build folder.
-- ``keep_path``, with default value=True, means if you want to keep the relative path when you copy the files from the source(build) to the destination(package). Typically headers, you keep the relative path, so if the header is in *build/include/mylib/path/header.h*, you write:
+- ``pattern`` is a pattern following fnmatch syntax of the files you want to copy, from the *build* to the *package* folders. Typically
+  something like ``*.lib`` or ``*.h``.
+- ``dst`` is the destination folder in the package. They will typically be ``include`` for headers, ``lib`` for libraries and so on, though
+  you can use any convention you like.
+- ``src`` is the folder where you want to search the files in the *build* folder. If you know that your libraries when you build your
+  package will be in *build/lib*, you will typically use ``build/lib`` in this parameter. Leaving it empty means the root build folder.
+- ``keep_path``, with default value=True, means if you want to keep the relative path when you copy the files from the source(build) to the
+  destination(package). Typically headers, you keep the relative path, so if the header is in *build/include/mylib/path/header.h*, you
+  write:
 - ``symlinks``, with default value=None, set it to True to activate symlink copying, like typical lib.so->lib.so.9.
-- ``excludes``, is a single pattern or a tuple of patterns to be excluded from the copy. If a file matches both the include and the exclude pattern, it will be excluded.
+- ``excludes``, is a single pattern or a tuple of patterns to be excluded from the copy. If a file matches both the include and the exclude
+  pattern, it will be excluded.
 
 .. code-block:: python
 
-   self.copy("*.h", "include", "build/include") #keep_path default is True
+    self.copy("*.h", "include", "build/include") #keep_path default is True
 
+So the final path in the package will be: ``include/mylib/path/header.h``, and as the *include* is usually added to the path, the includes
+will be in the form: ``#include "mylib/path/header.h"`` which is something desired.
 
-So the final path in the package will be: ``include/mylib/path/header.h``, and as the *include* is usually added to the path, the includes will be in the form: ``#include "mylib/path/header.h"`` which is something desired.
-
-``keep_path=False`` is something typically desired for libraries, both static and dynamic. Some compilers as MSVC, put them in paths as *Debug/x64/MyLib/Mylib.lib*. Using this option, we could write:
+``keep_path=False`` is something typically desired for libraries, both static and dynamic. Some compilers as MSVC, put them in paths as
+*Debug/x64/MyLib/Mylib.lib*. Using this option, we could write:
 
 .. code-block:: python
 
-   self.copy("*.lib", "lib", "", keep_path=False)
+    self.copy("*.lib", "lib", "", keep_path=False)
 
-
-And it will copy the lib to the package folder *lib/Mylib.lib*, which can be linked easily
+And it will copy the lib to the package folder *lib/Mylib.lib*, which can be linked easily.
 
 .. note::
 
-    If you are using CMake and you have an install target defined in your CMakeLists.txt, you
-    might be able to reuse it for this ``package()`` method. Please check :ref:`reuse_cmake_install`
+    If you are using CMake and you have an install target defined in your CMakeLists.txt, you might be able to reuse it for this
+    ``package()`` method. Please check :ref:`reuse_cmake_install`.
 
-
-The ``package()`` method will be called twice if the attribute ``no_copy_source`` is defined and True. One will copy from the ``source`` folder (typically packaging the headers and other data files), and the other will copy from the ``build`` folder, packaging the libraries and other binary artifacts. Also, when the local ``conan package`` command is issued with ``--source-folder`` and ``--build-folder``, it will execute two times, one in each folder, in the same way.
+The ``package()`` method will be called twice if the attribute ``no_copy_source`` is defined and ``True``. One will copy from the *source*
+folder (typically packaging the headers and other data files), and the other will copy from the *build* folder, packaging the libraries and
+other binary artifacts. Also, when the local ``$ conan package`` command is issued with ``--source-folder`` and ``--build-folder``, it will
+execute two times, one in each folder, in the same way.
 
 .. _method_package_info:
 
@@ -158,8 +177,9 @@ package_info()
 
 cpp_info
 ++++++++
-Each package has to specify certain build information for its consumers. This can be done in
-the ``cpp_info`` attribute within the ``package_info()`` method.
+
+Each package has to specify certain build information for its consumers. This can be done in the ``cpp_info`` attribute within the
+``package_info()`` method.
 
 The ``cpp_info`` attribute has the following properties you can assign/append to:
 
@@ -176,11 +196,10 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
     self.cpp_info.sharedlinkflags = []  # linker flags
     self.cpp_info.exelinkflags = []  # linker flags
 
-
-* includedirs: list of relative paths (starting from the package root) of directories where headers
-  can be found. By default it is initialized to ['include'], and it is rarely changed.
-* libs: ordered list of libs the client should link against. Empty by default, it is common
-  that different configurations produce different library names. For example:
+- **includedirs**: List of relative paths (starting from the package root) of directories where headers can be found. By default it is
+  initialized to ``['include']``, and it is rarely changed.
+- **libs**: Ordered list of libs the client should link against. Empty by default, it is common that different configurations produce
+  different library names. For example:
 
 .. code-block:: python
 
@@ -190,18 +209,17 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
         else:
             ...
 
-* libdirs: list of relative paths (starting from the package root) of directories in which to find
-  library object binaries (.lib, .a, .so. dylib). By default it is initialized to ['lib'], and it is rarely changed.
-* resdirs: list of relative paths (starting from the package root) of directories in which to find
-  resource files (images, xml, etc). By default it is initialized to ['res'], and it is rarely changed.
-* bindirs: list of relative paths (starting from the package root) of directories in which to find
-  library runtime binaries (like windows .dlls). By default it is initialized to ['bin'], and it is rarely changed.
-* defines: ordered list of preprocessor directives. It is common that the consumers have to specify
-  some sort of defines in some cases, so that including the library headers matches the binaries:
-* <c,cpp,exelink,sharedlink>flags, list of flags that the consumer should activate for proper
-  behavior. Usage of C++11 could be configured here, for example, although it is true that the consumer may
-  want to do some flag processing to check if different dependencies are setting incompatible flags
-  (c++11 after c++14)
+- **libdirs**: List of relative paths (starting from the package root) of directories in which to find library object binaries (\*.lib,
+  \*.a, \*.so, \*.dylib). By default it is initialized to ``['lib']``, and it is rarely changed.
+- **resdirs**: List of relative paths (starting from the package root) of directories in which to find resource files (images, xml, etc). By
+  default it is initialized to ``['res']``, and it is rarely changed.
+- **bindirs**: List of relative paths (starting from the package root) of directories in which to find library runtime binaries (like
+  Windows .dlls). By default it is initialized to ``['bin']``, and it is rarely changed.
+- **defines**: Ordered list of preprocessor directives. It is common that the consumers have to specify some sort of defines in some cases,
+  so that including the library headers matches the binaries:
+- **cflags**, **cppflags**, **sharedlinkflags**, **exelinkflags**: List of flags that the consumer should activate for proper behavior.
+  Usage of C++11 could be configured here, for example, although it is true that the consumer may want to do some flag processing to check
+  if different dependencies are setting incompatible flags (c++11 after c++14).
 
 .. code-block:: python
 
@@ -212,7 +230,6 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
 
         if not self.settings.os == "Windows":
             self.cpp_info.cppflags = ["-pthread"]
-
 
 If your recipe has requirements, you can access to your requirements ``cpp_info`` as well using the ``deps_cpp_info`` object.
 
@@ -226,20 +243,21 @@ If your recipe has requirements, you can access to your requirements ``cpp_info`
         def build(self):
             self.output.warn(self.deps_cpp_info["MyLib"].libdirs)
 
-
 .. note::
 
-    Please take into account that defining ``self.cpp_info.bindirs`` directories, does not have any effect on system paths, PATH environment variable, nor will be directly accessible by consumers. ``self.cpp_info`` information is translated to build-systems information via generators, for example for CMake, it will be a variable in ``conanbuildinfo.cmake``.
-    If you want a package to make accessible its executables to its consumers, you have to specify it with ``self.env_info`` as described in next section.
+    Please take into account that defining ``self.cpp_info.bindirs`` directories, does not have any effect on system paths, PATH environment
+    variable, nor will be directly accessible by consumers. ``self.cpp_info`` information is translated to build-systems information via
+    generators, for example for CMake, it will be a variable in ``conanbuildinfo.cmake``. If you want a package to make accessible its
+    executables to its consumers, you have to specify it with ``self.env_info`` as described in :ref:`method_package_info_env_info`.
 
 .. _method_package_info_env_info:
 
 env_info
 ++++++++
 
-Each package can also define some environment variables that the package needs to be reused.
-It's specially useful for :ref:`installer packages<create_installer_packages>`, to set the path with the "bin" folder of the packaged application.
-This can be done in the ``env_info`` attribute within the ``package_info()`` method.
+Each package can also define some environment variables that the package needs to be reused. It's specially useful for
+:ref:`installer packages<create_installer_packages>`, to set the path with the "bin" folder of the packaged application. This can be done in
+the ``env_info`` attribute within the ``package_info()`` method.
 
 .. code-block:: python
 
@@ -247,19 +265,19 @@ This can be done in the ``env_info`` attribute within the ``package_info()`` met
     self.env_info.othervar = "OTHER VALUE" # Assign "OTHER VALUE" to the othervar variable
     self.env_info.thirdvar.append("some value") # Every variable can be set or appended a new value
 
-
-One of the most typical usages for the PATH environment variable, would be to add the current binary package directories to the path, so consumers can use those executables easily:
+One of the most typical usages for the PATH environment variable, would be to add the current binary package directories to the path, so
+consumers can use those executables easily:
 
 .. code-block:: python
 
     # assuming the binaries are in the "bin" subfolder
     self.env_info.PATH.append(os.path.join(self.package_folder, "bin")
 
+The :ref:`virtualenv<virtual_environment_generator>` generator will use the self.env_info variables to prepare a script to activate/deactive
+a virtual environment.
 
-The :ref:`virtualenv<virtual_environment_generator>` generator will use the self.env_info variables to prepare a script to activate/deactive a virtual environment.
-
-In previous conan versions you needed to use `ConfigureEnvironment` helper (now deprecated) to reuse these variables, but it's not needed anymore.
-They will be automatically applied before calling the consumer conanfile.py methods `source`, `build`, `package` and `imports`.
+They will be automatically applied before calling the consumer *conanfile.py* methods ``source()``, ``build()``, ``package()`` and
+``imports()``.
 
 If your recipe has requirements, you can access to your requirements ``env_info`` as well using the ``deps_env_info`` object.
 
@@ -273,14 +291,13 @@ If your recipe has requirements, you can access to your requirements ``env_info`
         def build(self):
             self.output.warn(self.deps_env_info["MyLib"].othervar)
 
-
 .. _method_package_info_user_info:
 
 user_info
 +++++++++
 
-If you need to declare custom variables not related with C/C++ (`cpp_info`) and the variables are not
-environment variables (`env_info`), you can use the ``self.user_info`` object.
+If you need to declare custom variables not related with C/C++ (``cpp_info``) and the variables are not environment variables
+(``env_info``), you can use the ``self.user_info`` object.
 
 Currently only the ``cmake``, ``cmake_multi`` and ``txt`` generators supports ``user_info`` variables.
 
@@ -296,9 +313,8 @@ Currently only the ``cmake``, ``cmake_multi`` and ``txt`` generators supports ``
             self.user_info.var1 = 2
 
 
-For the example above, in the ``cmake`` and ``cmake_multi`` generators, a variable ``CONAN_USER_MYLIB_var1`` will be declared.
-
-If your recipe has requirements, you can access to your requirements ``user_info`` using the ``deps_user_info`` object.
+For the example above, in the ``cmake`` and ``cmake_multi`` generators, a variable ``CONAN_USER_MYLIB_var1`` will be declared. If your
+recipe has requirements, you can access to your requirements ``user_info`` using the ``deps_user_info`` object.
 
 .. code-block:: python
 
@@ -315,8 +331,8 @@ If your recipe has requirements, you can access to your requirements ``user_info
 configure(), config_options()
 -----------------------------
 
-If the package options and settings are related, and you want to configure either, you can do so
-in the ``configure()`` and ``config_options()`` methods. This is an example:
+If the package options and settings are related, and you want to configure either, you can do so in the ``configure()`` and
+``config_options()`` methods.
 
 ..  code-block:: python
 
@@ -333,18 +349,15 @@ in the ``configure()`` and ``config_options()`` methods. This is an example:
                 self.settings.clear()
                 self.options.remove("static")
 
-The package has 2 options set, to be compiled as a static (as opposed to shared) library,
-and also not to involve any builds, because header-only libraries will be used. In this case,
-the settings that would affect a normal build, and even the other option (static vs shared)
-do not make sense, so we just clear them. That means, if someone consumes MyLib with the
-``header_only: True`` option, the package downloaded and used will be the same, irrespective of
-the OS, compiler or architecture the consumer is building with.
+The package has 2 options set, to be compiled as a static (as opposed to shared) library, and also not to involve any builds, because
+header-only libraries will be used. In this case, the settings that would affect a normal build, and even the other option (static vs
+shared) do not make sense, so we just clear them. That means, if someone consumes MyLib with the ``header_only: True`` option, the package
+downloaded and used will be the same, irrespective of the OS, compiler or architecture the consumer is building with.
 
-The most typical usage would be the one with ``configure()`` while ``config_options()`` should be
-used more sparingly. ``config_options()`` is used to configure or constraint the available
-options in a package, **before** they are given a value. So when a value is tried to be assigned,
-it will raise an error. For example, let's suppose that a certain package library cannot be
-built as shared library in Windows, it can be done:
+The most typical usage would be the one with ``configure()`` while ``config_options()`` should be used more sparingly. ``config_options()``
+is used to configure or constraint the available options in a package, **before** they are given a value. So when a value is tried to be
+assigned it will raise an error. For example, let's suppose that a certain package library cannot be built as shared library in Windows, it
+can be done:
 
 ..  code-block:: python
 
@@ -352,17 +365,15 @@ built as shared library in Windows, it can be done:
         if self.settings.os == "Windows":
             del self.options.shared
 
-This will be executed before the actual assignment of ``options`` (then, such ``options`` values
-cannot be used inside this function), so the command ``$ conan install -o Pkg:shared=True`` will
-raise an Exception in Windows saying that ``shared`` is not an option for such package.
-
+This will be executed before the actual assignment of ``options`` (then, such ``options`` values cannot be used inside this function), so
+the command ``$ conan install -o Pkg:shared=True`` will raise an exception in Windows saying that ``shared`` is not an option for such
+package.
 
 requirements()
 --------------
 
-Besides the ``requires`` field, more advanced requirement logic can be defined in the
-``requirements()`` optional method, using for example values from the package ``settings`` or
-``options``:
+Besides the ``requires`` field, more advanced requirement logic can be defined in the ``requirements()`` optional method, using for example
+values from the package ``settings`` or ``options``:
 
 ..  code-block:: python
 
@@ -372,30 +383,27 @@ Besides the ``requires`` field, more advanced requirement logic can be defined i
         else:
             self.requires("opencv/2.2@drl/stable")
 
-
 This is a powerful mechanism for handling **conditional dependencies**.
 
-When you are inside the method, each call to ``self.requires()`` will add the corresponding
-requirement to the current list of requirements. It also has optional parameters that allow
-defining the special cases, as is shown below:
+When you are inside the method, each call to ``self.requires()`` will add the corresponding requirement to the current list of requirements.
+It also has optional parameters that allow defining the special cases, as is shown below:
 
 ..  code-block:: python
 
-   def requirements(self):
+    def requirements(self):
         self.requires("zlib/1.2@drl/testing", private=True, override=False)
 
-
-``self.requires`` method parameters:
-
-- **override**: Default False. True means that this is not an actual requirement, but something to
-  be passed upstream and override possible existing values.
-- **private**: Default False. True means that this requirement will be somewhat embedded (like
-  a static lib linked into a shared lib), so it is not required to link.
+``self.requires()`` parameters:
+    - **override** (Optional, Defaulted to ``False``): True means that this is not an actual requirement, but something to be passed
+      upstream and override possible existing values.
+    - **private** (Optional, Defaulted to ``False``): True means that this requirement will be somewhat embedded (like a static lib linked
+      into a shared lib), so it is not required to link.
 
 build_requirements()
 --------------------
 
-Build requirements are requirements that are only installed and used when the package is built from sources. If there is an existing pre-compiled binary, then the build requirements for this package will not be retrieved.
+Build requirements are requirements that are only installed and used when the package is built from sources. If there is an existing
+pre-compiled binary, then the build requirements for this package will not be retrieved.
 
 This method is useful for defining conditional build requirements, for example:
 
@@ -407,32 +415,34 @@ This method is useful for defining conditional build requirements, for example:
             if self.settings.os == "Windows":
                 self.build_requires("ToolWin/0.1@user/stable")
 
-Read more: :ref:`Build requirements <build_requires>`
+.. seealso::
+
+    :ref:`Build requirements <build_requires>`
 
 .. _method_system_requirements:
 
 system_requirements()
 ---------------------
-It is possible to install system-wide packages from conan. Just add a ``system_requirements()``
-method to your conanfile and specify what you need there.
 
-For a special use case you can use also ``conans.tools.os_info`` object to detect the operating system,
-version and distribution (linux):
+It is possible to install system-wide packages from conan. Just add a ``system_requirements()`` method to your conanfile and specify what
+you need there.
 
-- ``os_info.is_linux`` True if Linux
-- ``os_info.is_windows`` True if Windows
-- ``os_info.is_macos`` True if OSx
-- ``os_info.is_freebsd`` True if FreeBSD
-- ``os_info.is_solaris`` True if SunOS
-- ``os_info.os_version`` OS version
-- ``os_info.os_version_name`` Common name of the OS (Windows 7, Mountain Lion, Wheezy...)
-- ``os_info.linux_distro`` Linux distribution name (None if not Linux)
-- ``os_info.bash_path`` Returns the absolute path to a bash in the system
-- ``os_info.uname(options=None)`` Runs the "uname" command and returns the ouput. You can pass arguments with the `options` parameter.
-- ``os_info.detect_windows_subsystem()`` Returns "MSYS", "MSYS2", "CYGWIN" or "WSL" if any of these Windows subsystems are detected.
+For a special use case you can use also ``conans.tools.os_info`` object to detect the operating system, version and distribution (linux):
 
-Also you can use ``SystemPackageTool`` class, that will automatically invoke the right system package tool:
-**apt**, **yum**, **pkg**, **pkgutil**, **brew** and **pacman** depending on the system we are running.
+- ``os_info.is_linux``: True if Linux.
+- ``os_info.is_windows``: True if Windows.
+- ``os_info.is_macos``: True if OSx.
+- ``os_info.is_freebsd``: True if FreeBSD.
+- ``os_info.is_solaris``: True if SunOS.
+- ``os_info.os_version``: OS version.
+- ``os_info.os_version_name``: Common name of the OS (Windows 7, Mountain Lion, Wheezy...).
+- ``os_info.linux_distro``: Linux distribution name (None if not Linux).
+- ``os_info.bash_path``: Returns the absolute path to a bash in the system.
+- ``os_info.uname(options=None)``: Runs the "uname" command and returns the ouput. You can pass arguments with the `options` parameter.
+- ``os_info.detect_windows_subsystem()``: Returns "MSYS", "MSYS2", "CYGWIN" or "WSL" if any of these Windows subsystems are detected.
+
+You can also use ``SystemPackageTool`` class, that will automatically invoke the right system package tool: **apt**, **yum**, **pkg**,
+**pkgutil**, **brew** and **pacman** depending on the system we are running.
 
 ..  code-block:: python
 
@@ -470,9 +480,8 @@ On Windows, there is no standard package manager, however **choco** can be invok
             installer = SystemPackageTool(tool=ChocolateyTool()) # Invoke choco package manager to install the package
             installer.install(pack_name)
 
-Available SystemPackageTool classes:
-
-**AptTool**, **YumTool**, **BrewTool**, **PkgTool**, **PkgUtilTool**, **ChocolateyTool**, **PacManTool**
+Available SystemPackageTool classes: **AptTool**, **YumTool**, **BrewTool**, **PkgTool**, **PkgUtilTool**, **ChocolateyTool**,
+**PacManTool**.
 
 SystemPackageTool methods:
 
@@ -484,10 +493,9 @@ SystemPackageTool methods:
 The use of ``sudo`` in the internals of the ``install()`` and ``update()`` methods is controlled by the CONAN_SYSREQUIRES_SUDO
 environment variable, so if the users don't need sudo permissions, it is easy to opt-in/out.
 
-Conan will keep track of the execution of this method, so that it is not invoked again and again
-at every conan command. The execution is done per package, since some packages of the same
-library might have different system dependencies. If you are sure that all your binary packages
-have the same system requirements, just add the following line to your method:
+Conan will keep track of the execution of this method, so that it is not invoked again and again at every Conan command. The execution is
+done per package, since some packages of the same library might have different system dependencies. If you are sure that all your binary
+packages have the same system requirements, just add the following line to your method:
 
 ..  code-block:: python
 
@@ -500,17 +508,15 @@ have the same system requirements, just add the following line to your method:
 imports()
 ---------
 
-Importing files copies files from the local store to your project. This feature is handy
-for copying shared libraries (dylib in Mac, dll in Win) to the directory of your executable, so that you don't have
-to mess with your PATH to run them. But there are other use cases:
+Importing files copies files from the local store to your project. This feature is handy for copying shared libraries (*dylib* in Mac, *dll*
+in Win) to the directory of your executable, so that you don't have to mess with your PATH to run them. But there are other use cases:
 
-- Copy an executable to your project, so that it can be easily run. A good example is the google
-  **protobuf** code generator, go to the examples section to check it out.
-- Copy package data to your project, like configuration, images, sounds... A good example is the
-  OpenCV demo, in which face detection XML pattern files are required.
+- Copy an executable to your project, so that it can be easily run. A good example is the **Google's protobuf** code generator.
+- Copy package data to your project, like configuration, images, sounds... A good example is the **OpenCV** demo, in which face detection
+  XML pattern files are required.
 
-Importing files is also very convenient in order to redistribute your application, as many times
-you will just have to bundle your project's bin folder.
+Importing files is also very convenient in order to redistribute your application, as many times you will just have to bundle your project's
+bin folder.
 
 A typical ``imports()`` method for shared libs could be:
 
@@ -520,16 +526,25 @@ A typical ``imports()`` method for shared libs could be:
       self.copy("*.dll", "", "bin")
       self.copy("*.dylib", "", "lib")
 
+The ``self.copy()`` method inside ``imports()`` supports the following arguments:
 
-The ``self.copy()`` method inside ``imports()`` support the following arguments:
+.. code-block:: python
 
-- pattern: an fnmatch file pattern of the files that should be copied. E.g. \*.dll
-- dst: the destination local folder, wrt to current directory, to which the files will be copied. Eg: "bin"
-- src: the source folder in which those files will be searched. This folder will be stripped from the dst name. Eg.: lib/Debug/x86
-- root_package: fnmatch pattern of the package name ("OpenCV", "Boost") from which files will be copied. Default: all packages in deps
-- folder: (default=False). If enabled, it will copy the files from the local cache to a subfolder named as the package containing the files. Useful to avoid conflicting imports of files with the same name (e.g. License)
-- ignore_case: (default=False). If enabled will do a case-insensitive pattern matching
-- excludes: (default=None). Allows defining a list of patterns (even a single pattern) to be excluded from the copy, even if they match the main ``pattern``.
+    def copy(pattern, dst="", src="", root_package=None, folder=False, ignore_case=False, excludes=None)
+
+Parameters:
+    - **pattern** (Required): An fnmatch file pattern of the files that should be copied.
+    - **dst** (Optional, Defaulted to ``""``): Destination local folder, with reference to current directory, to which the files will be
+      copied.
+    - **src** (Optional, Defaulted to ``""``): Source folder in which those files will be searched. This folder will be stripped from the
+      dst parameter. Eg.: lib/Debug/x86
+    - **root_package** (Optional, Defaulted to *all packages in deps*): An fnmatch pattern of the package name ("OpenCV", "Boost") from
+      which files will be copied.
+    - **folder** (Optional, Defaulted to ``False``): If enabled, it will copy the files from the local cache to a subfolder named as the
+      package containing the files. Useful to avoid conflicting imports of files with the same name (e.g. License).
+    - **ignore_case** (Optional, Defaulted to ``False``): If enabled, it will do a case-insensitive pattern matching.
+    - **excludes** (Optional, Defaulted to ``None``): Allows defining a list of patterns (even a single pattern) to be excluded from the
+      copy, even if they match the main ``pattern``.
 
 Example to collect license files from dependencies:
 
@@ -538,8 +553,8 @@ Example to collect license files from dependencies:
     def imports(self):
         self.copy("license*", dst="licenses", folder=True, ignore_case=True)
 
-
-If you want to be able to customize the output user directory to work with both the ``cmake`` and ``cmake_multi`` generators, then you can do:
+If you want to be able to customize the output user directory to work with both the ``cmake`` and ``cmake_multi`` generators, then you can
+do:
 
 .. code-block:: python
 
@@ -548,29 +563,28 @@ If you want to be able to customize the output user directory to work with both 
         self.copy("*.dll", dst=dest, src="bin")
         self.copy("*.dylib*", dst=dest, src="lib")
 
-
-And then use, for example: ``conan install -e CONAN_IMPORT_PATH=Release -g cmake_multi``
+And then use, for example: ``$ conan install . -e CONAN_IMPORT_PATH=Release -g cmake_multi``
 
 When a conanfile recipe has an ``imports()`` method and it builds from sources, it will do the following:
 
 - Before running ``build()`` it will execute ``imports()`` in the build folder, copying dependencies artifacts
-- Run the ``build()`` method, which could use such imported binaries
+- Run the ``build()`` method, which could use such imported binaries.
 - Remove the copied (imported) artifacts after ``build()`` is finished.
 
-You can use the :ref:`keep_imports <keep_imports>`. attribute to keep the imported artifacts, and maybe :ref:`repackage <repackage>` them.
+You can use the :ref:`keep_imports <keep_imports>` attribute to keep the imported artifacts, and maybe :ref:`repackage <repackage>` them.
 
 .. _method_package_id:
 
 package_id()
 ------------
 
-Creates a unique id for the package. Default package id is calculated using ``settings``, ``options`` and ``requires`` properties.
-When a package creator specifies the values for any of thoses properties, it is telling that any value change will require a different
-binary package.
+Creates a unique id for the package. Default package id is calculated using ``settings``, ``options`` and ``requires`` properties. When a
+package creator specifies the values for any of thoses properties, it is telling that any value change will require a different binary
+package.
 
 However, sometimes a package creator would need to alter the default behavior, for example, to have only one binary package for several
-different compiler versions. In that case you can set a custom ``self.info`` object implementing this method and the pacakge id will
-be computed with the given information:
+different compiler versions. In that case you can set a custom ``self.info`` object implementing this method and the pacakge id will be
+computed with the given information:
 
 .. code-block:: python
 
@@ -581,27 +595,33 @@ be computed with the given information:
 
 Please, check the section :ref:`define_abi_compatibility` to get more details.
 
-**Available methods in the self.info object**:
+self.info
++++++++++
 
-- **self.info.header_only()**: The package will always be the same, irrespective of the OS, compiler or architecture the consumer is building with.
+This ``self.info`` class stores the information that will be used to compute the package id.
+
+
+self.info.header_only()
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The package will always be the same, irrespective of the OS, compiler or architecture the consumer is building with.
 
 .. code-block:: python
 
     def package_id(self):
         self.info.header_only()
 
-- **self.info.vs_toolset_compatible() / self.info.vs_toolset_incompatible()**:
+self.info.vs_toolset_compatible() / self.info.vs_toolset_incompatible()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default (vs_toolset_compatible mode), Conan will generate the same binary package when the compiler
-is Visual Studio and the ``compiler.toolset`` matches the specified ``compiler.version``.
-For example, if we install some packages specifying the following settings:
+By default (``vs_toolset_compatible()`` mode) Conan will generate the same binary package when the compiler is Visual Studio and the
+``compiler.toolset`` matches the specified ``compiler.version``. For example, if we install some packages specifying the following settings:
 
 .. code-block:: python
 
     def package_id(self):
         self.info.vs_toolset_compatible()
         # self.info.vs_toolset_incompatible()
-
 
 .. code-block:: text
 
@@ -616,44 +636,40 @@ And then we install again specifying these settings:
     compiler.version=15
     compiler.toolset=v140
 
-
-The compiler version is different, but Conan will not generate a different package, because the used
-``toolchain`` in both cases are considered (by default) the same.
-You can deactivate this default behavior using calling ``self.info.vs_toolset_incompatible()``.
+The compiler version is different, but Conan will not install a different package, because the used ``toolchain`` in both cases are
+considered the same. You can deactivate this default behavior using calling ``self.info.vs_toolset_incompatible()``.
 
 This is the relation of Visual Studio versions and the compatible toolchain:
 
-+-------------------------------------------+------------------------------+
-| Visual Studio Version                     | Compatible toolset           |
-+===========================================+==============================+
-| 15                                        |   v141                       |
-+-------------------------------------------+------------------------------+
-| 14                                        |   v140                       |
-+-------------------------------------------+------------------------------+
-| 13                                        |   v120                       |
-+-------------------------------------------+------------------------------+
-| 12                                        |   v120                       |
-+-------------------------------------------+------------------------------+
-| 11                                        |   v110                       |
-+-------------------------------------------+------------------------------+
-| 10                                        |   v100                       |
-+-------------------------------------------+------------------------------+
-| 9                                         |   v90                        |
-+-------------------------------------------+------------------------------+
-| 8                                         |   v80                        |
-+-------------------------------------------+------------------------------+
++-----------------------+--------------------+
+| Visual Studio Version | Compatible toolset |
++=======================+====================+
+| 15                    | v141               |
++-----------------------+--------------------+
+| 14                    | v140               |
++-----------------------+--------------------+
+| 13                    | v120               |
++-----------------------+--------------------+
+| 12                    | v120               |
++-----------------------+--------------------+
+| 11                    | v110               |
++-----------------------+--------------------+
+| 10                    | v100               |
++-----------------------+--------------------+
+| 9                     | v90                |
++-----------------------+--------------------+
+| 8                     | v80                |
++-----------------------+--------------------+
 
 
-- **self.info.discard_build_settings() / self.info.include_build_settings**:
+self.info.discard_build_settings() / self.info.include_build_settings()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default (discard_build_settings), Conan will generate the same binary when you change the ``os_build`` or ``arch_build``
-when the ``os`` and ``arch`` are declared respectively. This is because ``os_build`` represent the machine
-running Conan, so, for the consumer, the only setting that matters is where the built software will run,
-not where is running the compilation. The same applies to ``arch_build``.
+By default (``discard_build_settings()``) Conan will generate the same binary when you change the ``os_build`` or ``arch_build`` when the
+``os`` and ``arch`` are declared respectively. This is because ``os_build`` represent the machine running Conan, so, for the consumer, the
+only setting that matters is where the built software will run, not where is running the compilation. The same applies to ``arch_build``.
 
-Using the ``self.info.include_build_settings``, Conan will generate different packages when you change the ``os_build``
-or ``arch_build``.
-
+With ``self.info.include_build_settings()``, Conan will generate different packages when you change the ``os_build`` or ``arch_build``.
 
 .. code-block:: python
 
@@ -666,23 +682,19 @@ or ``arch_build``.
 build_id()
 ----------
 
-In the general case, there is one build folder for each binary package, with the exact same hash/ID
-of the package. However this behavior can be changed, there are a couple of scenarios that this might
-be interesting:
+In the general case, there is one build folder for each binary package, with the exact same hash/ID of the package. However this behavior
+can be changed, there are a couple of scenarios that this might be interesting:
 
-- You have a build script that generates several different configurations at once, like both debug
-  and release artifacts, but you actually want to package and consume them separately. Same for
-  different architectures or any other setting.
-- You build just one configuration (like release), but you want to create different binary packages
-  for different consuming cases. For example, if you have created tests for the library in the build
-  step, you might want to create two packages: one just containing the library for general usage, and
-  another one also containing the tests. First package could be used as a reference and the other one as
-  a tool to debug errors.
+- You have a build script that generates several different configurations at once, like both debug and release artifacts, but you actually
+  want to package and consume them separately. Same for different architectures or any other setting.
+- You build just one configuration (like release), but you want to create different binary packages for different consuming cases. For
+  example, if you have created tests for the library in the build step, you might want to create two packages: one just containing the
+  library for general usage, and another one also containing the tests. First package could be used as a reference and the other one as a
+  tool to debug errors.
 
-In both cases, if using different settings, the system will build twice (or more times) the same binaries,
-just to produce a different final binary package. With the ``build_id()`` method this logic can be
-changed. ``build_id()`` will create a new package ID/hash for the build folder, and you can define
-the logic you want in it. For example:
+In both cases, if using different settings, the system will build twice (or more times) the same binaries, just to produce a different final
+binary package. With the ``build_id()`` method this logic can be changed. ``build_id()`` will create a new package ID/hash for the build
+folder, and you can define the logic you want in it. For example:
 
 ..  code-block:: python
 
@@ -691,13 +703,10 @@ the logic you want in it. For example:
     def build_id(self):
         self.info_build.settings.build_type = "Any"
 
-
-So this recipe will generate a final different package for each debug/release configuration. But
-as the ``build_id()`` will generate the same ID for any ``build_type``, then just one folder and
-one build will be done. Such build should build both debug and release artifacts, and then the
-``package()`` method should package them accordingly to the ``self.settings.build_type`` value.
-Still different builds will be executed if using different compilers or architectures. This method
-is basically an optimization of build time, avoiding multiple re-builds.
+So this recipe will generate a final different package for each debug/release configuration. But as the ``build_id()`` will generate the
+same ID for any ``build_type``, then just one folder and one build will be done. Such build should build both debug and release artifacts,
+and then the ``package()`` method should package them accordingly to the ``self.settings.build_type`` value. Different builds will still be
+executed if using different compilers or architectures. This method is basically an optimization of build time, avoiding multiple re-builds.
 
 Other information like custom package options can also be changed:
 
@@ -710,9 +719,7 @@ Other information like custom package options can also be changed:
 deploy()
 --------
 
-This method can be used in a ``conanfile.py`` to install in the system or user folder artifacts from packages.
-
-The ``deploy()`` method is of the form:
+This method can be used in a *conanfile.py* to install in the system or user folder artifacts from packages.
 
 ..  code-block:: python
 
@@ -722,11 +729,11 @@ The ``deploy()`` method is of the form:
 
 Where:
 
-- ``self.copy_deps()`` is the same as ``self.copy()`` method inside :ref:`imports() method <method_imports>`.
 - ``self.copy()`` is the ``self.copy()`` method executed inside :ref:`package() method <method_package>`.
+- ``self.copy_deps()`` is the same as ``self.copy()`` method inside :ref:`imports() method <method_imports>`.
 
-Both methods allow the definition of absolute paths (to install in the system), in the ``dst`` argument.
-By default, the ``dst`` destionation folder will be the current one.
+Both methods allow the definition of absolute paths (to install in the system), in the ``dst`` argument. By default, the ``dst``
+destionation folder will be the current one.
 
 The ``deploy()`` method is designed to work on a package that is installed directly from its reference, as:
 
@@ -737,5 +744,5 @@ The ``deploy()`` method is designed to work on a package that is installed direc
     > Pkg/0.1@user/testing deploy(): Copied 1 '.dll' files: mylib.dll
     > Pkg/0.1@user/testing deploy(): Copied 1 '.exe' files: myexe.exe
 
-All other packages and dependencies, even transitive dependencies of "Pkg/0.1@user/testing" will not be deployed,
-it is the responsibility of the installed package to deploy what it needs from its dependencies.
+All other packages and dependencies, even transitive dependencies of "Pkg/0.1@user/testing" will not be deployed, it is the responsibility
+of the installed package to deploy what it needs from its dependencies.

--- a/reference/generators/cmake.rst
+++ b/reference/generators/cmake.rst
@@ -77,7 +77,7 @@ The values are ordered in the right order according to the dependency tree.
 
 - **Variables from user_info**
 
-If any of the requirements is filling the :ref:`user_info<user_info>` object in the :ref:`package_info<package_info>`
+If any of the requirements is filling the :ref:`user_info<method_package_info_user_info>` object in the :ref:`package_info<method_package_info>`
 method a set of variables will be declared following this naming:
 
 +--------------------------------+----------------------------------------------------------------------+

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -551,7 +551,7 @@ Parameters:
 tools.OSInfo and tools.SystemPackageTool
 ----------------------------------------
 
-These are helpers to install system packages. Check :ref:`system_requirements`
+These are helpers to install system packages. Check :ref:`method_system_requirements`.
 
 .. _cross_building_reference:
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -342,6 +342,8 @@ Parameters:
     - **strict** (Optional, Defaulted to ``True``): If ``True``, it raises an error if the searched string
       is not found, so nothing is actually replaced.
 
+.. _tools_check_with_algorithm_sum:
+
 tools.check_with_algorithm_sum()
 --------------------------------
 

--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -314,7 +314,7 @@ Using build requires
 
 Instead of downloading manually the toolchain and creating a profile, you can create a Conan package
 with it. The toolchain Conan package needs to fill the ``env_info`` object
-in the :ref:`package_info()<package_info>` method with the same variables we've specified in the examples
+in the :ref:`package_info()<method_package_info>` method with the same variables we've specified in the examples
 above in the ``[env]`` section of profiles.
 
 A layout of a Conan package for a toolchain could looks like this:

--- a/uploading_packages/bintray/uploading_bintray.rst
+++ b/uploading_packages/bintray/uploading_bintray.rst
@@ -56,8 +56,8 @@ repositories in the following order of priority:
   2. `conan-transit`_
   3. Your own repository
 
-If you want to have your own repository prioritized, please use the --insert command line option 
-when adding it
+If you want to have your own repository prioritized, please use the ``--insert`` command line option when adding it:
+
 .. code-block:: bash
 
     $ conan remote add <your_remote> <your_url> --insert
@@ -65,7 +65,7 @@ when adding it
       <your remote>: <your_url> [Verify SSL: True]
       conan-center: https://conan.bintray.com [Verify SSL: True]
       conan-transit: https://conan-transit.bintray.com [Verify SSL: True]
-    
+
 .. tip::
 
     Check the full reference of :ref:`$ conan remote<conan_remote>` command.


### PR DESCRIPTION
Added:
- Broken link references.
- References to methods starting with *method*
- Better param explanation with default values.
- Descrition of build()
- SystemPackageTool small section.
- Formatting

Removed:
- conan_info() method.
