### PR TITLE
Exclude .rst files from virtualenv relative folder

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -96,7 +96,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', '*/Lib/site-packages']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
When using virtual environments inside the same folder of the docs, pip installed pacakges are placed under *env/Lib/site-packages/...*. At the time of build ding the docs, sphinx searchs for *.rst* files and finds DESCRIPTION.rst files from the python packages.

```
checking consistency... C:\Users\danimtb\conan_docs\conan_docs\Lib\site-packages\Jinja2-2.10.dist-info\DESCRIPTION.rst: WARNING: document isn't included in any toctree
C:\Users\danimtb\conan_docs\conan_docs\Lib\site-packages\Pygments-2.2.0.dist-info\DESCRIPTION.rst: WARNING: document isn't included in any toctree
C:\Users\danimtb\conan_docs\conan_docs\Lib\site-packages\alabaster-0.7.11.dist-info\DESCRIPTION.rst: WARNING: document isn't included in any toctree
```

This PRs inclues an `explude_pattern` avoiding files under *.../Lib/site-packages/...*. It works for Windows but not sure if it is the same path in other platforms