### PR TITLE
[fix] CMake definitions must be assigned before calling cmake.configure()

### DIFF
--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -323,12 +323,12 @@ The following example of ``conanfile.py`` shows you how to manage a project with
 
     def configure_cmake(self):
         cmake = CMake(self)
-        cmake.configure()
 
         # put definitions here so that they are re-used in cmake between
         # build() and package()
         cmake.definitions["SOME_DEFINITION_NAME"] = "On"
 
+        cmake.configure()
         return cmake
 
     def build(self):


### PR DESCRIPTION
In order to be taken into account, `cmake.definitions` must be set before calling `cmake.configure()`.

