### PR TITLE
Clarifies builddirs and build_paths in package info

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -744,9 +744,9 @@ When executing local conan commands (for a package not in the local cache, but i
 cpp_info
 --------
 
-.. note::
+.. important::
 
-    This attribute is only defined inside ``package_info()`` method.
+    This attribute is only defined inside ``package_info()`` method being `None` elsewhere.
 
 The ``self.cpp_info`` is responsible for storing all the information needed by consumers of a package: include directories, library names,
 library paths... There are some default values that will be applied automatically if not indicated otherwise.

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -744,38 +744,46 @@ When executing local conan commands (for a package not in the local cache, but i
 cpp_info
 --------
 
-This attribute is only defined inside ``package_info()`` method, being None elsewhere, so please use it only inside this method.
+.. note::
 
-The ``self.cpp_info`` object can be filled with the needed information for the consumers of the current
-package:
+    This attribute is only defined inside ``package_info()`` method.
 
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| NAME                                      | DESCRIPTION                                                                                                                 |
-+===========================================+=============================================================================================================================+
-| self.cpp_info.includedirs                 | Ordered list with include paths, by default ['include']                                                                     |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.libdirs                     | Ordered list with lib paths, by default ['lib']                                                                             |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.resdirs                     | Ordered list of resource (data) paths, by default ['res']                                                                   |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.bindirs                     | Ordered list with include paths, by default ['bin']                                                                         |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.builddirs                   | Ordered list with build scripts paths, by default ['']. CMake will search in these dirs for cmake files, like findXXX.cmake |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.libs                        | Ordered list with the library names, by default empty []                                                                    |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.defines                     | Preprocessor definitions, by default empty []                                                                               |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cflags                      | Ordered list with pure C flags, by default empty []                                                                         |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cppflags                    | Ordered list with C++ flags, by default empty []                                                                            |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.sharedlinkflags             | Ordered list with linker flags (shared libs), by default empty []                                                           |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.exelinkflags                | Ordered list with linker flags (executables), by default empty []                                                           |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| self.cpp_info.rootpath                    | Filled with the root directory of the package, see deps_cpp_info                                                            |
-+-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+The ``self.cpp_info`` is responsible for storing all the information needed by consumers of a package: include directories, library names,
+library paths... There are some default values that will be applied automatically if not indicated otherwise.
+
+This object should be filled in ``package_info()`` method.
+
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| NAME                           | DESCRIPTION                                                                                             |
++================================+=========================================================================================================+
+| self.cpp_info.includedirs      | Ordered list with include paths, by default ['include']                                                 |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.libdirs          | Ordered list with lib paths, by default ['lib']                                                         |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.resdirs          | Ordered list of resource (data) paths, by default ['res']                                               |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.bindirs          | Ordered list with include paths, by default ['bin']                                                     |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.builddirs        | | Ordered list with build scripts directory paths, by default [''] (Package folder directory)           |
+|                                | | CMake generators will search in these dirs for files like *findXXX.cmake*                             |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.libs             | Ordered list with the library names, by default empty []                                                |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.defines          | Preprocessor definitions, by default empty []                                                           |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cflags           | Ordered list with pure C flags, by default empty []                                                     |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cppflags         | Ordered list with C++ flags, by default empty []                                                        |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.sharedlinkflags  | Ordered list with linker flags (shared libs), by default empty []                                       |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.exelinkflags     | Ordered list with linker flags (executables), by default empty []                                       |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.rootpath         | Filled with the root directory of the package, see ``deps_cpp_info``                                    |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+
+The paths of the directories in the directory variables indicated above are relative to the
+:ref:`self.package_folder<folders_attributes_reference>` directory.
 
 .. seealso::
 


### PR DESCRIPTION
Some additional information and rephrasing.

closes conan-io/conan#3956