### PR TITLE
Added exports for base class example

### DIFF
--- a/howtos/python_code_reuse.rst
+++ b/howtos/python_code_reuse.rst
@@ -195,3 +195,4 @@ And then:
     class ConanFileToolsTest(ConanBase):
         name = "test"
         version = "1.9"
+        exports = "base_conan.py"


### PR DESCRIPTION
Missing `exports = "base_conan.py"` y the how-to example.

closes #591