### PR TITLE
deprecating old python reuse

### DIFF
--- a/devtools/build_requires.rst
+++ b/devtools/build_requires.rst
@@ -158,6 +158,11 @@ Then the install command will retrieve the ``mytest_framework``, build and run t
 Common python code
 ------------------
 
+.. warning::
+
+    This way of reusing python code has been superseded by ``python_requires``.
+    Please check :ref:`python_requires`
+
 The same technique can be even used to inject and reuse python code in the package recipes, without having to declare dependencies to such
 python packages.
 


### PR DESCRIPTION
At least comment it in the docs.

Is it something that we want to deprecate? I think so.
Maybe even remove in Conan 2.0 the automatic injection of PYTHONPATH from the dependencies, for all methods?