### PR TITLE
Raise error with malformed table warning (with test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/conf.py
+++ b/conf.py
@@ -411,6 +411,8 @@ def copy_legacy_redirects(app, docname): # Sphinx expects two arguments
         for html_src_path, dst_path in redirect_files.items():
             target_path = app.outdir + '/' + html_src_path
             html = redirect_template % dst_path
+            if not os.path.exists(os.path.dirname(target_path)):
+                os.makedirs(os.path.dirname(target_path))
             with open(target_path, "w") as f:
                 f.write(html)
 

--- a/deploy_gh_pages.py
+++ b/deploy_gh_pages.py
@@ -110,6 +110,6 @@ if __name__ == "__main__":
 
         deploy()
     else:
-        call("make spelling")
         call("make html")
+        call("make spelling")
         call("make linkcheck")

--- a/make.bat
+++ b/make.bat
@@ -73,7 +73,7 @@ if errorlevel 9009 (
 
 
 if "%1" == "html" (
-	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	%SPHINXBUILD% -W -b html %ALLSPHINXOPTS% %BUILDDIR%/html
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished. The HTML pages are in %BUILDDIR%/html.

--- a/make_mac.sh
+++ b/make_mac.sh
@@ -1,3 +1,3 @@
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
-make html
+make -W html

--- a/reference/build_helpers/autotools.rst
+++ b/reference/build_helpers/autotools.rst
@@ -310,7 +310,7 @@ The following environment variables will also affect the `AutoToolsBuildEnvironm
 +--------------------+-------------------------------------------------------------------------------------+
 | CFLAGS             | Options for the C compiler (-g, -s, -m64, -m32, -fPIC)                              |
 +--------------------+-------------------------------------------------------------------------------------+
-| CXXFLAGS           | Options for the C++ compiler (-g, -s, -stdlib, -m64, -m32, -fPIC, -std)             |
+| CXXFLAGS           | Options for the C++ compiler (-g, -s, -stdlib, -m64, -m32, -fPIC, -std)          |
 +--------------------+-------------------------------------------------------------------------------------+
 | CPPFLAGS           | Preprocessor definitions (-D, -I)                                                   |
 +--------------------+-------------------------------------------------------------------------------------+

--- a/reference/build_helpers/autotools.rst
+++ b/reference/build_helpers/autotools.rst
@@ -310,7 +310,7 @@ The following environment variables will also affect the `AutoToolsBuildEnvironm
 +--------------------+-------------------------------------------------------------------------------------+
 | CFLAGS             | Options for the C compiler (-g, -s, -m64, -m32, -fPIC)                              |
 +--------------------+-------------------------------------------------------------------------------------+
-| CXXFLAGS           | Options for the C++ compiler (-g, -s, -stdlib, -m64, -m32, -fPIC, -std)          |
+| CXXFLAGS           | Options for the C++ compiler (-g, -s, -stdlib, -m64, -m32, -fPIC, -std)             |
 +--------------------+-------------------------------------------------------------------------------------+
 | CPPFLAGS           | Preprocessor definitions (-D, -I)                                                   |
 +--------------------+-------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR enables warnings as errors only for `make html` command

```
(conan_docs) λ make html
Running Sphinx v1.7.9
Initializing Spelling Checker
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] reference/build_helpers/autotools

Warning, treated as error:
C:\Users\danimtb\conan_docs\reference\build_helpers\autotools.rst:304:Malformed table.

+--------------------+-------------------------------------------------------------------------------------+
| NAME               | DESCRIPTION                                                                         |
+====================+=====================================================================================+
| LIBS               | Library names to link                                                               |
+--------------------+-------------------------------------------------------------------------------------+
| LDFLAGS            | Link flags, (-L, -m64, -m32)                                                        |
+--------------------+-------------------------------------------------------------------------------------+
| CFLAGS             | Options for the C compiler (-g, -s, -m64, -m32, -fPIC)                              |
+--------------------+-------------------------------------------------------------------------------------+
| CXXFLAGS           | Options for the C++ compiler (-g, -s, -stdlib, -m64, -m32, -fPIC, -std)          |
+--------------------+-------------------------------------------------------------------------------------+
| CPPFLAGS           | Preprocessor definitions (-D, -I)                                                   |
+--------------------+-------------------------------------------------------------------------------------+
```