### PR TITLE
Fix search: pin sphinx version to 1.7.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx==1.7.9
 sphinxcontrib-spelling


### PR DESCRIPTION
closes #826 
Looks this is an already reported issue in sphinx-doc/sphinx#5460

Pinning sphinx version to 1.7.9 seems to solve the issue. This also explains why it worked locally first aand then it didn't: I run pip install again

Also sphinx 1.8.0 was released ton September 12th (https://pypi.org/project/Sphinx/#history), just few days before the issue was reported.