### PR TITLE
Avoid dangerous rm -rf

### DIFF
--- a/using_packages/workflows.rst
+++ b/using_packages/workflows.rst
@@ -43,7 +43,7 @@ Now you are ready to build:
 
 .. code-block:: bash
 
-    $ cmake ../example-hello -G "Visual Studio 14 Win64" //or other generator
+    $ cmake ../example-hello -G "Visual Studio 14 Win64"  # or other generator
     $ cmake --build . --config Release
     $ ./bin/greet
 
@@ -53,8 +53,7 @@ build with a new configuration with different settings, if needed:
 
 .. code-block:: bash
 
-    $ cd example-hello-build
-    $ rm -rf *
+    $ cd example-hello-build && rm -rf *
     $ conan install ../example-hello -s compiler="<other compiler>" --build=missing
     $ cmake ../example-hello -G "<other generator>"
     $ cmake --build . --config Release


### PR DESCRIPTION
`rm -rf *` may be dangerous if the `cd` before failed.
`rm -rf example-hello-build/*` might be dangerous if a space is added before the `*`.
Other danger is the user calling that from bash history but from the wrong directory.

A possible improvement would be:
`cd example-hello-build && rm -rf *`

As a bonus, I added a fix for a bash comment.