### PR TITLE
Line from config.rst missing in official docs. (second try)

### DIFF
--- a/reference/commands/consumer/config.rst
+++ b/reference/commands/consumer/config.rst
@@ -74,7 +74,7 @@ These are the special files and the rules applied to merge them:
 The file *remotes.txt* is the only file listed above which does not have a direct counterpart in
 the ``~/.conan`` folder. Its format is a list of entries, one on each line, with the form
 
-.. code-block::
+.. code-block:: text
 
     [remote name] [remote url] [bool]
     


### PR DESCRIPTION
`code-block` directive without a language specification doesn't seem to work properly in sphinx. [The official documentation](https://docs.conan.io/en/latest/reference/commands/consumer/config.html) is missing that line completely. I couldn't find a version in the repo that has that error, so I assume it's not generated correctly.