### PR TITLE
Docs related to the evaluation of SCM attributes

### DIFF
--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -119,7 +119,7 @@ remote and commit of the local repository:
         ...
 
 
-You can commit and push the ``conanfile.py`` to your origin repository, which will always preserve the "auto"
+You can commit and push the ``conanfile.py`` to your origin repository, which will always preserve the ``auto``
 values. But when the file is exported to the conan local cache, the copied recipe in the local cache
 will point to the captured remote and commit:
 
@@ -139,10 +139,35 @@ will point to the captured remote and commit:
 
 
 So when you :ref:`upload the recipe <uploading_packages>` to a conan remote, the recipe will contain
-the "absolute" URL and commit.
+the "resolved" URL and commit.
 
 When you are requiring your ``HelloConan``, the ``conan install`` will retrieve the recipe from the
 remote. If you are building the package, the source code will be fetched from the captured url/commit.
+
+As SCM attributes are evaluated in the workspace context (see :ref:`scm attribute <scm_attribute>`),
+you can write more complex functions to retrieve the proper values, this source *conanfile.py* will
+be valid too:
+
+.. code-block:: python
+   :emphasize-lines: 7, 8
+
+    import os
+    from conans import ConanFile, CMake, tools
+
+    def get_remote_url():
+         """ Get remote url regardless of the cloned directory """
+         here = os.path.dirname(__file__)
+         svn = tools.SVN(here)
+         return svn.get_remote_url()
+
+    class HelloConan(ConanFile):
+         scm = {
+            "type": "git",
+            "subfolder": "hello",
+            "url": get_remote_url(),
+            "revision": "auto"
+         }
+        ...
 
 
 .. tip::

--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -162,7 +162,7 @@ be valid too:
 
     class HelloConan(ConanFile):
          scm = {
-            "type": "git",
+            "type": "svn",
             "subfolder": "hello",
             "url": get_remote_url(),
             "revision": "auto"

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -1036,7 +1036,7 @@ Used to clone/checkout a repository. It is a dictionary with the following possi
    - ``shallow``: Will sync the git submodules using ``submodule sync``
    - ``recursive``: Will sync the git submodules using ``submodule sync --recursive``
 
-SCM attributes are evaluated in the workspace context where the _conanfile.py_ is located before
+SCM attributes are evaluated in the workspace context where the *conanfile.py* is located before
 exporting it to the Conan cache, so these values can be returned from arbitrary functions that
 depend on the workspace layout. Nevertheless, all the other code in the recipe must be able to
 run in the export folder inside the cache, where it has access only to the files exported (see

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -540,6 +540,8 @@ They can be specified as a comma separated tuple in the package recipe:
 
 Read more: :ref:`Build requiremens <build_requires>`
 
+.. _exports_attribute:
+
 exports
 -------
 
@@ -1033,6 +1035,13 @@ Used to clone/checkout a repository. It is a dictionary with the following possi
 - **submodule** (Optional, Defaulted to ``None``):
    - ``shallow``: Will sync the git submodules using ``submodule sync``
    - ``recursive``: Will sync the git submodules using ``submodule sync --recursive``
+
+SCM attributes are evaluated in the workspace context where the _conanfile.py_ is located before
+exporting it to the Conan cache, so these values can be returned from arbitrary functions that
+depend on the workspace layout. Nevertheless, all the other code in the recipe must be able to
+run in the export folder inside the cache, where it has access only to the files exported (see
+attribute :ref:`exports <exports_attribute>`) and to any other functionality
+from a :ref:`python_requires <python_requires>`.
 
 To know more about the usage of ``scm`` check:
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1382,7 +1382,7 @@ Methods:
 .. warning::
 
     SVN allows to checkout a subdirectory of the remote repository, take into account that the
-    return value of some of these function may depend on the root of the working copy that has been
+    return value of some of these functions may depend on the root of the working copy that has been
     checked out.
 
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1379,6 +1379,12 @@ Methods:
 - **get_repo_root()**:
     Returns the root folder of the working copy.
 
+.. warning::
+
+    SVN allows to checkout a subdirectory of the remote repository, take into account that the
+    return value of some of these function may depend on the root of the working copy that has been
+    checked out.
+
 
 .. _tools_apple:
 


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/pull/4088

As SCM are evaluated in the user workspace where the ``conanfile.py`` is located before exporting it to the cache, it accepts arbitrary complex functions to compute the value of its attributes (it is needed to ensure consistency of some SVN workflows).