### PR TITLE
Added references to CONAN_RUN_TEST in doc

### DIFF
--- a/howtos/header_only.rst
+++ b/howtos/header_only.rst
@@ -80,12 +80,12 @@ If you want to run the library unit test while packaging, you would need this re
     If you are :ref:`cross building <cross_building>` your **library** or **app** you'll probably need
     to skip the **unit tests** because your target binary cannot be executed in current building host.
     To do it you can use :ref:`tools.get_env() <tools_get_env>` in combination with
-    :ref:`CONAN_RUN_TEST <conan_run_test>` env variable, defined as **False**
+    :ref:`CONAN_RUN_TESTS <conan_run_tests>` env variable, defined as **False**
     in profile for cross building and replace ``cmake.test()`` with:
 
     .. code-block:: python
 
-        if tools.get_env("CONAN_RUN_TEST", True):
+        if tools.get_env("CONAN_RUN_TESTS", True):
             cmake.test()
 
 Which will use a ``CMakeLists.txt`` file in the root folder:

--- a/howtos/header_only.rst
+++ b/howtos/header_only.rst
@@ -80,10 +80,13 @@ If you want to run the library unit test while packaging, you would need this re
     If you are :ref:`cross building <cross_building>` your **library** or **app** you'll probably need
     to skip the **unit tests** because your target binary cannot be executed in current building host.
     To do it you can use :ref:`tools.get_env() <tools_get_env>` in combination with
-    :ref:`CONAN_RUN_TEST <conan_run_test>` **environment variable** added to your profile for cross building.
-    You can replace ``cmake.test()`` with a conditional call like:
+    :ref:`CONAN_RUN_TEST <conan_run_test>` env variable, defined as **False**
+    in profile for cross building and replace ``cmake.test()`` with:
 
-    ``cmake.test() if tools.get_env("CONAN_RUN_TEST", False)``
+    .. code-block:: python
+
+        if tools.get_env("CONAN_RUN_TEST", True):
+            cmake.test()
 
 Which will use a ``CMakeLists.txt`` file in the root folder:
 

--- a/howtos/header_only.rst
+++ b/howtos/header_only.rst
@@ -76,6 +76,15 @@ If you want to run the library unit test while packaging, you would need this re
             self.info.header_only()
 
 
+.. tip::
+    If you are :ref:`cross building <cross_building>` your **library** or **app** you'll probably need
+    to skip the **unit tests** because your target binary cannot be executed in current building host.
+    To do it you can use :ref:`tools.get_env() <tools_get_env>` in combination with
+    :ref:`CONAN_RUN_TEST <conan_run_test>` **environment variable** added to your profile for cross building.
+    You can replace ``cmake.test()`` with a conditional call like:
+
+    ``cmake.test() if tools.get_env("CONAN_RUN_TEST", False)``
+
 Which will use a ``CMakeLists.txt`` file in the root folder:
 
 .. code-block:: cmake

--- a/howtos/header_only.rst
+++ b/howtos/header_only.rst
@@ -77,6 +77,8 @@ If you want to run the library unit test while packaging, you would need this re
 
 
 .. tip::
+    .. _header_only_unit_tests_tip:
+
     If you are :ref:`cross building <cross_building>` your **library** or **app** you'll probably need
     to skip the **unit tests** because your target binary cannot be executed in current building host.
     To do it you can use :ref:`tools.get_env() <tools_get_env>` in combination with

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -345,10 +345,10 @@ uploading packages, as they will be read-only and that could have other side-eff
     It is not recommended to upload packages directly from developers machines with read-only mode as it could lead to insconsistencies.
     For better reproducibility we recommend that packages are created and uploaded by CI machines.
 
-.. _conan_run_test:
+.. _conan_run_tests:
 
-CONAN_RUN_TEST
---------------
+CONAN_RUN_TESTS
+---------------
 
 **Defaulted to**: Not defined (True/False if defined)
 
@@ -364,11 +364,11 @@ It can be defined in your profile files at ``~/.conan/profiles``
 
     ...
     [env]
-    CONAN_RUN_TEST=False
+    CONAN_RUN_TESTS=False
 
 or declared in command line when invoking conan:
 
 .. code-block:: bash
 
-    $ CONAN_RUN_TEST=False conan <command> ...
+    $ CONAN_RUN_TESTS=False conan <command> ...
 

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -344,3 +344,29 @@ uploading packages, as they will be read-only and that could have other side-eff
 
     It is not recommended to upload packages directly from developers machines with read-only mode as it could lead to insconsistencies.
     For better reproducibility we recommend that packages are created and uploaded by CI machines.
+
+CONAN_RUN_TEST
+--------------
+
+**Defaulted to**: Not defined (True/False if defined)
+
+This environment variable (if defined) can be used in ``conanfile.py`` to enable/disable the tests for a library or
+application.
+
+It can be used as a convention variable and it's specially useful if a library has unit tests
+and you are doing :ref:`cross building <cross_building>`, the target binary can't be executed in current host machine building the package.
+
+It can be defined in your profile files at ``~/.conan/profiles``
+
+.. code-block:: python
+
+    ...
+    [env]
+    CONAN_RUN_TEST=False
+
+or declared in command line when invoking conan:
+
+.. code-block:: bash
+
+    $ CONAN_RUN_TEST=False conan <command> ...
+

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -345,6 +345,8 @@ uploading packages, as they will be read-only and that could have other side-eff
     It is not recommended to upload packages directly from developers machines with read-only mode as it could lead to insconsistencies.
     For better reproducibility we recommend that packages are created and uploaded by CI machines.
 
+.. _conan_run_test:
+
 CONAN_RUN_TEST
 --------------
 

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -375,3 +375,27 @@ or declared in command line when invoking ``$ conan install`` to reduce the vari
 
 See how to retrieve the value with :ref:`tools.get_env() <tools_get_env>` and check an use case
 with :ref:`a header only with unit tests recipe <header_only_unit_tests_tip>` while cross building.
+
+.. code-block:: python
+
+    from conans import ConanFile, CMake, tools
+
+    class HelloConan(ConanFile):
+        name = "Hello"
+        version = "0.1"
+        settings = "os", "compiler", "arch", "build_type"
+        exports_sources = "include/*", "CMakeLists.txt", "example.cpp"
+        no_copy_source = True
+
+        def build(self): # this is not building a library, just tests
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+            if tools.get_env("CONAN_RUN_TESTS", True):
+                cmake.test()
+
+        def package(self):
+            self.copy("*.h")
+
+        def package_id(self):
+            self.info.header_only()

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -376,6 +376,8 @@ or declared in command line when invoking ``$ conan install`` to reduce the vari
 See how to retrieve the value with :ref:`tools.get_env() <tools_get_env>` and check an use case
 with :ref:`a header only with unit tests recipe <header_only_unit_tests_tip>` while cross building.
 
+See example of build method in ``conanfile.py`` to enable/disable running tests with CMake:
+
 .. code-block:: python
 
     from conans import ConanFile, CMake, tools
@@ -383,19 +385,10 @@ with :ref:`a header only with unit tests recipe <header_only_unit_tests_tip>` wh
     class HelloConan(ConanFile):
         name = "Hello"
         version = "0.1"
-        settings = "os", "compiler", "arch", "build_type"
-        exports_sources = "include/*", "CMakeLists.txt", "example.cpp"
-        no_copy_source = True
 
-        def build(self): # this is not building a library, just tests
+        def build(self):
             cmake = CMake(self)
             cmake.configure()
             cmake.build()
             if tools.get_env("CONAN_RUN_TESTS", True):
                 cmake.test()
-
-        def package(self):
-            self.copy("*.h")
-
-        def package_id(self):
-            self.info.header_only()

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -371,7 +371,7 @@ or declared in command line when invoking ``$ conan install`` to reduce the vari
 
 .. code-block:: bash
 
-    $ conan install -e CONAN_RUN_TEST=0 ...
+    $ conan install . -e CONAN_RUN_TEST=0
 
 See how to retrieve the value with :ref:`tools.get_env() <tools_get_env>` and check an use case
 with :ref:`a header only with unit tests recipe <header_only_unit_tests_tip>` while cross building.

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -356,7 +356,8 @@ This environment variable (if defined) can be used in ``conanfile.py`` to enable
 application.
 
 It can be used as a convention variable and it's specially useful if a library has unit tests
-and you are doing :ref:`cross building <cross_building>`, the target binary can't be executed in current host machine building the package.
+and you are doing :ref:`cross building <cross_building>`, the target binary can't be executed in current
+host machine building the package.
 
 It can be defined in your profile files at ``~/.conan/profiles``
 
@@ -366,8 +367,11 @@ It can be defined in your profile files at ``~/.conan/profiles``
     [env]
     CONAN_RUN_TESTS=False
 
-or declared in command line when invoking ``conan install`` to reduce the variable scope for conan execution
+or declared in command line when invoking ``$ conan install`` to reduce the variable scope for conan execution
 
 .. code-block:: bash
 
     $ conan install -e CONAN_RUN_TEST=0 ...
+
+See how to retrieve the value with :ref:`tools.get_env() <tools_get_env>` and check an use case
+with :ref:`a header only with unit tests recipe <header_only_unit_tests_tip>` while cross building.

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -366,9 +366,8 @@ It can be defined in your profile files at ``~/.conan/profiles``
     [env]
     CONAN_RUN_TESTS=False
 
-or declared in command line when invoking conan:
+or declared in command line when invoking ``conan install`` to reduce the variable scope for conan execution
 
 .. code-block:: bash
 
-    $ CONAN_RUN_TESTS=False conan <command> ...
-
+    $ conan install -e CONAN_RUN_TEST=0 ...

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -248,6 +248,41 @@ Parameters:
     - **sha1** (Optional, Defaulted to ``""``): SHA1 hash code to check the downloaded file.
     - **sha256** (Optional, Defaulted to ``""``): SHA256 hash code to check the downloaded file.
 
+tools.get_env()
+---------------
+
+.. code-block:: python
+
+   def get_env(env_key, default=None, environment=os.environ)
+
+Parses an environment and cast its value against the **default** type passed as an argument.
+
+Following python conventions, returns **default** if **env_key** is not defined.
+
+See an usage exampel with an environment variable defined while executing conan
+
+.. code-block:: bash
+
+   $ TEST_ENV="1" conan <command> ...
+
+.. code-block:: python
+
+   from conans import tools
+
+   tools.get_env("TEST_ENV") # returns "1", returns current value
+   tools.get_env("TEST_ENV_NOT_DEFINED") # returns None, TEST_ENV_NOT_DEFINED not declared
+   tools.get_env("TEST_ENV_NOT_DEFINED", []) # returns [], TEST_ENV_NOT_DEFINED not declared
+   tools.get_env("TEST_ENV", "2") # returns "1"
+   tools.get_env("TEST_ENV", False) # returns True (default value is boolean)
+   tools.get_env("TEST_ENV", 2) # returns 1
+   tools.get_env("TEST_ENV", 2.0) # returns 1.0
+   tools.get_env("TEST_ENV", []) # returns ["1"]
+
+Parameters:
+   - **env_key** (Required): environment variable name.
+   - **default** (Optional, Defaulted to ``None``): default value to return if not defined or cast value against.
+   - **environment** (Optional, Defaulted to ``os.environ``): environment dictionary to look for.
+
 tools.download()
 ----------------
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -261,7 +261,7 @@ Parses an environment and cast its value against the **default** type passed as 
 
 Following python conventions, returns **default** if **env_key** is not defined.
 
-See an usage exampel with an environment variable defined while executing conan
+See an usage example with an environment variable defined while executing conan
 
 .. code-block:: bash
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -255,7 +255,7 @@ tools.get_env()
 
 .. code-block:: python
 
-   def get_env(env_key, default=None, environment=os.environ)
+   def get_env(env_key, default=None, environment=None)
 
 Parses an environment and cast its value against the **default** type passed as an argument.
 
@@ -283,7 +283,7 @@ See an usage example with an environment variable defined while executing conan
 Parameters:
    - **env_key** (Required): environment variable name.
    - **default** (Optional, Defaulted to ``None``): default value to return if not defined or cast value against.
-   - **environment** (Optional, Defaulted to ``os.environ``): environment dictionary to look for.
+   - **environment** (Optional, Defaulted to ``None``): os.environ if None or environment dictionary to look for.
 
 tools.download()
 ----------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -283,7 +283,7 @@ See an usage example with an environment variable defined while executing conan
 Parameters:
    - **env_key** (Required): environment variable name.
    - **default** (Optional, Defaulted to ``None``): default value to return if not defined or cast value against.
-   - **environment** (Optional, Defaulted to ``None``): os.environ if None or environment dictionary to look for.
+   - **environment** (Optional, Defaulted to ``None``): ``os.environ`` if ``None`` or environment dictionary to look for.
 
 tools.download()
 ----------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -248,6 +248,8 @@ Parameters:
     - **sha1** (Optional, Defaulted to ``""``): SHA1 hash code to check the downloaded file.
     - **sha256** (Optional, Defaulted to ``""``): SHA256 hash code to check the downloaded file.
 
+.. _tools_get_env:
+
 tools.get_env()
 ---------------
 


### PR DESCRIPTION
fixes #511 
references conan-io/conan#2427


```
17:41 $ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.6.7
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 156 source files that are out of date
updating environment: 156 added, 0 changed, 0 removed
reading sources... [100%] videos
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/pvicente/git/conan/docs/howtos/use_gtest.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] videos
/Users/pvicente/git/conan/docs/integrations/android_studio.rst:90: WARNING: Could not lex literal_block as "groovy". Highlighting skipped.
generating indices... genindex
writing additional pages... search
copying images... [100%] integrations/../images/clion/configure_warning_info.png
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.
Generating sitemap.xml in /Users/pvicente/git/conan/docs/_build/html/sitemap.xml

Build finished. The HTML pages are in _build/html.
```