### PR TITLE
Explicitly mention that remote name is uppercased

### DIFF
--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -242,9 +242,10 @@ Conan will request to the user to input a password.
 
 These variables are useful for unattended executions like CI servers or automated tasks.
 
-If the remote name contains "-" you have to replace it with "_" in the variable name:
+The remote name is transformed to all uppercase. If the remote name contains "-",
+you have to replace it with "_" in the variable name.
 
-For example: For a remote named "conan-center":
+For example, for a remote named "conan-center":
 
 .. code-block:: bash
 


### PR DESCRIPTION
Responsible code: https://github.com/conan-io/conan/blob/d9a75eff01098338d4d242d8591a704e75bf3a9c/conans/client/userio.py#L105