### PR TITLE
Add leading spaces to these two lines to get rid of the leading space…

### DIFF
--- a/creating_packages/getting_started.rst
+++ b/creating_packages/getting_started.rst
@@ -68,8 +68,8 @@ Let's have a look at the root package recipe *conanfile.py*:
             # properly
             tools.replace_in_file("hello/CMakeLists.txt", "PROJECT(MyHello)",
                                   '''PROJECT(MyHello)
- include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
- conan_basic_setup()''')
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()''')
 
         def build(self):
             cmake = CMake(self)


### PR DESCRIPTION
…s in the rest of the code snippet

My last change messed up the leading spaces in this code snippet.  Looks like the code block needs to be aligned like this:

.. code-block:: python

    from conans import ConanFile, CMake, tools

    class HelloConan(ConanFile):
        name = "Hello"
        version = "0.1"

Anything that's more to the left than 'from' above will push everything to the right.  This fixes that.  I generated the html to verify it's fixed and also copied the snippet into a conanfile.py and ran conan create against it to make sure it still works.