### PR TITLE
Fix link target, improve link text

### DIFF
--- a/creating_packages/package_dev_flow.rst
+++ b/creating_packages/package_dev_flow.rst
@@ -21,7 +21,7 @@ The local workflow encourages users to do trial-and-error in a local sub-directo
 typically test building their projects with other build tools. The strategy is to test the *conanfile.py* methods individually during this
 phase.
 
-We will use `this example <git@github.com:memsharded/example_conan_flow.git>`_ to follow the steps in the order below:
+We will use the following `conan flow example <https://github.com/memsharded/example_conan_flow.git>`_ to follow the steps in the order below:
 
 $ conan source
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
Git through ssh links can't be resolved by a browser.