### PR TITLE
Bugfixes 1.0.3

### DIFF
--- a/conan1.0.rst
+++ b/conan1.0.rst
@@ -103,7 +103,7 @@ New features
 
     os:
         Windows:
-            subsystem: [None, cygwin, msys, msys2, sfu, wsl]
+            subsystem: [None, cygwin, msys, msys2, wsl]
 
 This subsetting can be used by build helpers as ``CMake``, to act accordingly.
 

--- a/conan1.0.rst
+++ b/conan1.0.rst
@@ -70,7 +70,7 @@ instead of specifying the minors too.
 The default profile detection and creation has been modified accordingly, but if you have a default
 profile you may want to update it to reflect this:
 
-.. code-block::
+.. code-block::text
 
     [settings]
     os=Linux

--- a/conan1.0.rst
+++ b/conan1.0.rst
@@ -15,7 +15,7 @@ There has been a few things that will break existing usage (compared to 0.30). M
 .. code-block:: bash
 
     # instead of --path=myfolder --file=myconanfile.py, now you can do:
-    $ conan install . # Note the "." is now compulsory
+    $ conan install . # Note the "." is now mandatory
     $ conan install folder/myconanfile.txt
     $ conan install ../myconanfile.py
     $ conan info .
@@ -103,7 +103,7 @@ New features
 
     os:
         Windows:
-            subsystem: [None, cygwin, msys, msys2, wsl]
+            subsystem: [None, cygwin, msys, msys2, sfu, wsl]
 
 This subsetting can be used by build helpers as ``CMake``, to act accordingly.
 

--- a/creating_packages/package_local_dev_flow.rst
+++ b/creating_packages/package_local_dev_flow.rst
@@ -85,11 +85,11 @@ _____________
 
 Just as it sounds, this CLI command now simply runs the package() method of a recipe.
 Like the conan build command, it basically takes “input” and “output” folders.
-In this case ``--build-folder`` and ``--package-folder``:
+In this case as **input**: ``--source-folder --build-folder`` and **output**: ``--package-folder``:
 
 .. code-block:: bash
 
-    $ conan package . --build-folder=tmp/build --package-folder=tmp/package
+    $ conan package . --source-folder=tmp/source --build-folder=tmp/build --package-folder=tmp/package
 
 
 conan create

--- a/getting_started.rst
+++ b/getting_started.rst
@@ -134,7 +134,7 @@ issued, it will use some settings, specified on the command line or taken from t
    :width: 500 px
    :align: center
 
-So for a command like ``$ conan install -s os="Linux" -s compiler="gcc"``, the steps are:
+So for a command like ``$ conan install .. -s os="Linux" -s compiler="gcc"``, the steps are:
 
 - First check if the package recipe (for Poco/1.8.0.1@pocoproject/stable package) exists in the
   local cache. If we are just starting, our cache will be empty.

--- a/using_packages/using_profiles.rst
+++ b/using_packages/using_profiles.rst
@@ -6,7 +6,7 @@ Using profiles
 So far we have used the default settings stored in ``~/.conan/profiles/default`` and defined as command line arguments.
 
 However, configurations can be large, settings can be very different, and we might want to switch easily between different configurations
-with different settings, options, etc.. The best way to this is using profiles.
+with different settings, options, etc.. The best way to do it is using profiles.
 
 A profile file contains a predefined set of ``settings``, ``options``, ``environment variables``, and ``build_requires`` and has this
 structure:


### PR DESCRIPTION
Some bug fixes while using doc.

Only two warnings detected
```
13:04 $ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.6.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 156 source files that are out of date
updating environment: 156 added, 0 changed, 0 removed
reading sources... [100%] videos                                                                                                                      
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/pedro/git_projects/conan.io/docs/howtos/use_gtest.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] videos                                                                                                                       
/home/pedro/git_projects/conan.io/docs/integrations/android_studio.rst:90: WARNING: Could not lex literal_block as "groovy". Highlighting skipped.
generating indices... genindex
writing additional pages... search
copying images... [100%] integrations/../images/clion/configure_warning_info.png                                                                      
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.
Generating sitemap.xml in /home/pedro/git_projects/conan.io/docs/_build/html/sitemap.xml

Build finished. The HTML pages are in _build/html.
```