### PR TITLE
More fixes/enhancement

### DIFF
--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -20,7 +20,7 @@ When this package is installed by a *conanfile.txt*, another package *conanfile.
 
 .. code-block:: bash
 
-    $ conan install MyLib/1.0@user/channel -s arch=x86_64 -s ...
+    $ conan install . MyLib/1.0@user/channel -s arch=x86_64 -s ...
 
 The process will be:
 
@@ -39,7 +39,7 @@ If the package is installed again with different settings, for example, for 32bi
 
 .. code-block:: bash
 
-    $ conan install MyLib/1.0@user/channel -s arch=x86 -s ...
+    $ conan install . MyLib/1.0@user/channel -s arch=x86 -s ...
 
 The process will be repeated, but now generating a different package ID, because the ``arch``
 setting will have a different value. The same applies for different compilers, compiler versions,

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -20,7 +20,7 @@ When this package is installed by a *conanfile.txt*, another package *conanfile.
 
 .. code-block:: bash
 
-    $ conan install . MyLib/1.0@user/channel -s arch=x86_64 -s ...
+    $ conan install MyLib/1.0@user/channel -s arch=x86_64 -s ...
 
 The process will be:
 
@@ -39,7 +39,7 @@ If the package is installed again with different settings, for example, for 32bi
 
 .. code-block:: bash
 
-    $ conan install . MyLib/1.0@user/channel -s arch=x86 -s ...
+    $ conan install MyLib/1.0@user/channel -s arch=x86 -s ...
 
 The process will be repeated, but now generating a different package ID, because the ``arch``
 setting will have a different value. The same applies for different compilers, compiler versions,

--- a/creating_packages/package_approaches.rst
+++ b/creating_packages/package_approaches.rst
@@ -4,14 +4,14 @@ Packaging approaches
 Package recipes have three methods to control the package's binary compatibility and to implement
 different packaging approaches: :ref:`method_package_id`, :ref:`method_build_id` and :ref:`method_package_info`.
 
-This methods provide package creators with the posibility to follow different packages approaches
-and chose the best one for each library.
+The above methods let package creators follow different package approaches to choose
+the best fit for each library.
 
 1 config (1 build) -> 1 package
 -------------------------------
 
-A typical approach is to have each package contain the artifacts just for one configuration. In this
-approach, for example, the debug pre-compiled libraries will be in a different package than the
+A typical approach is to have one configuration for each package containing the artifacts.
+In this approach, for example, the debug pre-compiled libraries will be in a different package than the
 release pre-compiled libraries.
 
 So if there is a package recipe that builds a “hello” library, there will be one package containing

--- a/devtools/create_installer_packages.rst
+++ b/devtools/create_installer_packages.rst
@@ -118,7 +118,7 @@ Using the tool packages in your system
 ......................................
 
 
-You can use the :ref:`virtual_env generator <virtualenv_generator>` to get the requirements applied
+You can use the :ref:`virtualenv generator <virtualenv_generator>` to get the requirements applied
 in your system.
 
 For example, if you are working in Windows, with MinGW and CMake.
@@ -154,7 +154,7 @@ or leave them unspecified in the file and pass them as command line parameters.
 
 .. code-block:: bash
 
-   $ conan install
+   $ conan install .
 
 
 4. Activate the virtual environment in your shell:

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -85,7 +85,7 @@ locations in the system. Let's modify the example recipe adding the ``deploy()``
         self.copy("*", dst="bin", src="bin")
 
 
-And call ``conan create``
+And run ``$ conan create``
 
 .. code-block:: bash
 
@@ -126,7 +126,7 @@ the ``Consumer`` package is willing to execute the ``greet`` app while building 
             with tools.environment_append(env.vars):
                 self.run("greet")
 
-Now run ``conan install`` and ``conan build`` for this consumer recipe:
+Now run ``$ conan install`` and ``$ conan build`` for this consumer recipe:
 
 .. code-block:: bash
 
@@ -170,7 +170,6 @@ to greet executable:
 
 .. _repackage:
 
-
 Runtime packages and re-packaging
 ----------------------------------
 It is possible to create packages that contain only runtime binaries, getting rid of all build-time dependencies.
@@ -204,12 +203,21 @@ This recipe has the following characteristics:
   is not define, then using the default empty one), are kept and not removed after build
 - The ``package()`` method packages the imported artifacts that will be in the build folder.
 
-
-Installing and running this package, can be done by any of the means presented above, for example, we could do:
+To create and upload to remote this package:
 
 .. code-block:: bash
 
-    $ conan install . -g virtualrunenv
+    $ conan create . user/testing
+    $ conan upload HelloRun* --all -r=my-remote
+
+
+After that, installing and running this package, can be done by any of the means presented above,
+for example, we could do:
+
+.. code-block:: bash
+
+    $ conan install HelloRun/0.1@user/testing -g virtualrunenv
+    # You can specify the remote with -r=my-remote
     # It will not install Hello/0.1@...
     $ activate_run.sh # $ source activate_run.sh in Unix/Linux
     $ greet

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -70,7 +70,8 @@ We will get some files, that can be called to activate and deactivate such envir
 Imports
 --------
 It is possible to define a custom conanfile (either .txt or .py), with an ``imports`` section, that can retrieve from local
-cache the desired files. This approach, requires an user conanfile, so it might not be very convenient.
+cache the desired files. This approach, requires an user conanfile.
+For more details see example below :ref:`runtime packages<repackage>`
 
 
 Deployable packages
@@ -169,6 +170,7 @@ to greet executable:
 
 .. _repackage:
 
+
 Runtime packages and re-packaging
 ----------------------------------
 It is possible to create packages that contain only runtime binaries, getting rid of all build-time dependencies.
@@ -207,12 +209,9 @@ Installing and running this package, can be done by any of the means presented a
 
 .. code-block:: bash
 
-    $ conan install HelloRun/0.1@user/testing -g virtualrunenv
+    $ conan install . -g virtualrunenv
     # It will not install Hello/0.1@...
-    $ activate
+    $ activate_run.sh # $ source activate_run.sh in Unix/Linux
     $ greet
     > Hello World!
-
-
-
-
+    $ deactivate_run.sh # $ source deactivate_run.sh in Unix/Linux

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -33,7 +33,7 @@ Now, we can create the package as usual, but if we try to run the executable, it
 
 .. code-block:: bash
 
-    $ conan create user/testing
+    $ conan create . user/testing
     ...
     Hello/0.1@user/testing package(): Copied 1 '.h' files: hello.h
     Hello/0.1@user/testing package(): Copied 1 '.exe' files: greet.exe
@@ -62,10 +62,10 @@ We will get some files, that can be called to activate and deactivate such envir
 
 .. code-block:: bash
 
-    $ activate # $ source activate in nix
+    $ activate_run.sh # $ source activate_run.sh in Unix/Linux
     $ greet
     > Hello World!
-
+    $ deactivate_run.sh # $ source deactivate_run.sh in Unix/Linux
 
 Imports
 --------

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -20,7 +20,7 @@ We can crate a package that contains an executable, for example from the default
 
     $ conan new Hello/0.1
 
-The source code used contains an executable called ``greet``, but it is not packaged by default. Lets modify the recipe
+The source code used contains an executable called ``greet``, but it is not packaged by default. Let's modify the recipe
 ``package()`` method to also package the executable:
 
 .. code-block:: python
@@ -52,7 +52,7 @@ The ``virtualrunenv`` generator will generate files that add the packages defaul
 - It adds the dependencies ``lib`` subfolder to the ``LD_LIBRARY_PATH`` environment variable (for Linux shared libraries)
 - It adds the dependencies ``bin`` subfolder to the ``PATH`` environment variable (for executables)
 
-So if we install the package, specifying such ``virtualenv`` like:
+So if we install the package, specifying such ``virtualrunenv`` like:
 
 .. code-block:: bash
 
@@ -70,19 +70,25 @@ We will get some files, that can be called to activate and deactivate such envir
 Imports
 --------
 It is possible to define a custom conanfile (either .txt or .py), with an ``imports`` section, that can retrieve from local
-cache the desired files. This approach, requires a user conanfile, so it might not be very convenient.
+cache the desired files. This approach, requires an user conanfile, so it might not be very convenient.
 
 
 Deployable packages
 --------------------
-With the ``deploy()`` method, a package can specify which files and artifacts to copy to user space, of to other locations
-in the system. In the above example we could add to our ``Hello`` conanfile.py, and run ``conan create`` again:
+With the ``deploy()`` method, a package can specify which files and artifacts to copy to user space or to other
+locations in the system. Let's modify the example recipe adding the ``deploy()`` method:
 
 .. code-block:: python
 
     def deploy(self):
         self.copy("*", dst="bin", src="bin")
 
+
+And call ``conan create``
+
+.. code-block:: bash
+
+    $ conan create . user/testing
 
 With that method in our package recipe, it will copy the executable when installed directly:
 

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -125,6 +125,15 @@ the ``Consumer`` package is willing to execute the ``greet`` app while building 
             with tools.environment_append(env.vars):
                 self.run("greet")
 
+Now run ``conan install`` and ``conan build`` for this consumer recipe:
+
+.. code-block:: bash
+
+    $ conan install . && conan build .
+    ...
+    Project: Running build()
+    Hello World!
+
 Instead of using the environment, it is also possible to access the path of the dependencies:
 
 .. code-block:: python

--- a/howtos/manage_shared_libraries/env_vars.rst
+++ b/howtos/manage_shared_libraries/env_vars.rst
@@ -184,7 +184,7 @@ We could also use a :ref:`virtualenv generator<virtual_environment_generator>` t
     toolA:shared=True
 
     [generators]
-    virtualenvironment
+    virtualenv
 
 
 **In the terminal window:**
@@ -215,7 +215,7 @@ the environment variables poiting to the "lib" and "bin" folders.
     toolA:shared=True
 
     [generators]
-    virtualrunenvironment
+    virtualenv
 
 
 **In the terminal window:**

--- a/mastering/virtualenv.rst
+++ b/mastering/virtualenv.rst
@@ -88,7 +88,7 @@ Virtualbuildenv environment
 Use the generator ``virtualbuildenv`` to activate an environment that will set the environment variables for
 Autotools and Visual Studio.
 
-This will generate ``activate_build`` and ``deactivate_build`` files.
+The generator will create ``activate_build`` and ``deactivate_build`` files.
 
 .. seealso:: Read More about the building environment variables defined in the sections :ref:`Building with autotools <autotools_reference>` and :ref:`Build with Visual Studio<msbuild>`.
 
@@ -105,7 +105,7 @@ Use the generator ``virtualrunenv`` to activate an environment that will:
 - Append to ``PATH`` environment variable every ``bin`` folder of your requirements.
 - Append to ``LD_LIBRARY_PATH`` and ``DYLD_LIBRARY_PATH`` environment variables each ``lib`` folder of  your requirements.
 
-This generator is especially useful:
+The generator will create ``activate_run`` and ``deactivate_run`` files. This generator is especially useful:
 
 - If you are requiring packages with shared libraries and you are running some executable that needs those libraries.
 - If you have a requirement with some tool (executable) and you need it in the path.

--- a/uploading_packages/bintray/uploading_bintray.rst
+++ b/uploading_packages/bintray/uploading_bintray.rst
@@ -56,12 +56,8 @@ repositories in the following order of priority:
   2. `conan-transit`_
   3. Your own repository
 
-<<<<<<< HEAD
-If you want to have your own repository prioritized, please use the ``--insert`` command line option when adding it:
-=======
 If you want to have your own repository prioritized, please use the ``--insert`` command line option
 when adding it:
->>>>>>> master
 
 .. code-block:: bash
 

--- a/uploading_packages/remotes.rst
+++ b/uploading_packages/remotes.rst
@@ -49,9 +49,9 @@ team. Currently there are two central repositories:
 .. pull-quote::
 
    This repository is an exact copy of the old ``server.conan.io`` repository at **June 11, 2017
-   08:00 CET**. It is a read-only repository, sou you can download any packages that it hosts but
-   you are not able to upload packages to it. This repository only exists for backwards
-   compatibility and the packages there **will never be updated**.
+   08:00 CET**. It's a read-only repository, so you can only download hosted packages but
+   you won't be able to upload anything else. This repository only exists for backwards
+   compatibility and the currently hosted packages **will never be updated**.
 
 Conan comes with both **conan-center** and **conan-transit** repositories configured by default.
 Just in case you want to manually configure these repositories you can always add them like this:

--- a/uploading_packages/uploading_to_remotes.rst
+++ b/uploading_packages/uploading_to_remotes.rst
@@ -58,7 +58,7 @@ just want to check if we can download the binaries and use them:
 
 .. code-block:: bash
 
-    $ conan create . demo/testing --no-export --build=never
+    $ conan create . demo/testing --not-export --build=never
 
 You will see that the test is built, but the packages are not. The binaries are simply downloaded
 from your local server. You can check their existence on your local computer again with:


### PR DESCRIPTION
Output for html target:

```bash
13:20 $ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.6.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 156 source files that are out of date
updating environment: 156 added, 0 changed, 0 removed
reading sources... [100%] videos                                                                                                                                                         
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/pedro/git_projects/conan.io/docs/howtos/use_gtest.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] videos                                                                                                                                                          
/home/pedro/git_projects/conan.io/docs/integrations/android_studio.rst:90: WARNING: Could not lex literal_block as "groovy". Highlighting skipped.
generating indices... genindex
writing additional pages... search
copying images... [100%] integrations/../images/clion/configure_warning_info.png                                                                                                         
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.
Generating sitemap.xml in /home/pedro/git_projects/conan.io/docs/_build/html/sitemap.xml

Build finished. The HTML pages are in _build/html.
```