### PR TITLE
Windows 10 & 2016 Server MAX_PATH limit can be bypassed even with python 2.7

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -567,17 +567,17 @@ something like `C:/.conan/tmpdir`. All the folder layout in the conan cache is m
 
 This attribute will not have any effect in other OS, it will be discarded.
 
-From Windows 10 (ver. 10.0.14393), it is possible to opt-in disabling the path limits. Check `this link
-<https://docs.microsoft.com/es-es/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation>`_ for more info.
+From Windows 10 (ver. 10.0.14393), it is possible to `opt-in disabling the path limits
+<https://docs.microsoft.com/es-es/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation>`_.
 Latest python installers might offer to enable this while installing python. With this limit removed, the ``short_paths`` functionality is
-totally unnecessary. Please note that this only works with Python 3.6 and newer.
+totally unnecessary.
 
 .. _no_copy_source:
 
 no_copy_source
 --------------
 
-The attribute ``no_copy_source`` tells the recipe that the source code will not be copied from the ``source`` folder to the ``build`` folder. 
+The attribute ``no_copy_source`` tells the recipe that the source code will not be copied from the ``source`` folder to the ``build`` folder.
 This is mostly an optimization for packages with large source codebases, to avoid extra copies. It is **mandatory** that the source code must not be modified at all by the configure or build scripts, as the source code will be shared among all builds.
 
 To be able to use it, the package recipe can access the ``self.source_folder`` attribute, which will point to the ``build`` folder when ``no_copy_source=False`` or not defined, and will point to the ``source`` folder when ``no_copy_source=True``

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -443,10 +443,6 @@ marked as `short_paths` will be stored in the `C:\\.conan` (or the current drive
 
 If set to "None", it will disable the `short_paths` feature in Windows for modern Windows that enable long paths at the system level.
 
-.. note::
-
-    Please note that this only works with Python 3.6 and newer.
-
 CONAN_VERBOSE_TRACEBACK
 -----------------------
 


### PR DESCRIPTION
MAX_PATH fixes for #780.