### PR TITLE
doc: Fix conan requires converted to mailto link

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -136,7 +136,7 @@ issued, it will use some settings, specified on the command line or taken from t
 
 So for a command like ``$ conan install .. -s os="Linux" -s compiler="gcc"``, the steps are:
 
-- First check if the package recipe (for Poco/1.8.0.1@pocoproject/stable package) exists in the
+- First check if the package recipe (for ``Poco/1.8.0.1@pocoproject/stable`` package) exists in the
   local cache. If we are just starting, our cache will be empty.
 - Look for the package recipe in the defined remotes. By default, conan comes with the Bintray
   remotes defined (you can change that), so the conan client will search in `conan-center` and


### PR DESCRIPTION
The @ sign in "Poco/1.8.0.1@pocoproject/stable" was detected as being part of an email address and incorrectly converted to a mailto link.