### PR TITLE
Line from config.rst missing in official docs.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,14 @@ Check https://github.com/conan-io/conan for issues and more details about develo
   Conan 1.5 shouldn't break any existing 1.0 recipe, or command line invocation. If it does, please report in github.
   Please read more :ref:`about Conan stability<stability>`.
 
+
+1.5.2 (5-July-2018)
+--------------------
+
+- Bugfix: Fixed bug with pre-1.0 packages with sources.
+- Bugfix: Fixed regression in private requirements.
+
+
 1.5.1 (29-June-2018)
 --------------------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,10 @@ Check https://github.com/conan-io/conan for issues and more details about develo
   Conan 1.5 shouldn't break any existing 1.0 recipe, or command line invocation. If it does, please report in github.
   Please read more :ref:`about Conan stability<stability>`.
 
+1.6.0 ()
+----------------------
+
+- Feature: ``conan remote list --raw`` prints remote info in a format valid for *remotes.txt*, so it can be used for ``conan config install``
 
 1.5.2 (5-July-2018)
 --------------------

--- a/changelog.rst
+++ b/changelog.rst
@@ -18,6 +18,7 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 - Feature: ``conan remote list --raw`` prints remote info in a format valid for *remotes.txt*, so it can be used for ``conan config install``
 - Feature: Visual Studio generator creates *conanbuildinfo.props* file using ``$(USERPROFILE)`` macro.
 - Feature: Added ``filename`` parameter to ``tools.get()`` in case it cannot be deduced from URL.
+- Feature: Added XZ extensions to ``unzip()``. It will only work in Python 3 with lzma support enabled, producing an error otherwise.
 
 1.5.2 (5-July-2018)
 --------------------

--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,10 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 1.6.0 ()
 ----------------------
 
+- Feature: Added new ``self.run(..., run_environment=True)`` argument, that applies automatically ``PATH``, ``LD_LIBRARY_PATH`` and ``DYLD_LIBRARY_PATH``
+  environment variable, from the dependencies, to the execution of the current command.
+- Feature: Added new ``self.run(..., ignore_errors=True)`` argument, that inhibits launching an exception if the commands fails, user can
+  capture the return code.
 - Feature: The ``json`` generator now outputs the settings and options
 - Feature: ``conan remote list --raw`` prints remote info in a format valid for *remotes.txt*, so it can be used for ``conan config install``
 - Feature: Visual Studio generator creates *conanbuildinfo.props* file using ``$(USERPROFILE)`` macro.

--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 
 - Feature: The ``json`` generator now outputs the settings and options
 - Feature: ``conan remote list --raw`` prints remote info in a format valid for *remotes.txt*, so it can be used for ``conan config install``
+- Feature: Visual Studio generator creates *conanbuildinfo.props* file using ``$(USERPROFILE)`` macro.
 
 1.5.2 (5-July-2018)
 --------------------

--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 1.6.0 ()
 ----------------------
 
+- Feature: The ``json`` generator now outputs the settings and options
 - Feature: ``conan remote list --raw`` prints remote info in a format valid for *remotes.txt*, so it can be used for ``conan config install``
 
 1.5.2 (5-July-2018)

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -118,7 +118,8 @@ Running from packages
 ---------------------
 
 If a dependency has an executable that we want to run in the conanfile it can be done directly in code
-using the ``RunEnvironment`` helper. For example, if we want to execute the ``greet`` app while building the ``Consumer`` package:
+using the ``run_environment=True`` argument. It internally uses a ``RunEnvironment`` helper. 
+For example, if we want to execute the ``greet`` app while building the ``Consumer`` package:
 
 .. code-block:: python
 
@@ -131,9 +132,8 @@ using the ``RunEnvironment`` helper. For example, if we want to execute the ``gr
         requires = "Hello/0.1@user/testing"
 
         def build(self):
-            env = RunEnvironment(self)
-            with tools.environment_append(env.vars):
-                self.run("greet")
+            self.run("greet", run_environment=True)
+
 
 Now run :command:`conan install` and :command:`conan build` for this consumer recipe:
 
@@ -144,7 +144,7 @@ Now run :command:`conan install` and :command:`conan build` for this consumer re
     Project: Running build()
     Hello World!
 
-Instead of using the environment, it is also possible to access the path of the dependencies:
+Instead of using the environment, it is also possible to explicitly access the path of the dependencies:
 
 .. code-block:: python
 
@@ -152,7 +152,7 @@ Instead of using the environment, it is also possible to access the path of the 
         path = os.path.join(self.deps_cpp_info["Hello"].rootpath, "bin")
         self.run("%s/greet" % path)
 
-Note that this might not be enough if shared libraries exist. Using the ``RunEnvironment`` helper above 
+Note that this might not be enough if shared libraries exist. Using the ``run_environment=True`` helper above 
 is a more complete solution.
 
 Finally, there is another approach: the package containing the executable can add its *bin* folder directly to the ``PATH``.

--- a/howtos/manage_shared_libraries/env_vars.rst
+++ b/howtos/manage_shared_libraries/env_vars.rst
@@ -82,10 +82,8 @@ execute directly ``toolA`` using RunEnvironment build helper to set the environm
 
         def build(self):
             exe_name = "toolA.exe" if self.settings.os == "Windows" else "toolA"
-            env_build = RunEnvironment(self)
-            with tools.environment_append(env_build.vars):
-                self.run("%s --someparams" % exe_name)
-                ...
+            self.run("%s --someparams" % exe_name, run_environment=True)
+            ...
 
 Building an application using the shared library from ``toolA``
 ---------------------------------------------------------------

--- a/integrations.rst
+++ b/integrations.rst
@@ -34,3 +34,4 @@ packages can be consumed, created, and continuously deployed/tested with each, a
    integrations/youcompleteme
    integrations/scons
    integrations/other
+   integrations/pylint

--- a/integrations/pylint.rst
+++ b/integrations/pylint.rst
@@ -1,0 +1,19 @@
+.. _pylint_integration:
+
+Linting conanfile.py
+====================
+
+``conan create`` command verifies the recipe file using pylint.
+
+However if you have IDE which has support for Python and may do linting automatically,
+there are false warnings caused by the fact that Conan populates some
+fields of recipe dynamically based on context.
+
+Conan provides a plugin which makes pylint aware of these dynamic fields and their types.
+To using it when running pylint outside Conan just add to your ``.pylintrc`` file:
+
+.. code-block:: ini
+
+    [MASTER]
+    load-plugins=conans.pylint_plugin
+

--- a/reference/build_helpers/run_environment.rst
+++ b/reference/build_helpers/run_environment.rst
@@ -1,5 +1,12 @@
 .. _run_environment_reference:
 
+
+.. warning::
+
+    The ``RunEnvironment`` is no longer needed, at least explicitly in conanfile.py. It has been integrated
+    in the ``self.run(..., run_environment=True)`` argument. Check :ref:`self.run() docs <running_commands>`.
+
+
 RunEnvironment
 ==============
 
@@ -52,6 +59,8 @@ It sets the following environment variables:
             with tools.environment_append(env_build.vars):
                 # self.run('./myexetool") # won't work, even if 'DYLD_LIBRARY_PATH' is in the env
                 self.run('DYLD_LIBRARY_PATH=%s ./myexetool" % os.environ['DYLD_LIBRARY_PATH'])
+
+    This is already automatically handled by the ``self.run(..., run_environment=True)`` argument.
 
 .. seealso::
 

--- a/reference/commands/consumer/config.rst
+++ b/reference/commands/consumer/config.rst
@@ -74,7 +74,7 @@ These are the special files and the rules applied to merge them:
 The file *remotes.txt* is the only file listed above which does not have a direct counterpart in
 the ``~/.conan`` folder. Its format is a list of entries, one on each line, with the form
 
-.. code-block::
+.. code-block:: text
 
     [remote name] [remote url] [bool]
     

--- a/reference/commands/misc/remote.rst
+++ b/reference/commands/misc/remote.rst
@@ -41,6 +41,16 @@ Manages the remote list and the package recipes associated to a remote.
       conan-center: https://conan.bintray.com [Verify SSL: True]
       local: http://localhost:9300 [Verify SSL: True]
 
+- List remotes in a format valid for *remotes.txt* (``conan config install``):
+
+  .. code-block:: bash
+
+      $ conan remote list --raw
+      conan-center https://conan.bintray.com True
+      local http://localhost:9300 True
+      # capture the current remotes in a text file
+      $ conan remote list --raw > remotes.txt
+
 - Add a new remote:
 
   .. code-block:: bash

--- a/reference/conanfile/other.rst
+++ b/reference/conanfile/other.rst
@@ -16,6 +16,7 @@ Use the `self.output` to print contents to the output.
 
 Check the source code. You might be able to produce different outputs with different colors.
 
+.. _running_commands:
 
 Running commands
 ----------------
@@ -23,7 +24,8 @@ Running commands
 
 .. code-block:: python
 
-    run(self, command, output=True, cwd=None, win_bash=False, subsystem=None, msys_mingw=True):
+    run(self, command, output=True, cwd=None, win_bash=False, subsystem=None, msys_mingw=True,
+        ignore_errors=False, run_environment=False):
 
 
 ``self.run()`` is a helper to run system commands and throw exceptions when errors occur,
@@ -46,3 +48,9 @@ Optional parameters:
 - **win_bash** (Optional, Defaulted to ``False``): When True, it will run the configure/make commands inside a bash.
 - **subsystem** (Optional, Defaulted to ``None`` will autodetect the subsystem). Used to escape the command according to the specified subsystem.
 - **msys_mingw** (Optional, Defaulted to ``True``) If the specified subsystem is MSYS2, will start it in MinGW mode (native windows development).
+- **ignore_errors** (Optional, Defaulted to ``False``). The method raises an exception if the command fails. If ``ignore_errors=True``, it
+  will not raise, and the user can use the return code instead to check for errors.
+- **run_environment** (Optional, Defaulted to ``False``). Applies a ``RunEnvironment``, so the environment variables PATH, LD_LIBRARY_PATH,
+  DYLIB_LIBRARY_PATH are defined in the command execution, adding the values of the "lib" and "bin" folders of the dependencies.
+  Allows executables to be run using shared libraries from its dependencies easily.
+

--- a/reference/generators/json.rst
+++ b/reference/generators/json.rst
@@ -3,7 +3,7 @@
 json
 ====
 
-A file named *conanbuildinfo.json* will be generated. It will contain the information about every dependency:
+A file named *conanbuildinfo.json* will be generated. It will contain the information about every dependency and the installed settings and options:
 
 .. code-block:: json
 
@@ -38,6 +38,15 @@ A file named *conanbuildinfo.json* will be generated. It will contain the inform
           "...": "..."
         }
       ],
+      "settings": {
+        "os": "Linux",
+        "arch": "armv7"
+      },
+      "options": {
+        "curl": {
+          "shared": true,
+        }
+      }
     }
 
 
@@ -70,3 +79,13 @@ deps_user_info
 --------------
 
 The user variables defined by upstream dependencies
+
+settings
+--------
+
+The settings used during `conan install`
+
+options
+-------
+
+The options of each dependency

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -207,7 +207,7 @@ tools.unzip()
 Function mainly used in ``source()``, but could be used in ``build()`` in special cases, as
 when retrieving pre-built binaries from the Internet.
 
-This function accepts ``.tar.gz``, ``.tar``, ``.tzb2``, ``.tar.bz2``, ``.tgz`` and ``.zip`` files, 
+This function accepts ``.tar.gz``, ``.tar``, ``.tzb2``, ``.tar.bz2``, ``.tgz``, ``.txz``, ``tar.xz``, and ``.zip`` files,
 and decompress them into the given destination folder (the current one by default).
 
 .. code-block:: python


### PR DESCRIPTION
`code-block` directive without a language specification doesn't seem to work properly in sphinx. [The official documentation](https://docs.conan.io/en/latest/reference/commands/consumer/config.html) is missing that line completely. I couldn't find a version in the repo that has that error, so I assume it's not generated correctly.