### PR TITLE
#968 Move how to extract license

### DIFF
--- a/howtos.rst
+++ b/howtos.rst
@@ -21,6 +21,7 @@ This section shows common solutions and different approaches to typical problems
    howtos/collaborate_packages
    howtos/link_apple_framework
    howtos/collect_licenses
+   howtos/extract_licenses_from_headers
    howtos/capture_version
    howtos/other_languages_package_manager
    howtos/use_tls_certificates

--- a/howtos/extract_licenses_from_headers.rst
+++ b/howtos/extract_licenses_from_headers.rst
@@ -1,0 +1,17 @@
+.. _extract_licenses_from_headers:
+
+How to extract licenses from headers
+====================================
+
+Sometimes there is no ``license`` file, and you will need to extract the license from a header file, as in the following example:
+
+  .. code-block:: python
+
+    def package():
+        # Extract the License/s from the header to a file
+        tmp = tools.load("header.h")
+        license_contents = tmp[2:tmp.find("*/", 1)] # The license begins with a C comment /* and ends with */
+        tools.save("LICENSE", license_contents)
+
+        # Package it
+        self.copy("license*", dst="licenses",  ignore_case=True, keep_path=False)

--- a/uploading_packages/bintray/conan_center_guide.rst
+++ b/uploading_packages/bintray/conan_center_guide.rst
@@ -95,18 +95,7 @@ Recipe Quality
     def package():
         self.copy("license*", dst="licenses",  ignore_case=True, keep_path=False)
 
-  Sometimes there is no ``license`` file, and you will need to extract the license from a header file, as in the following example:
-
-  .. code-block:: python
-
-    def package():
-        # Extract the License/s from the header to a file
-        tmp = tools.load("header.h")
-        license_contents = tmp[2:tmp.find("*/", 1)] # The license begins with a C comment /* and ends with */
-        tools.save("LICENSE", license_contents)
-
-        # Package it
-        self.copy("license*", dst="licenses",  ignore_case=True, keep_path=False)
+  Sometimes there is no ``license`` file, for that, read :ref:`Howtos/Extract licenses from headers<extract_licenses_from_headers>`.
 
 - **Invalid configurations:** There is a special exception, ``conans.errors.ConanInvalidConfiguration`` to be launched
   from ``configure()`` function in a recipe if the given configuration/options is known not to work. This way the recipe


### PR DESCRIPTION
Hi!

This PR is related to #968 

I moved the section the explain how to extract a license from a header file to "Howtos" tree.

closes #968 