### PR TITLE
Added deploy() to conan install execution flow

### DIFF
--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -87,8 +87,24 @@ installed, Conan will write the files for the specified generators.
 3. ``requirements()``
 4. ``package_id()``
 5. ``package_info()``
+6. ``deploy()``
 
-Note this describes the process of installing a pre-built binary package and not building with :command:`--build`.
+Note this describes the process of installing a pre-built binary package. If the package has to be built, :command:`conan install --build`
+executes the following:
+
+1. ``config_options()``
+2. ``configure()``
+3. ``requirements()``
+4. ``package_id()``
+5. ``build_requirements()``
+6. ``build_id()``
+7. ``system_requirements()``
+8. ``source()``
+9. ``imports()``
+10. ``build()``
+11. ``package()``
+12. ``package_info()``
+13. ``deploy()``
 
 **Examples**
 

--- a/reference/commands/creator/create.rst
+++ b/reference/commands/creator/create.rst
@@ -122,6 +122,5 @@ This is the recommended way to create packages.
 11. ``package()``
 12. ``package_info()``
 
-In case of installing a pre-built binary, steps from 5 to 11 will be skipped. Note ``package_info()`` is used for consumers, it should not
-be fired if there is no *test_package*. Note also that ``deploy()`` method is only used in :command:`conan install`.
-
+In case of installing a pre-built binary, steps from 5 to 11 will be skipped. Note that ``deploy()`` method is only used in
+:command:`conan install`.


### PR DESCRIPTION
``deploy()`` was missing from ``conan install`` execution flow.

Added also the flow for ``conan install --build``

closes #637