### PR TITLE
Fixing a target name typo at the cmake_find_package generator reference

### DIFF
--- a/reference/generators/cmake_find_package.rst
+++ b/reference/generators/cmake_find_package.rst
@@ -41,7 +41,7 @@ Being {name} the package name:
 Target in Find<package_name>.cmake
 ----------------------------------
 
-A target named ``{name}:{name}`` target is generated with the following properties adjusted:
+A target named ``{name}::{name}`` target is generated with the following properties adjusted:
 
 - ``INTERFACE_INCLUDE_DIRECTORIES``: Containing all the include directories of the package.
 - ``INTERFACE_LINK_LIBRARIES``: Library paths to link.


### PR DESCRIPTION
Added a missing colon to the name of the target.