### PR TITLE
Fix docs for running conan_server in a subdirectory

### DIFF
--- a/uploading_packages/running_your_server.rst
+++ b/uploading_packages/running_your_server.rst
@@ -207,7 +207,7 @@ Running conan server with SSL using nginx
 
     .. code-block:: text
 
-        $ conan remote add myremote https://myservername.mydomain.com/subdir
+        $ conan remote add myremote https://myservername.mydomain.com
 
 Running conan server with SSL using nginx in a subdirectory
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -231,8 +231,8 @@ Running conan server with SSL using nginx in a subdirectory
                ssl_certificate_key /usr/local/etc/nginx/ssl/server.key;
                server_name myservername.mydomain.com;
 
-               location ~/subdir/(.*)$ {
-                  proxy_pass http://0.0.0.0:9300/$1;
+               location /subdir/ {
+                  proxy_pass http://0.0.0.0:9300/;
                }
           }
 
@@ -240,7 +240,7 @@ Running conan server with SSL using nginx in a subdirectory
 
     .. code-block:: text
 
-        $ conan remote add myremote https://myservername.mydomain.com/subdir
+        $ conan remote add myremote https://myservername.mydomain.com/subdir/
 
 Running conan server using Apache
 +++++++++++++++++++++++++++++++++


### PR DESCRIPTION
The previous suggested configuration works OK for search, but for me it fails on
upload.

Without a trailing slash in the remote, the urljoin implementation drops the
subdirectory from the URL created for http PUTs.

The suggested nginx configuration did not work for upload either. It fails to
preserve the query string, meaning the jwt token is lost. I'm no nginx expert, but the technique here worked for me to preserve all relevant information.