### PR TITLE
Fix typo and structure in default profile section

### DIFF
--- a/reference/config_files/default_profile.rst
+++ b/reference/config_files/default_profile.rst
@@ -5,7 +5,6 @@ profiles/default
 
 This is the typical *~/.conan/profiles/default* file:
 
-
 .. code-block:: text
 
     [build_requires]
@@ -22,9 +21,9 @@ This is the typical *~/.conan/profiles/default* file:
 The settings defaults are the setting values used whenever you issue a :command:`conan install` command over a *conanfile* in one of your
 projects. The initial values for these default settings are auto-detected the first time you run a :command:`conan` command.
 
-You can override the default settings using the :command:`-s` parameter in :command:`conan install` and :command:`conan info` commands but when you
-specify a profile, :command:`conan install --profile gcc48`, the default profile won't be applied, unless you specify it with an ``include()``
-statement:
+You can override the default settings using the :command:`-s` parameter in :command:`conan install` and :command:`conan info` commands but
+when you specify a profile, :command:`conan install --profile gcc48`, the default profile won't be applied, unless you specify it with an
+``include()`` statement:
 
 .. code-block:: text
    :caption: my_clang_profile
@@ -43,7 +42,9 @@ statement:
 
 .. tip::
 
-   Default profile can be overriden using the environment variable ``CONAN_DEFAULT_PROFILE_PATH``.
+    Default profile can be overridden using the environment variable ``CONAN_DEFAULT_PROFILE_PATH``.
 
 
-.. seealso:: Check the section :ref:`Mastering conan/Profiles <profiles>` to read more about this feature.
+.. seealso::
+
+    Check the section :ref:`profiles` to read more about this feature.


### PR DESCRIPTION
There was a linting warning in the spell check for "*overrid**d**en*"