### PR TITLE
Don't use $ for command names, improve bincrafter's blog link

### DIFF
--- a/creating_packages/package_dev_flow.rst
+++ b/creating_packages/package_dev_flow.rst
@@ -12,8 +12,8 @@ some costly operations:
 But sometimes, specially with big libraries, while we are developing the recipe, **we cannot afford** to perform every time these
 operations.
 
-The following section is the local development flow description based on the Bincrafters community at
-`their Blog <https://bincrafters.github.io>`_.
+The following section is the local development flow description based on the
+`Bincrafters community blog <https://bincrafters.github.io>`_.
 
 ----
 
@@ -23,8 +23,8 @@ phase.
 
 We will use the following `conan flow example <https://github.com/memsharded/example_conan_flow.git>`_ to follow the steps in the order below:
 
-$ conan source
-^^^^^^^^^^^^^^
+conan source
+^^^^^^^^^^^^
 
 You will generally want to start off with the :command:`conan source` command. The strategy here is that you’re testing your source method in
 isolation, and downloading the files to a temporary sub-folder relative to the *conanfile.py*. This just makes it easier to get to the
@@ -50,8 +50,8 @@ This method outputs the source files into the source-folder.
 Once you’ve got your source method right and it contains the files you expect, you can move on to testing the various attributes and methods
 relating to the downloading of dependencies.
 
-$ conan install
-^^^^^^^^^^^^^^^
+conan install
+^^^^^^^^^^^^^
 
 Conan has multiple methods and attributes which relate to dependencies (all the ones with the word "require" in the name). The command
 :command:`conan install` activates all them.
@@ -75,8 +75,8 @@ This also generates *conaninfo.txt* and *conanbuildinfo.xyz* (extension depends 
 (``install-folder``), which will be needed for the next step. Once you've got this command working with no errors, you can move on to
 testing the ``build()`` method.
 
-$ conan build
-^^^^^^^^^^^^^
+conan build
+^^^^^^^^^^^
 
 The build method takes a path to a folder that has sources and also to the install folder to get the information of the settings and
 dependencies. It uses a path to a folder where it will perform the build.
@@ -104,8 +104,8 @@ dependencies. It uses a path to a folder where it will perform the build.
 This is pretty strightforward, but it does add a very helpful new shortcut for people who are packaging their own library. Now, developers
 can make changes in their normal source directory and just pass that path as the ``--source-folder``.
 
-$ conan package
-^^^^^^^^^^^^^^^
+conan package
+^^^^^^^^^^^^^
 
 Just as it sounds, this command now simply runs the ``package()`` method of a recipe. It needs all the information of the other folders in
 order to collect the needed information for the package: header files from source folder, settings and depency information from the install
@@ -132,8 +132,8 @@ folder and built artifacts from the build folder.
     PROJECT package(): Copied 2 '.lib' files: greet.lib, hello.lib
     PROJECT: Package 'package' created
 
-$ conan export-pkg
-^^^^^^^^^^^^^^^^^^
+conan export-pkg
+^^^^^^^^^^^^^^^^
 
 When you have checked that the packaged is done correctly, you can generate the package in the local cache. Note that the package is
 generated again to make sure this step is always reproducible.
@@ -162,8 +162,8 @@ This parameters takes the same parameters as ``package()`` but in this case ther
     Hello/0.1@user/channel package(): Copied 2 '.lib' files: greet.lib, hello.lib
     Hello/0.1@user/channel: Package '6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7' created
 
-$ conan test
-^^^^^^^^^^^^
+conan test
+^^^^^^^^^^
 
 The finally step to test the package for consumer is the test command. This step is quite straight-forward:
 
@@ -201,13 +201,13 @@ As a summary, you could use the default folders and the flow would be as simple 
     PROJECT package(): Copied 2 '.lib' files: greet.lib, hello.lib
     PROJECT: Package 'package' created
 
-$ conan create
-^^^^^^^^^^^^^^
+conan create
+^^^^^^^^^^^^
 
 Now we know we have all the steps of a recipe working. Thus, now is an appropriate time to try to run the recipe all the way through, and
 put it completely in the local cache.
 
-The usual command for this is **$ conan create** and it basically performs the previous commands with :command:`conan test` for *test_package*
+The usual command for this is :command:`conan create` and it basically performs the previous commands with :command:`conan test` for the `test_package`
 folder:
 
 .. code-block:: bash


### PR DESCRIPTION
Using $ as a prefix when you're describing a prompt is ok, as it's a reminder.
It helps knowing the command should be (in that specific context) called as a user ($ prefix) and not as root (# prefix).
However, sprinkling it everywhere adds more noise than information, and makes it harder to read.