### PR TITLE
Refactor/review of the Tools section

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -622,7 +622,7 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 - Feature: ``CMake`` new ``patch_config_paths()`` methods that will replace absolute paths to conan package path variables, so cmake find scripts are relocatable.
 - Feature: new :command:`--test-build-folder` command line argument to define the location of the *test_package* build folder, and new conan.conf ``temp_test_folder`` and environment variable ``CONAN_TEMP_TEST_FOLDER``, that if set to True will automatically clean the test_package build folder after running.
 - Feature: Conan manages relative urls for upload/download to allow access the server from different configured networks or in domain subdirectories.
-- Feature: Added ``CONAN_SKIP_VS_PROJECTS_UPGRADE`` environment variable to skip the upgrade of Visual Studio project when using :ref:`tools_build_sln_command`, the :ref:`msvc_build_command<msvc_build_command>` and the :ref:`MSBuild()<msbuild>` build helper.
+- Feature: Added ``CONAN_SKIP_VS_PROJECTS_UPGRADE`` environment variable to skip the upgrade of Visual Studio project when using :ref:`tools_build_sln_command`, the :ref:`msvc_build_command<tools_msvc_build_command>` and the :ref:`MSBuild()<msbuild>` build helper.
 - Feature: Improved detection of Visual Studio installations, possible to prioritize between multiple installed Visual tools with the ``CONAN_VS_INSTALLATION_PREFERENCE`` env-var and ``vs_installation_preference`` conan.conf variable.
 - Feature: Added ``keep_path`` parameter to ``self.copy()`` within the ``imports()`` method.
 - Feature: Added ``[build_requires]`` section to *conanfile.txt*.

--- a/changelog.rst
+++ b/changelog.rst
@@ -622,7 +622,7 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 - Feature: ``CMake`` new ``patch_config_paths()`` methods that will replace absolute paths to conan package path variables, so cmake find scripts are relocatable.
 - Feature: new :command:`--test-build-folder` command line argument to define the location of the *test_package* build folder, and new conan.conf ``temp_test_folder`` and environment variable ``CONAN_TEMP_TEST_FOLDER``, that if set to True will automatically clean the test_package build folder after running.
 - Feature: Conan manages relative urls for upload/download to allow access the server from different configured networks or in domain subdirectories.
-- Feature: Added ``CONAN_SKIP_VS_PROJECTS_UPGRADE`` environment variable to skip the upgrade of Visual Studio project when using :ref:`build_sln_command<build_sln_command>`, the :ref:`msvc_build_command<msvc_build_command>` and the :ref:`MSBuild()<msbuild>` build helper.
+- Feature: Added ``CONAN_SKIP_VS_PROJECTS_UPGRADE`` environment variable to skip the upgrade of Visual Studio project when using :ref:`tools_build_sln_command`, the :ref:`msvc_build_command<msvc_build_command>` and the :ref:`MSBuild()<msbuild>` build helper.
 - Feature: Improved detection of Visual Studio installations, possible to prioritize between multiple installed Visual tools with the ``CONAN_VS_INSTALLATION_PREFERENCE`` env-var and ``vs_installation_preference`` conan.conf variable.
 - Feature: Added ``keep_path`` parameter to ``self.copy()`` within the ``imports()`` method.
 - Feature: Added ``[build_requires]`` section to *conanfile.txt*.

--- a/howtos/header_only.rst
+++ b/howtos/header_only.rst
@@ -81,8 +81,8 @@ If you want to run the library unit test while packaging, you would need this re
 
     If you are :ref:`cross building <cross_building>` your **library** or **app** you'll probably need
     to skip the **unit tests** because your target binary cannot be executed in current building host.
-    To do it you can use :ref:`tools.get_env() <tools_get_env>` in combination with
-    :ref:`CONAN_RUN_TESTS <conan_run_tests>` env variable, defined as **False**
+    To do it you can use :ref:`tools_get_env` in combination with
+    :ref:`env_vars_conan_run_tests` environment variable, defined as **False**
     in profile for cross building and replace ``cmake.test()`` with:
 
     .. code-block:: python

--- a/integrations/pkg_config_pc_files.rst
+++ b/integrations/pkg_config_pc_files.rst
@@ -210,5 +210,5 @@ So it can be a good solution in case you are building **library A** with a build
 
 .. seealso::
 
-    Check the :ref:`pkgconfigtool`, a wrapper of the :command:`pkg-config` tool that allows to extract flags,
-    library paths, etc. for any *.pc* file.
+    Check the :ref:`tools_pkgconfig`, a wrapper of the :command:`pkg-config` tool that allows to extract flags, library paths, etc. for any
+    *.pc* file.

--- a/integrations/visual_studio.rst
+++ b/integrations/visual_studio.rst
@@ -74,7 +74,7 @@ Calling Visual Studio compiler
 ------------------------------
 
 You can call your Visual Studio compiler from your ``build()`` method using the ``VisualStudioBuildEnvironment`` and the
-``tools.vcvars_command``.
+:ref:`tools_vcvars_command`.
 
 Check the :ref:`msbuild` section for more info.
 

--- a/integrations/xcode.rst
+++ b/integrations/xcode.rst
@@ -61,14 +61,17 @@ Click on the project again. In the **info/configurations** section, choose **con
 
 Build your project as usual.
 
+.. seealso::
+
+    Check the :ref:`Reference/Generators/xcode <xcode_generator>` for the complete reference.
+
+.. seealso::
+
+    Check the :ref:`Tools section about Apple tools<tools_is_apple_os>` to ease the integration with the Apple development tools in your
+    recipes using the toolchain as a :ref:`build require<build_requires>`.
 
 
-.. seealso:: Check the :ref:`Reference/Generators/xcode <xcode_generator>` for the complete reference.
+.. seealso::
 
-
-.. seealso:: Check the :ref:`Tools section about Apple tools<tools_apple>` to ease the integration with the Apple development tools
-             in your recipes using the toolchain as a :ref:`build require<build_requires>`.
-
-
-.. seealso:: Check the :ref:`Darwin Toolchain package<darwin_toolchain>` section to know how to **cross build** for ``iOS``, ``watchOS`` and ``tvOS``.
-
+    Check the :ref:`Darwin Toolchain package<darwin_toolchain>` section to know how to **cross build** for ``iOS``, ``watchOS`` and
+    ``tvOS``.

--- a/mastering/logging.rst
+++ b/mastering/logging.rst
@@ -6,7 +6,7 @@ Logging
 How to log and debug a conan execution
 ------------------------------------------
 
-You can use the :ref:`conan_trace_file` environment variable to log and debug several conan command execution.
+You can use the :ref:`env_vars_conan_trace_file` environment variable to log and debug several conan command execution.
 Set the ``CONAN_TRACE_FILE`` environment variable pointing to a log file.
 
 Example:
@@ -71,9 +71,9 @@ The */tmp/conan_trace.log* file only three lines will be appended:
 How to log the build process
 ------------------------------------------
 
-You can log your command executions ``self.run`` in a file named *conan_run.log* using the environment variable :ref:`conan_log_run_to_file`.
+You can log your command executions ``self.run`` in a file named *conan_run.log* using the environment variable :ref:`env_vars_conan_log_run_to_file`.
 
-You can also use the variable :ref:`conan_print_run_commands` to log extra information about the commands being executed.
+You can also use the variable :ref:`env_vars_conan_print_run_commands` to log extra information about the commands being executed.
 
 
 Package the log files

--- a/mastering/virtualenv.rst
+++ b/mastering/virtualenv.rst
@@ -123,4 +123,4 @@ using the virtualrunenv generator, the ``bin`` folder of the package will be ava
 we will be executing the cmake of the package.
 
 
-.. seealso:: - :ref:`Reference/Tools/environment_append <environment_append_tool>`
+.. seealso:: - :ref:`Reference/Tools/environment_append <tools_environment_append>`

--- a/reference/build_helpers/autotools.rst
+++ b/reference/build_helpers/autotools.rst
@@ -275,7 +275,7 @@ Parameters:
     - **args** (Optional, Defaulted to ``""``): A list of additional arguments to be passed to the ``make`` command. Each argument will be
       escaped accordingly to the current shell. No extra arguments will be added if ``args=""``.
     - **make_program** (Optional, Defaulted to ``None``): Allows to specify a different ``make`` executable, e.g., ``mingw32-make``. The
-      environment variable :ref:`CONAN_MAKE_PROGRAM<conan_make_program>` can be used too.
+      environment variable :ref:`env_vars_conan_make_program` can be used too.
     - **target** (Optional, Defaulted to ``None``): Choose which target to build. This allows building of e.g., docs, shared libraries or
       install for some AutoTools projects.
     - **vars** (Optional, Defaulted to ``None``): Overrides custom environment variables in the make step.
@@ -293,7 +293,7 @@ Parameters:
     - **args** (Optional, Defaulted to ``""``): A list of additional arguments to be passed to the ``make`` command. Each argument will be
       escaped accordingly to the current shell. No extra arguments will be added if ``args=""``.
     - **make_program** (Optional, Defaulted to ``None``): Allows to specify a different ``make`` executable, e.g., ``mingw32-make``. The
-      environment variable :ref:`CONAN_MAKE_PROGRAM<conan_make_program>` can be used too.
+      environment variable :ref:`env_vars_conan_make_program` can be used too.
     - **vars** (Optional, Defaulted to ``None``): Overrides custom environment variables in the install step.
 
 Environment variables

--- a/reference/build_helpers/autotools.rst
+++ b/reference/build_helpers/autotools.rst
@@ -25,7 +25,7 @@ This helper sets ``LIBS``, ``LDFLAGS``, ``CFLAGS``, ``CXXFLAGS`` and ``CPPFLAGS`
          autotools.configure()
          autotools.make()
 
-It also works using the :ref:`environment_append <environment_append_tool>` context manager applied to your **configure and make** commands,
+It also works using the :ref:`environment_append <tools_environment_append>` context manager applied to your **configure and make** commands,
 calling `configure` and `make` manually:
 
 .. code-block:: python
@@ -317,4 +317,4 @@ The following environment variables will also affect the `AutoToolsBuildEnvironm
 
 .. seealso::
 
-    - :ref:`Reference/Tools/environment_append <environment_append_tool>`
+    - :ref:`Reference/Tools/environment_append <tools_environment_append>`

--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -56,7 +56,7 @@ Parameters:
     - **conanfile** (Required): Conanfile object. Usually ``self`` in a *conanfile.py*
     - **generator** (Optional, Defaulted to ``None``): Specify a custom generator instead of autodetect it. e.g., "MinGW Makefiles"
     - **cmake_system_name** (Optional, Defaulted to ``True``): Specify a custom value for ``CMAKE_SYSTEM_NAME`` instead of autodetect it.
-    - **parallel** (Optional, Defaulted to ``True``): If ``True``, will append the `-jN` attribute for parallel building being N the :ref:`cpu_count()<cpu_count>`.
+    - **parallel** (Optional, Defaulted to ``True``): If ``True``, will append the `-jN` attribute for parallel building being N the :ref:`cpu_count()<tools_cpu_count>`.
     - **build_type** (Optional, Defaulted to ``None``): Force the build type instead of taking the value from the settings. Note this will
       also make the ``CMAKE_BUILD_TYPE`` to be declared for multi configuration generators.
     - **toolset** (Optional, Defaulted to ``None``): Specify a toolset for Visual Studio.

--- a/reference/build_helpers/run_environment.rst
+++ b/reference/build_helpers/run_environment.rst
@@ -63,4 +63,4 @@ It sets the following environment variables:
 .. seealso::
 
     - :ref:`manage_shared_libraries_env_vars`
-    - :ref:`environment_append_tool`
+    - :ref:`tools_environment_append`

--- a/reference/build_helpers/visual_studio.rst
+++ b/reference/build_helpers/visual_studio.rst
@@ -92,7 +92,7 @@ Parameters:
     - **force_vcvars** (Optional, Defaulted to ``False``): Will ignore if the environment is already set for a different Visual Studio
       version.
     - **parallel** (Optional, Defaulted to ``True``): Will use the configured number of cores in the :ref:`conan_conf` file or
-      :ref:`cpu_count`:
+      :ref:`tools_cpu_count`:
 
         - **In the solution**: Building the solution with the projects in parallel. (``/m:`` parameter).
         - **CL compiler**: Building the sources in parallel. (``/MP:`` compiler flag)
@@ -272,7 +272,7 @@ parallel
 
 Defaulted to ``False``.
 
-Sets the flag ``/MP`` in order to compile the sources in parallel using cores found by :ref:`cpu_count`.
+Sets the flag ``/MP`` in order to compile the sources in parallel using cores found by :ref:`tools_cpu_count`.
 
 .. seealso::
 

--- a/reference/build_helpers/visual_studio.rst
+++ b/reference/build_helpers/visual_studio.rst
@@ -122,7 +122,7 @@ Parameters:
 
 .. note::
 
-    The ``MSBuild()`` build helper will, before calling to :command:`MSBuild`, call :ref:`vcvars_command` to adjust the environment
+    The ``MSBuild()`` build helper will, before calling to :command:`MSBuild`, call :ref:`tools_vcvars_command` to adjust the environment
     according to the settings. When cross-building from x64 to x86 the toolchain by default is ``x86``. If you want to use ``amd64_x86``
     instead, set the environment variable ``PreferredToolArchitecture=x64``.
 
@@ -163,7 +163,7 @@ VisualStudioBuildEnvironment
 ============================
 
 Prepares the needed environment variables to invoke the Visual Studio compiler.
-Use it together with :ref:`vcvars_command`.
+Use it together with :ref:`tools_vcvars_command`.
 
 .. code-block:: python
    :emphasize-lines: 9, 10, 11

--- a/reference/build_helpers/visual_studio.rst
+++ b/reference/build_helpers/visual_studio.rst
@@ -22,7 +22,7 @@ information from the requirements: include directories, library names, flags etc
 
     - :ref:`VisualStudioBuildEnvironment<visual_studio_build>` to adjust the ``LIB`` and ``CL``
       environment variables with all the information from the requirements: include directories, library names, flags etc.
-    - :ref:`tools.msvc_build_command<msvc_build_command>` to call ``MSBuild``.
+    - :ref:`tools_msvc_build_command` to call ``msbuild``.
 
 You can adjust all the information from the requirements accessing to the ``build_env`` that it is a :ref:`visual_studio_build` object:
 

--- a/reference/build_helpers/visual_studio.rst
+++ b/reference/build_helpers/visual_studio.rst
@@ -276,4 +276,4 @@ Sets the flag ``/MP`` in order to compile the sources in parallel using cores fo
 
 .. seealso::
 
-    Read more about :ref:`environment_append_tool`.
+    Read more about :ref:`tools_environment_append`.

--- a/reference/config_files/conan.conf.rst
+++ b/reference/config_files/conan.conf.rst
@@ -104,7 +104,7 @@ The ``verbose_traceback`` variable will print the complete traceback when an err
 to debug the detected error.
 
 The ``bash_path`` variable is used only in windows to help the
-:ref:`tools.run_in_windows_bash()<run_in_windows_bash_tool>` function to locate our Cygwin/MSYS2 bash.
+:ref:`tools.run_in_windows_bash()<tools_run_in_windows_bash>` function to locate our Cygwin/MSYS2 bash.
 Set it with the bash executable path if it's not in the PATH or you want to use a different one.
 
 The ``cmake_***`` variables will declare the corresponding CMake variable when you use the

--- a/reference/config_files/conan.conf.rst
+++ b/reference/config_files/conan.conf.rst
@@ -110,9 +110,9 @@ Set it with the bash executable path if it's not in the PATH or you want to use 
 The ``cmake_***`` variables will declare the corresponding CMake variable when you use the
 :ref:`cmake generator<cmake_generator>` and the :ref:`CMake build tool<cmake_reference>`.
 
-The ``cpu_count`` variable set the number of cores that the :ref:`tools.cpu_count()<cpu_count>` will return,
+The ``cpu_count`` variable set the number of cores that the :ref:`tools_cpu_count` will return,
 by default the number of cores available in your machine.
-Conan recipes can use the cpu_count() tool to build the library using more than one core.
+Conan recipes can use the ``cpu_count()`` tool to build the library using more than one core.
 
 The ``pylintrc`` variable points to a custom ``pylintrc`` file that allows configuring custom rules
 for the python linter executed at ``export`` time. A use case could be to define some custom indents

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -360,7 +360,7 @@ CONAN_SKIP_VS_PROJECTS_UPGRADE
 
 **Defaulted to**: ``False``/``0``
 
-When set to ``True``/``1``, the :ref:`build_sln_command<build_sln_command>`, the :ref:`msvc_build_command<msvc_build_command>`
+When set to ``True``/``1``, the :ref:`tools_build_sln_command`, the :ref:`msvc_build_command<msvc_build_command>`
 and the :ref:`MSBuild()<msbuild>` build helper, will not call ``devenv`` command to upgrade the ``sln`` project, irrespective of
 the ``upgrade_project`` parameter value.
 

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -99,8 +99,8 @@ CONAN_CPU_COUNT
 
 **Defaulted to**: Number of available cores in your machine.
 
-Set the number of cores that the :ref:`tools.cpu_count()<cpu_count>` will return.
-Conan recipes can use the cpu_count() tool to build the library using more than one core.
+Set the number of cores that the :ref:`tools_cpu_count` will return.
+Conan recipes can use the ``cpu_count()`` tool to build the library using more than one core.
 
 CONAN_DEFAULT_PROFILE_PATH
 --------------------------

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -16,7 +16,6 @@ CMAKE RELATED VARIABLES
 There are some Conan environment variables that will set the equivalent CMake variable using the :ref:`cmake generator<cmake_generator>` and
 the :ref:`CMake build tool<cmake_reference>`:
 
-
 +-----------------------------------------+------------------------------------------------------------------------------------------------+
 | Variable                                | CMake set variable                                                                             |
 +=========================================+================================================================================================+
@@ -54,16 +53,16 @@ to locate our Cygwin/MSYS2 bash. Set it with the bash executable path if it's no
 CONAN_CMAKE_GENERATOR
 ---------------------
 
-Conan ``CMake`` helper class is just a convenience to help to translate conan
-settings and options into cmake parameters, but you can easily do it yourself, or adapt it.
+Conan ``CMake`` helper class is just a convenience to help to translate Conan
+settings and options into CMake parameters, but you can easily do it yourself, or adapt it.
 
 For some compiler configurations, as ``gcc`` it will use by default the ``Unix Makefiles``
-cmake generator. Note that this is not a package settings, building it with makefiles or other
+CMake generator. Note that this is not a package settings, building it with makefiles or other
 build system, as Ninja, should lead to the same binary if using appropriately the same
 underlying compiler settings. So it doesn't make sense to provide a setting or option for this.
 
 So it can be set with the environment variable ``CONAN_CMAKE_GENERATOR``. Just set its value 
-to your desired cmake generator (as ``Ninja``).
+to your desired CMake generator (as ``Ninja``).
 
 CONAN_COLOR_DARK
 ----------------
@@ -79,7 +78,7 @@ CONAN_COLOR_DISPLAY
 
 **Defaulted to**: Not defined
 
-By default if undefined conan output will use color if a tty is detected.
+By default if undefined Conan output will use color if a tty is detected.
 
 Set it to ``False``/``0`` to remove console output colors.
 Set it to ``True``/``1`` to force console output colors.
@@ -89,7 +88,7 @@ CONAN_COMPRESSION_LEVEL
 
 **Defaulted to**: ``9``
 
-Conan uses ``tgz`` compression for archives before uploading them to remotes. The default compression
+Conan uses *.tgz* compression for archives before uploading them to remotes. The default compression
 level is good and fast enough for most cases, but users with huge packages might want to change it and
 set ``CONAN_COMPRESSION_LEVEL`` environment variable to a lower number, which is able to get slightly
 bigger archives but much better compression speed.
@@ -121,7 +120,6 @@ Invocations of Conan commands where an interactive prompt would otherwise appear
 This variable can also be set in ``conan.conf`` as ``non_interactive = True`` in the ``[general]``
 section.
 
-
 CONAN_ENV_XXXX_YYYY
 -------------------
 
@@ -149,7 +147,7 @@ The ``XXXX`` is the setting name upper-case, and the ``YYYY`` (optional) is the 
 
     CONAN_ENV_ARCH = "x86"
 
-.. _conan_log_run_to_file:
+.. _env_vars_conan_log_run_to_file:
 
 CONAN_LOG_RUN_TO_FILE
 ---------------------
@@ -164,7 +162,7 @@ In case we execute ``self.run`` in our ``source()`` method, the ``conan_run.log`
 to the ``build`` folder following the regular execution flow. So the ``conan_run.log`` will contain all the logs from your conanfile.py command
 executions.
 
-The file can be included in the conan package (for debugging purposes) using the ``package`` method.
+The file can be included in the Conan package (for debugging purposes) using the ``package`` method.
 
 .. code-block:: python
 
@@ -176,7 +174,7 @@ CONAN_LOG_RUN_TO_OUTPUT
 
 **Defaulted to**: ``1``
 
-If set to ``0`` conan won't print the command output to the stdout.
+If set to ``0`` Conan won't print the command output to the stdout.
 Can be used with ``CONAN_LOG_RUN_TO_FILE`` set to ``1`` to log only to file and not printing the output.
 
 CONAN_LOGGING_LEVEL
@@ -184,7 +182,7 @@ CONAN_LOGGING_LEVEL
 
 **Defaulted to**: ``50``
 
-By default conan logging level is only set for critical events. If you want
+By default Conan logging level is only set for critical events. If you want
 to show more detailed logging information, set this variable to lower values, as ``10`` to show
 debug information.
 
@@ -208,7 +206,7 @@ For example: For a remote named "conan-center":
 
     SET CONAN_LOGIN_USERNAME_CONAN_CENTER=MyUser
 
-.. _conan_make_program:
+.. _env_vars_conan_make_program:
 
 CONAN_MAKE_PROGRAM
 ------------------
@@ -252,13 +250,13 @@ For example, for a remote named "conan-center":
     SET CONAN_PASSWORD_CONAN_CENTER=Mypassword
 
 CONAN_HOOKS
--------------
+-----------
 
 **Defaulted to**: Not defined
 
 Can be set to a comma separated list with the names of the hooks that will be executed when running a Conan command.
 
-.. _conan_print_run_commands:
+.. _env_vars_conan_print_run_commands:
 
 CONAN_PRINT_RUN_COMMANDS
 ------------------------
@@ -287,7 +285,7 @@ CONAN_READ_ONLY_CACHE
 
 **Defaulted to**: Not defined
 
-This environment variable if defined, will make the conan cache read-only. This could prevent
+This environment variable if defined, will make the Conan cache read-only. This could prevent
 developers to accidentally edit some header of their dependencies while navigating code in their
 IDEs.
 
@@ -305,7 +303,7 @@ uploading packages, as they will be read-only and that could have other side-eff
     It is not recommended to upload packages directly from developers machines with read-only mode as it could lead to inconsistencies.
     For better reproducibility we recommend that packages are created and uploaded by CI machines.
 
-.. _conan_run_tests:
+.. _env_vars_conan_run_tests:
 
 CONAN_RUN_TESTS
 ---------------
@@ -353,7 +351,7 @@ See example of build method in ``conanfile.py`` to enable/disable running tests 
             if tools.get_env("CONAN_RUN_TESTS", True):
                 cmake.test()
 
-.. _env_var_conan_skip_vs_project_upgrade:
+.. _env_vars_conan_skip_vs_project_upgrade:
 
 CONAN_SKIP_VS_PROJECTS_UPGRADE
 ------------------------------
@@ -402,7 +400,7 @@ CONAN_TEMP_TEST_FOLDER
 
 Activating this variable will make build folder of *test_package* to be created in the temporary folder of your machine.
 
-.. _conan_trace_file:
+.. _env_vars_conan_trace_file:
 
 CONAN_TRACE_FILE
 ----------------
@@ -458,7 +456,6 @@ marked as `short_paths` will be stored in the ``C:\.conan`` (or the current driv
 
 If set to ``None``, it will disable the `short_paths` feature in Windows for modern Windows that enable long paths at the system level.
 
-
 CONAN_USE_ALWAYS_SHORT_PATHS
 ----------------------------
 
@@ -467,7 +464,6 @@ CONAN_USE_ALWAYS_SHORT_PATHS
 If defined to ``True`` or ``1``, every package will be stored in the *short paths directory* resolved
 by Conan after evaluating ``CONAN_USER_HOME_SHORT`` variable (see above). This variable, therefore,
 overrides the value defined in recipes for the attribute :ref:`short paths<short_paths_reference>`.
-
 
 CONAN_VERBOSE_TRACEBACK
 -----------------------

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -360,7 +360,7 @@ CONAN_SKIP_VS_PROJECTS_UPGRADE
 
 **Defaulted to**: ``False``/``0``
 
-When set to ``True``/``1``, the :ref:`tools_build_sln_command`, the :ref:`msvc_build_command<msvc_build_command>`
+When set to ``True``/``1``, the :ref:`tools_build_sln_command`, the :ref:`tools_msvc_build_command`
 and the :ref:`MSBuild()<msbuild>` build helper, will not call ``devenv`` command to upgrade the ``sln`` project, irrespective of
 the ``upgrade_project`` parameter value.
 

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -93,6 +93,8 @@ level is good and fast enough for most cases, but users with huge packages might
 set ``CONAN_COMPRESSION_LEVEL`` environment variable to a lower number, which is able to get slightly
 bigger archives but much better compression speed.
 
+.. _env_vars_conan_cpu_count:
+
 CONAN_CPU_COUNT
 ---------------
 
@@ -471,6 +473,8 @@ CONAN_VERBOSE_TRACEBACK
 **Defaulted to**: ``0``
 
 When an error is raised in a recipe or even in the Conan code base, if set to ``1`` it will show the complete traceback to ease the debugging.
+
+.. _env_vars_conan_vs_installation_preference:
 
 CONAN_VS_INSTALLATION_PREFERENCE
 --------------------------------

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -48,7 +48,7 @@ CONAN_BASH_PATH
 
 **Defaulted to**: Not defined
 
-Used only in windows to help the :ref:`tools.run_in_windows_bash()<run_in_windows_bash_tool>` function
+Used only in windows to help the :ref:`tools.run_in_windows_bash()<tools_run_in_windows_bash>` function
 to locate our Cygwin/MSYS2 bash. Set it with the bash executable path if it's not in the ``PATH`` or you want to use a different one.
 
 CONAN_CMAKE_GENERATOR

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -184,7 +184,7 @@ Parameters:
                        'armv7': 'ARM',
                        'armv8': 'ARM64'}
 
-.. _msvc_build_command:
+.. _tools_msvc_build_command:
 
 tools.msvc_build_command() [DEPRECATED]
 ---------------------------------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -29,7 +29,7 @@ tools.cpu_count()
     def tools.cpu_count()
 
 Returns the number of CPUs available, for parallel builds. If processor detection is not enabled, it will safely return 1. Can be
-overwritten with the environment variable ``CONAN_CPU_COUNT`` and configured in the :ref:`conan_conf`.
+overwritten with the environment variable :ref:`env_vars_conan_cpu_count` and configured in the :ref:`conan_conf`.
 
 .. _tools_vcvars_command:
 
@@ -171,7 +171,7 @@ Parameters:
     - **build_type** (Optional, Defaulted to ``None``): Override the build type defined in the settings (``settings.build_type``).
     - **arch** (Optional, Defaulted to ``None``): Override the architecture defined in the settings (``settings.arch``).
     - **parallel** (Optional, Defaulted to ``True``): Enables Visual Studio parallel build with ``/m:X`` argument, where X is defined by
-      ``CONAN_CPU_COUNT`` environment variable or by the number of cores in the processor by default.
+      :ref:`env_vars_conan_cpu_count` environment variable or by the number of cores in the processor by default.
     - **toolset** (Optional, Defaulted to ``None``): Specify a toolset. Will append a ``/p:PlatformToolset`` option.
     - **platforms** (Optional, Defaulted to ``None``): Dictionary with the mapping of archs/platforms from Conan naming to another one. It
       is useful for Visual Studio solutions that have a different naming in architectures. Example: ``platforms={"x86":"Win32"}`` (Visual
@@ -1171,8 +1171,8 @@ tools.vs_installation_path()
     def vs_installation_path(version, preference=None)
 
 Returns the Visual Studio installation path for the given version. It uses :ref:`tools_vswhere` and :ref:`tools_vs_comntools`. It will also
-look for the installation paths following ``CONAN_VS_INSTALLATION_PREFERENCE`` environment variable or the preference parameter itself. If
-the tool is not able to return the path it will return ``None``.
+look for the installation paths following :ref:`env_vars_conan_vs_installation_preference` environment variable or the preference parameter
+itself. If the tool is not able to return the path it will return ``None``.
 
 .. code-block:: python
 
@@ -1183,7 +1183,7 @@ the tool is not able to return the path it will return ``None``.
 Parameters:
     - **version** (Required): Visual Studio version to locate. Valid version numbers are strings: ``"10"``, ``"11"``, ``"12"``, ``"13"``,
       ``"14"``, ``"15"``...
-    - **preference** (Optional, Defaulted to ``None``): Set to value of ``CONAN_VS_INSTALLATION_PREFERENCE`` or defaulted to
+    - **preference** (Optional, Defaulted to ``None``): Set to value of :ref:`env_vars_conan_vs_installation_preference` or defaulted to
       ``["Enterprise", "Professional", "Community", "BuildTools"]``. If only set to one type of preference, it will return the installation
       path only for that Visual type and version, otherwise ``None``.
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1107,7 +1107,7 @@ Recursively walks a given directory (using ``os.walk()``) and returns a list of 
 Parameters:
     - **path** (Required): Path of the directory.
 
-.. _vswhere:
+.. _tools_vswhere:
 
 tools.vswhere()
 ---------------
@@ -1141,7 +1141,7 @@ Parameters:
       object and property names. Example: ``"properties.nickname"`` will return the "nickname" property under "properties".
     - **nologo** (Optional, Defaulted to ``True``): Do not show logo information.
 
-.. _vs_comntools:
+.. _tools_vs_comntools:
 
 tools.vs_comntools()
 --------------------
@@ -1161,6 +1161,8 @@ Returns the value of the environment variable ``VS<compiler_version>.0COMNTOOLS`
 Parameters:
     - **compiler_version** (Required): String with the version number: ``"14"``, ``"12"``...
 
+.. tools_vs_installation_path:
+
 tools.vs_installation_path()
 ----------------------------
 
@@ -1168,9 +1170,9 @@ tools.vs_installation_path()
 
     def vs_installation_path(version, preference=None)
 
-Returns the Visual Studio installation path for the given version. It uses :ref:`vswhere` and :ref:`vs_comntools`. It will also look for the
-installation paths following ``CONAN_VS_INSTALLATION_PREFERENCE`` environment variable or the preference parameter itself. If the tool is
-not able to return the path it will return ``None``.
+Returns the Visual Studio installation path for the given version. It uses :ref:`tools_vswhere` and :ref:`tools_vs_comntools`. It will also
+look for the installation paths following ``CONAN_VS_INSTALLATION_PREFERENCE`` environment variable or the preference parameter itself. If
+the tool is not able to return the path it will return ``None``.
 
 .. code-block:: python
 
@@ -1184,6 +1186,8 @@ Parameters:
     - **preference** (Optional, Defaulted to ``None``): Set to value of ``CONAN_VS_INSTALLATION_PREFERENCE`` or defaulted to
       ``["Enterprise", "Professional", "Community", "BuildTools"]``. If only set to one type of preference, it will return the installation
       path only for that Visual type and version, otherwise ``None``.
+
+.. _tools_replace_prefix_in_pc_file:
 
 tools.replace_prefix_in_pc_file()
 ---------------------------------
@@ -1208,6 +1212,8 @@ Replaces the ``prefix`` variable in a package config file *.pc* with the specifi
 .. seealso::
 
     Check section :ref:`pc_files` to know more.
+
+.. _tools_collect_libs:
 
 tools.collect_libs()
 --------------------
@@ -1240,7 +1246,7 @@ For UNIX libraries staring with **lib**, like *libmath.a*, this tool will collec
     This tool collects the libraries searching directly inside the package folder and returns them in no specific order. If libraries are
     inter-dependent, then ``package_info()`` method should order them to achieve correct linking order.
 
-.. _pkgconfigtool:
+.. _tools_pkgconfig:
 
 tools.PkgConfig()
 -----------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -256,6 +256,8 @@ Parameters:
     - **pattern** (Optional, Defaulted to ``None``): Extract from the archive only paths matching the pattern. This should be a Unix
       shell-style wildcard. See `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ documentation for more details.
 
+.. _tools_untargz:
+
 tools.untargz()
 ---------------
 
@@ -281,6 +283,8 @@ Parameters:
     - **destination** (Optional, Defaulted to ``"."``): Destination folder for *untargzed* files.
     - **pattern** (Optional, Defaulted to ``None``): Extract from the archive only paths matching the pattern. This should be a Unix
       shell-style wildcard. See `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ documentation for more details.
+
+.. _tools_get:
 
 tools.get()
 -----------
@@ -356,6 +360,8 @@ Parameters:
     - **default** (Optional, Defaulted to ``None``): default value to return if not defined or cast value against.
     - **environment** (Optional, Defaulted to ``None``): ``os.environ`` if ``None`` or environment dictionary to look for.
 
+.. _tools_download:
+
 tools.download()
 ----------------
 
@@ -399,6 +405,8 @@ Parameters:
       ``requests`` Python library. Check other uses here: http://docs.python-requests.org/en/master/user/authentication
     - **headers** (Optional, Defaulted to ``None``): A dictionary with additional headers.
 
+.. _tools_ftp_download:
+
 tools.ftp_download()
 --------------------
 
@@ -421,6 +429,8 @@ Parameters:
     - **filename** (Required): The filename, including the path/folder where it is located.
     - **login** (Optional, Defaulted to ``""``): Login credentials for the ftp server.
     - **password** (Optional, Defaulted to ``""``): Password credentials for the ftp server.
+
+.. _tools_replace_in_file:
 
 tools.replace_in_file()
 -----------------------
@@ -451,6 +461,8 @@ Parameters:
     - **strict** (Optional, Defaulted to ``True``): If ``True``, it raises an error if the searched string is not found, so nothing is
       actually replaced.
 
+.. _tools_replace_path_in_file:
+
 tools.replace_path_in_file()
 ----------------------------
 
@@ -477,7 +489,7 @@ Parameters:
       directory separators are taken into account:
 
       - ``None``: Only when Windows operating system is detected.
-      - ``False``: Deactivated, it will match exact patterns (like ``tools.replace_in_file()``).
+      - ``False``: Deactivated, it will match exact patterns (like :ref:`tools_replace_in_file`).
       - ``True``: Always activated, irrespective of the detected operating system.
 
 .. _tools_run_environment:
@@ -534,6 +546,8 @@ The previous is equivalent to:
     tools.check_with_algorithm_sum("sha1", "myfile.zip",
                                     "eb599ec83d383f0f25691c184f656d40384f9435")
 
+.. _tools_patch:
+
 tools.patch()
 -------------
 
@@ -565,7 +579,7 @@ If the patch to be applied uses alternate paths that have to be stripped like th
     - old content
     + new content
 
-Then, the number of folders to be stripped from the path can be specifyed :
+Then, the number of folders to be stripped from the path can be specified:
 
 .. code-block:: python
 
@@ -605,6 +619,8 @@ manager block ends, the environment variables will be unset.
 Parameters:
     - **env_vars** (Required): Dictionary object with environment variable name and its value.
 
+.. _tools_chdir:
+
 tools.chdir()
 -------------
 
@@ -624,6 +640,8 @@ This is a context manager that allows to temporary change the current directory 
 
 Parameters:
     - **newdir** (Required): Directory path name to change the current directory.
+
+.. _tools_pythonpath:
 
 tools.pythonpath()
 ------------------
@@ -676,6 +694,8 @@ object inside, and should have declared in its ``package_info()``:
 Parameters:
     - **conanfile** (Required): Current ``ConanFile`` object.
 
+.. _tools_no_op:
+
 tools.no_op()
 -------------
 
@@ -693,6 +713,8 @@ Context manager that performs nothing. Useful to condition any other context man
         with tools.chdir("some_dir") if self.options.myoption else tools.no_op():
             # if not self.options.myoption, we are not in the "some_dir"
             pass
+
+.. _tools_human_size:
 
 tools.human_size()
 ------------------
@@ -714,7 +736,8 @@ downloads and unzip progress.
 Parameters:
     - **size_bytes** (Required): Number of bytes.
 
-.. _osinfo_reference:
+.. _tools_osinfo:
+.. _tools_systempackagetool:
 
 tools.OSInfo and tools.SystemPackageTool
 ----------------------------------------
@@ -744,6 +767,8 @@ Parameters:
     - **self_os** (Optional, Defaulted to ``None``): Current operating system where the build is being done.
     - **self_arch** (Optional, Defaulted to ``None``): Current architecture where the build is being done.
 
+.. _tools_get_gnu_triplet:
+
 tools.get_gnu_triplet()
 -----------------------
 
@@ -758,7 +783,7 @@ Parameters:
     - **arch** (Required): Architecture to be used to create the triplet.
     - **compiler** (Optional, Defaulted to ``None``): Compiler used to create the triplet (only needed for Windows).
 
-.. _run_in_windows_bash_tool:
+.. _tools_run_in_windows_bash:
 
 tools.run_in_windows_bash()
 ---------------------------
@@ -791,6 +816,8 @@ Parameters:
     - **env** (Optional, Defaulted to ``None``) You can pass a dictionary with environment variable to be applied **at first place** so they
       will have more priority than others.
 
+.. _tools_get_cased_path:
+
 tools.get_cased_path()
 ----------------------
 
@@ -801,6 +828,8 @@ tools.get_cased_path()
 This function converts a case-insensitive absolute path to a case-sensitive one. That is, with the real cased characters. Useful when using
 Windows subsystems where the file system is case-sensitive.
 
+.. _tools_remove_from_path:
+
 tools.remove_from_path()
 ------------------------
 
@@ -808,8 +837,8 @@ tools.remove_from_path()
 
     remove_from_path(command)
 
-This is a context manager that allows you to remove a tool from the ``PATH``. Conan will locate the executable (using :ref:`which`) and will
-remove from the ``PATH`` the directory entry that contains it. It's not necessary to specify the extension.
+This is a context manager that allows you to remove a tool from the ``PATH``. Conan will locate the executable (using :ref:`tools_which`)
+and will remove from the ``PATH`` the directory entry that contains it. It's not necessary to specify the extension.
 
 .. code-block:: python
 
@@ -817,6 +846,8 @@ remove from the ``PATH`` the directory entry that contains it. It's not necessar
 
     with tools.remove_from_path("make"):
         self.run("some command")
+
+.. _tools_unix_path:
 
 tools.unix_path()
 -----------------
@@ -832,6 +863,8 @@ Parameters:
     - **path_flavor** (Optional, Defaulted to ``None``, will try to autodetect the subsystem): Type of Unix path to be returned. Options are
       ``MSYS``, ``MSYS2``, ``CYGWIN``, ``WSL`` and ``SFU``.
 
+.. _tools_escape_windows_cmd:
+
 tools.escape_windows_cmd()
 --------------------------
 
@@ -846,6 +879,8 @@ Useful to escape commands to be executed in a windows bash (msys2, cygwin etc).
 
 Parameters:
     - **command** (Required): Command to execute.
+
+.. _tools_sha1sum_sha256sum_md5sum:
 
 tools.sha1sum(), sha256sum(), md5sum()
 --------------------------------------
@@ -868,6 +903,8 @@ Return the respective hash or checksum for a file.
 Parameters:
     - **file_path** (Required): Path to the file.
 
+.. _tools_md5:
+
 tools.md5()
 -----------
 
@@ -885,6 +922,8 @@ Returns the MD5 hash for a string or byte object.
 
 Parameters:
     - **content** (Required): String or bytes to calculate its md5.
+
+.. _tools_save:
 
 tools.save()
 ------------
@@ -906,6 +945,8 @@ Parameters:
     - **content** (Required): Content that should be saved into the file.
     - **append** (Optional, Defaulted to ``False``): If ``True``, it will append the content.
 
+.. _tools_load:
+
 tools.load()
 ------------
 
@@ -925,6 +966,8 @@ the file.
 Parameters:
     - **path** (Required): Path to the file.
     - **binary** (Optional, Defaulted to ``False``): If ``True``, it reads the the file as binary code.
+
+.. _tools_mkdir_rmdir:
 
 tools.mkdir(), tools.rmdir()
 ----------------------------
@@ -952,7 +995,7 @@ This makes it safe to use these functions in the ``package()`` method of a *cona
 Parameters:
     - **path** (Required): Path to the directory.
 
-.. _which:
+.. _tools_which:
 
 tools.which()
 -------------
@@ -1017,6 +1060,8 @@ Converts line breaks in a text file from DOS format (CRLF) to Unix format (LF).
 Parameters:
     - **filepath** (Required): The file to convert.
 
+.. tools_tocuh:
+
 tools.touch()
 -------------
 
@@ -1041,6 +1086,8 @@ Optionally, a tuple of two numbers can be specified, which denotes the new value
 Parameters:
     - **fname** (Required): File name of the file to be touched.
     - **times** (Optional, Defaulted to ``None``: Tuple with 'last access' and 'last modified' times.
+
+.. _tools_relative_dirs:
 
 tools.relative_dirs()
 ---------------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -8,8 +8,7 @@
 Tools
 =====
 
-Under the tools module there are several functions and utilities that can be used in conan package
-recipes:
+Under the tools module there are several functions and utilities that can be used in Conan package recipes:
 
 .. code-block:: python
    :emphasize-lines: 2
@@ -29,8 +28,8 @@ tools.cpu_count()
 
     def tools.cpu_count()
 
-Returns the number of CPUs available, for parallel builds. If processor detection is not enabled, it will safely return 1.
-Can be overwritten with the environment variable ``CONAN_CPU_COUNT`` and configured in the :ref:`conan.conf file<conan_conf>`.
+Returns the number of CPUs available, for parallel builds. If processor detection is not enabled, it will safely return 1. Can be
+overwritten with the environment variable ``CONAN_CPU_COUNT`` and configured in the :ref:`conan_conf`.
 
 .. _vcvars_command:
 
@@ -42,12 +41,10 @@ tools.vcvars_command()
     def vcvars_command(settings, arch=None, compiler_version=None, force=False, vcvars_ver=None,
                        winsdk_version=None)
 
-Returns, for given settings, the command that should be called to load the Visual
-Studio environment variables for a certain Visual Studio version. It wraps the functionality of
-`vcvarsall <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2017>`_ but
-does not execute the command, as that typically have to be done in the same command as the compilation,
-so the variables are loaded for the same subprocess. It will be typically used in the ``build()``
-method, like this:
+Returns, for given settings, the command that should be called to load the Visual Studio environment variables for a certain Visual Studio
+version. It wraps the functionality of `vcvarsall <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2017>`_
+but does not execute the command, as that typically have to be done in the same command as the compilation, so the variables are loaded for
+the same subprocess. It will be typically used in the ``build()`` method, like this:
 
 .. code-block:: python
 
@@ -60,14 +57,13 @@ method, like this:
             self.run("%s && configure %s" % (vcvars, " ".join(args)))
             self.run("%s && %s %s" % (vcvars, build_command, " ".join(build_args)))
 
-The ``vcvars_command`` string will contain something like ``call "%vsXX0comntools%../../VC/vcvarsall.bat"`` for the
-corresponding Visual Studio version for the current settings.
+The ``vcvars_command`` string will contain something like ``call "%vsXX0comntools%../../VC/vcvarsall.bat"`` for the corresponding Visual
+Studio version for the current settings.
 
-This is typically not needed if using ``CMake``, as the cmake generator will handle the correct
-Visual Studio version.
+This is typically not needed if using CMake, as the ``cmake`` generator will handle the correct Visual Studio version.
 
-If **arch** or **compiler_version** is specified, it will ignore the settings and return the command
-to set the Visual Studio environment for these parameters.
+If **arch** or **compiler_version** is specified, it will ignore the settings and return the command to set the Visual Studio environment
+for these parameters.
 
 Parameters:
     - **settings** (Required): Conanfile settings. Use ``self.settings``.
@@ -77,12 +73,12 @@ Parameters:
     - **winsdk_version** (Optional, Defaulted to ``None``): Specifies the version of the Windows SDK to use.
     - **vcvars_ver** (Optional, Defaulted to ``None``): Specifies the Visual Studio compiler toolset to use.
 
-
 .. note::
 
-    When cross-building from x64 to x86 the toolchain by default is ``x86``.
-    If you want to use ``amd64_x86`` instead, set the environment variable ``PreferredToolArchitecture=x64``.
+    When cross-building from x64 to x86 the toolchain by default is ``x86``. If you want to use ``amd64_x86`` instead, set the environment
+    variable ``PreferredToolArchitecture=x64``.
 
+.. _vcvars_dict:
 
 tools.vcvars_dict()
 -------------------
@@ -92,12 +88,10 @@ tools.vcvars_dict()
     vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
                 vcvars_ver=None, winsdk_version=None, only_diff=True)
 
-Returns a dictionary with the variables set by the **tools.vcvars_command** that can be directly
-applied to ``tools.environment_append``.
+Returns a dictionary with the variables set by the :ref:`vcvars_command` that can be directly applied to :ref:`tools_environment_append`.
 
-The values of the variables ``INCLUDE``,  ``LIB``, ``LIBPATH`` and ``PATH`` will be returned
-as a list, so when used with ``tools.environment_append``, the previous environment values that these variables
-could have, will be appended automatically.
+The values of the variables ``INCLUDE``,  ``LIB``, ``LIBPATH`` and ``PATH`` will be returned as a list. When used with
+:ref:`tools_environment_append`, the previous environment values that these variables may have will be appended automatically.
 
 .. code-block:: python
 
@@ -108,17 +102,13 @@ could have, will be appended automatically.
         with tools.environment_append(env_vars):
             # Do something
 
-
 Parameters:
-    - Same as ``vcvars_command``.
-    - **filter_known_paths** (Optional, Defaulted to ``False``): When True, the function will only keep the PATH
-      entries that follows some known patterns, filtering all the non-Visual Studio ones. When False,
-      it will keep the PATH will all the system entries.
-    - **only_diff** (Optional, Defaulted to ``True``): When True, the command will return only the variables set by
-      ``vcvarsall`` and not the whole environment.
-      If `vcvars` modifies an environment variable by appending values to the old value (separated by ``;``),
-      only the new values will be returned, as a list.
-
+    - Same as :ref:`vcvars_command`.
+    - **filter_known_paths** (Optional, Defaulted to ``False``): When True, the function will only keep the PATH entries that follows some
+      known patterns, filtering all the non-Visual Studio ones. When False, it will keep the PATH will all the system entries.
+    - **only_diff** (Optional, Defaulted to ``True``): When True, the command will return only the variables set by ``vcvarsall`` and not
+      the whole environment. If `vcvars` modifies an environment variable by appending values to the old value (separated by ``;``), only
+      the new values will be returned, as a list.
 
 tools.vcvars()
 --------------
@@ -131,9 +121,8 @@ tools.vcvars()
 
     This context manager tool has no effect if used in a platform different from Windows.
 
-This is a context manager that allows to append to the environment all the variables set by the **tools.vcvars_dict()**.
-You can replace **tools.vcvars_command()** and use this context manager to get a cleaner way to activate the Visual Studio
-environment:
+This is a context manager that allows to append to the environment all the variables set by the :ref:`vcvars_dict`. You can replace
+:ref:`vcvars_command` and use this context manager to get a cleaner way to activate the Visual Studio environment:
 
 .. code-block:: python
 
@@ -145,22 +134,20 @@ environment:
 
 .. _build_sln_command:
 
-
-tools.build_sln_command() (DEPRECATED)
+tools.build_sln_command() [DEPRECATED]
 --------------------------------------
 
 .. warning::
 
-    This tool is deprecated and will be removed in Conan 2.0.
-    Use :ref:`MSBuild()<msbuild>` build helper instead.
+    This tool is deprecated and will be removed in Conan 2.0. Use :ref:`MSBuild()<msbuild>` build helper instead.
 
 .. code-block:: python
 
     def build_sln_command(settings, sln_path, targets=None, upgrade_project=True, build_type=None,
                           arch=None, parallel=True, toolset=None, platforms=None)
 
-Returns the command to call `devenv` and `msbuild` to build a Visual Studio project.
-It's recommended to use it along with ``vcvars_command()``, so that the Visual Studio tools will be in path.
+Returns the command to call `devenv` and `msbuild` to build a Visual Studio project. It's recommended to use it with :ref:`vcvars_command`,
+so that the Visual Studio tools will be in path.
 
 .. code-block:: python
 
@@ -180,8 +167,8 @@ Parameters:
       ``True``/``1``, this parameter will be ignored and the project won't be upgraded.
     - **build_type** (Optional, Defaulted to ``None``): Override the build type defined in the settings (``settings.build_type``).
     - **arch** (Optional, Defaulted to ``None``): Override the architecture defined in the settings (``settings.arch``).
-    - **parallel** (Optional, Defaulted to ``True``): Enables VS parallel build with ``/m:X`` argument, where X is defined by CONAN_CPU_COUNT environment variable
-      or by the number of cores in the processor by default.
+    - **parallel** (Optional, Defaulted to ``True``): Enables Visual Studio parallel build with ``/m:X`` argument, where X is defined by
+      ``CONAN_CPU_COUNT`` environment variable or by the number of cores in the processor by default.
     - **toolset** (Optional, Defaulted to ``None``): Specify a toolset. Will append a ``/p:PlatformToolset`` option.
     - **platforms** (Optional, Defaulted to ``None``): Dictionary with the mapping of archs/platforms from Conan naming to another one. It
       is useful for Visual Studio solutions that have a different naming in architectures. Example: ``platforms={"x86":"Win32"}`` (Visual
@@ -196,15 +183,12 @@ Parameters:
 
 .. _msvc_build_command:
 
-
-tools.msvc_build_command() (DEPRECATED)
+tools.msvc_build_command() [DEPRECATED]
 ---------------------------------------
 
 .. warning::
 
-    This tool is deprecated and will be removed in Conan 2.0.
-    Use :ref:`MSBuild()<msbuild>`.get_command() instead.
-
+    This tool is deprecated and will be removed in Conan 2.0. Use :ref:`MSBuild()<msbuild>`.get_command() instead.
 
 .. code-block:: python
 
@@ -212,11 +196,11 @@ tools.msvc_build_command() (DEPRECATED)
                            arch=None, parallel=True, force_vcvars=False, toolset=None, platforms=None)
 
 Returns a string with a joint command consisting in setting the environment variables via ``vcvars.bat`` with the above
-``tools.vcvars_command()`` function, and building a Visual Studio project with the ``tools.build_sln_command()`` function.
+:ref:`vcvars_command` function, and building a Visual Studio project with the ``tools.build_sln_command()`` function.
 
 Parameters:
-    - Same parameters as the above :ref:`tools.build_sln_command()<build_sln_command>`.
-    - **force_vcvars**: Optional. Defaulted to False. Will set ``vcvars_command(force=force_vcvars)``.
+    - Same parameters as the above :ref:`build_sln_command`.
+    - **force_vcvars**: Optional. Defaulted to False. Will set ``tools.vcvars_command(force=force_vcvars)``.
 
 .. _tools_unzip:
 
@@ -227,11 +211,11 @@ tools.unzip()
 
     def unzip(filename, destination=".", keep_permissions=False, pattern=None)
 
-Function mainly used in ``source()``, but could be used in ``build()`` in special cases, as
-when retrieving pre-built binaries from the Internet.
+Function mainly used in ``source()``, but could be used in ``build()`` in special cases, as when retrieving pre-built binaries from the
+Internet.
 
-This function accepts ``.tar.gz``, ``.tar``, ``.tzb2``, ``.tar.bz2``, ``.tgz``, ``.txz``, ``tar.xz``, and ``.zip`` files,
-and decompresses them into the given destination folder (the current one by default).
+This function accepts ``.tar.gz``, ``.tar``, ``.tzb2``, ``.tar.bz2``, ``.tgz``, ``.txz``, ``tar.xz``, and ``.zip`` files, and decompresses
+them into the given destination folder (the current one by default).
 
 .. code-block:: python
 
@@ -249,8 +233,7 @@ You can keep the permissions of the files using the ``keep_permissions=True`` pa
 
     tools.unzip("myfile.zip", "myfolder", keep_permissions=True)
 
-Use the ``pattern=None`` parameter if you want to filter specific files and
-paths to decompress from the archive.
+Use ``pattern=None`` if you want to filter specific files and paths to decompress from the archive.
 
 .. code-block:: python
 
@@ -267,10 +250,8 @@ Parameters:
     - **keep_permissions** (Optional, Defaulted to ``False``): Keep permissions of files. **WARNING:** Can be dangerous if the zip
       was not created in a NIX system, the bits could produce undefined permission schema. Use only this option if you are sure that
       the zip was created correctly.
-    - **pattern** (Optional, Defaulted to ``None``): Extract from the archive
-      only paths matching the pattern. This should be a Unix shell-style
-      wildcard, see `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_
-      documentation for more details.
+    - **pattern** (Optional, Defaulted to ``None``): Extract from the archive only paths matching the pattern. This should be a Unix
+      shell-style wildcard. See `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ documentation for more details.
 
 tools.untargz()
 ---------------
@@ -279,9 +260,8 @@ tools.untargz()
 
     def untargz(filename, destination=".", pattern=None)
 
-Extract tar gz files (or in the family). This is the function called by the previous ``unzip()``
-for the matching extensions, so generally not needed to be called directly, call ``unzip()`` instead
-unless the file had a different extension.
+Extract *.tar.gz* files (or in the family). This is the function called by the previous ``unzip()`` for the matching extensions, so
+generally not needed to be called directly, call ``unzip()`` instead unless the file had a different extension.
 
 .. code-block:: python
 
@@ -296,10 +276,8 @@ unless the file had a different extension.
 Parameters:
     - **filename** (Required): File to be unzipped.
     - **destination** (Optional, Defaulted to ``"."``): Destination folder for *untargzed* files.
-    - **pattern** (Optional, Defaulted to ``None``): Extract from the archive
-      only paths matching the pattern. This should be a Unix shell-style
-      wildcard, see `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_
-      documentation for more details.
+    - **pattern** (Optional, Defaulted to ``None``): Extract from the archive only paths matching the pattern. This should be a Unix
+      shell-style wildcard. See `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ documentation for more details.
 
 tools.get()
 -----------
@@ -309,9 +287,9 @@ tools.get()
     def get(url, filenname="", md5="", sha1="", sha256="", keep_permissions=False, pattern=None,
             verify=True, retry=2, retry_wait=5, overwrite=False, auth=None, headers=None)
 
-Just a high level wrapper for download, unzip, and remove the temporary zip file once unzipped.
-You can pass hash checking parameters: ``md5``, ``sha1``, ``sha256``. All the specified algorithms
-will be checked, if any of them doesn't match, it will raise a ``ConanException``.
+Just a high level wrapper for download, unzip, and remove the temporary zip file once unzipped. You can pass hash checking parameters:
+``md5``, ``sha1``, ``sha256``. All the specified algorithms will be checked. If any of them doesn't match, it will raise a
+``ConanException``.
 
 .. code-block:: python
 
@@ -332,10 +310,12 @@ Parameters:
     - **verify** (Optional, Defaulted to ``True``): When False, disables https certificate validation.
     - **retry** (Optional, Defaulted to ``2``): Number of retries in case of failure.
     - **retry_wait** (Optional, Defaulted to ``5``): Seconds to wait between download attempts.
-    - **overwrite**: (Optional, Defaulted to ``False``): When `True` Conan will overwrite the destination file if exists, if False it will raise.
-    - **auth** (Optional, Defaulted to ``None``): A tuple of user, password can be passed to use HTTPBasic authentication. This is passed directly to the
-      requests python library, check here other uses of the **auth** parameter: http://docs.python-requests.org/en/master/user/authentication
-    - **headers** (Optional, Defaulted to ``None``): A dict with additional headers.
+    - **overwrite**: (Optional, Defaulted to ``False``): When ``True`` Conan will overwrite the destination file if it exists. Otherwise it
+      will raise.
+    - **auth** (Optional, Defaulted to ``None``): A tuple of user, password can be passed to use HTTPBasic authentication. This is passed
+      directly to the ``requests`` Python library. Check here other uses of the **auth** parameter:
+      http://docs.python-requests.org/en/master/user/authentication
+    - **headers** (Optional, Defaulted to ``None``): A dictionary with additional headers.
 
 .. _tools_get_env:
 
@@ -344,35 +324,34 @@ tools.get_env()
 
 .. code-block:: python
 
-   def get_env(env_key, default=None, environment=None)
+    def get_env(env_key, default=None, environment=None)
 
-Parses an environment and cast its value against the **default** type passed as an argument.
+Parses an environment and cast its value against the **default** type passed as an argument. Following Python conventions, returns
+**default** if **env_key** is not defined.
 
-Following python conventions, returns **default** if **env_key** is not defined.
-
-See an usage example with an environment variable defined while executing conan
+This is a usage example with an environment variable defined while executing Conan:
 
 .. code-block:: bash
 
-   $ TEST_ENV="1" conan <command> ...
+    $ TEST_ENV="1" conan <command> ...
 
 .. code-block:: python
 
-   from conans import tools
+    from conans import tools
 
-   tools.get_env("TEST_ENV") # returns "1", returns current value
-   tools.get_env("TEST_ENV_NOT_DEFINED") # returns None, TEST_ENV_NOT_DEFINED not declared
-   tools.get_env("TEST_ENV_NOT_DEFINED", []) # returns [], TEST_ENV_NOT_DEFINED not declared
-   tools.get_env("TEST_ENV", "2") # returns "1"
-   tools.get_env("TEST_ENV", False) # returns True (default value is boolean)
-   tools.get_env("TEST_ENV", 2) # returns 1
-   tools.get_env("TEST_ENV", 2.0) # returns 1.0
-   tools.get_env("TEST_ENV", []) # returns ["1"]
+    tools.get_env("TEST_ENV") # returns "1", returns current value
+    tools.get_env("TEST_ENV_NOT_DEFINED") # returns None, TEST_ENV_NOT_DEFINED not declared
+    tools.get_env("TEST_ENV_NOT_DEFINED", []) # returns [], TEST_ENV_NOT_DEFINED not declared
+    tools.get_env("TEST_ENV", "2") # returns "1"
+    tools.get_env("TEST_ENV", False) # returns True (default value is boolean)
+    tools.get_env("TEST_ENV", 2) # returns 1
+    tools.get_env("TEST_ENV", 2.0) # returns 1.0
+    tools.get_env("TEST_ENV", []) # returns ["1"]
 
 Parameters:
-   - **env_key** (Required): environment variable name.
-   - **default** (Optional, Defaulted to ``None``): default value to return if not defined or cast value against.
-   - **environment** (Optional, Defaulted to ``None``): ``os.environ`` if ``None`` or environment dictionary to look for.
+    - **env_key** (Required): environment variable name.
+    - **default** (Optional, Defaulted to ``None``): default value to return if not defined or cast value against.
+    - **environment** (Optional, Defaulted to ``None``): ``os.environ`` if ``None`` or environment dictionary to look for.
 
 tools.download()
 ----------------
@@ -382,13 +361,13 @@ tools.download()
     def download(url, filename, verify=True, out=None, retry=2, retry_wait=5, overwrite=False,
                  auth=None, headers=None)
 
-Retrieves a file from a given URL into a file with a given filename. It uses certificates from a
-list of known verifiers for https downloads, but this can be optionally disabled.
+Retrieves a file from a given URL into a file with a given filename. It uses certificates from a list of known verifiers for https
+downloads, but this can be optionally disabled.
 
 .. code-block:: python
 
     from conans import tools
-    
+
     tools.download("http://someurl/somefile.zip", "myfilename.zip")
 
     # to disable verification:
@@ -407,13 +386,15 @@ Parameters:
     - **url** (Required): URL to download
     - **filename** (Required): Name of the file to be created in the local storage
     - **verify** (Optional, Defaulted to ``True``): When False, disables https certificate validation.
-    - **out**: (Optional, Defaulted to ``None``): An object with a write() method can be passed to get the output, stdout will use if not specified.
+    - **out**: (Optional, Defaulted to ``None``): An object with a ``write()`` method can be passed to get the output. ``stdout`` will use
+      if not specified.
     - **retry** (Optional, Defaulted to ``2``): Number of retries in case of failure.
     - **retry_wait** (Optional, Defaulted to ``5``): Seconds to wait between download attempts.
-    - **overwrite**: (Optional, Defaulted to ``False``): When `True` Conan will overwrite the destination file if exists, if False it will raise.
-    - **auth** (Optional, Defaulted to ``None``): A tuple of user, password can be passed to use HTTPBasic authentication. This is passed directly to the
-      requests python library, check here other uses of the **auth** parameter: http://docs.python-requests.org/en/master/user/authentication
-    - **headers** (Optional, Defaulted to ``None``): A dict with additional headers.
+    - **overwrite**: (Optional, Defaulted to ``False``): When ``True``, Conan will overwrite the destination file if exists. Otherwise it
+      will raise an exception.
+    - **auth** (Optional, Defaulted to ``None``): A tuple of user and password to use HTTPBasic authentication. This is used directly in the
+      ``requests`` Python library. Check other uses here: http://docs.python-requests.org/en/master/user/authentication
+    - **headers** (Optional, Defaulted to ``None``): A dictionary with additional headers.
 
 tools.ftp_download()
 --------------------
@@ -422,8 +403,7 @@ tools.ftp_download()
 
     def ftp_download(ip, filename, login="", password="")
 
-Retrieves a file from an FTP server. Right now it doesn't support SSL, but you might implement it yourself using the standard python FTP library, and also if
-you need some special functionality.
+Retrieves a file from an FTP server. This doesn't support SSL, but you might implement it yourself using the standard Python FTP library.
 
 .. code-block:: python
 
@@ -446,14 +426,14 @@ tools.replace_in_file()
 
     def replace_in_file(file_path, search, replace, strict=True)
 
-This function is useful for a simple "patch" or modification of source files. A typical use would
-be to augment some library existing ``CMakeLists.txt`` in the ``source()`` method, so it uses
-Conan dependencies without forking or modifying the original project:
+This function is useful for a simple "patch" or modification of source files. A typical use would be to augment some library existing
+*CMakeLists.txt* in the ``source()`` method of a *conanfile.py*, so it uses Conan dependencies without forking or modifying the original
+project:
 
 .. code-block:: python
 
     from conans import tools
-    
+
     def source(self):
         # get the sources from somewhere
         tools.replace_in_file("hello/CMakeLists.txt", "PROJECT(MyHello)",
@@ -465,8 +445,8 @@ Parameters:
     - **file_path** (Required): File path of the file to perform the replace in.
     - **search** (Required): String you want to be replaced.
     - **replace** (Required): String to replace the searched string.
-    - **strict** (Optional, Defaulted to ``True``): If ``True``, it raises an error if the searched string
-      is not found, so nothing is actually replaced.
+    - **strict** (Optional, Defaulted to ``True``): If ``True``, it raises an error if the searched string is not found, so nothing is
+      actually replaced.
 
 tools.replace_path_in_file()
 ----------------------------
@@ -475,8 +455,7 @@ tools.replace_path_in_file()
 
     def replace_path_in_file(file_path, search, replace, strict=True, windows_paths=None)
 
-Replace a path in a file with another string. In Windows, it will match the path even if the
-casing and the path separator doesn't match.
+Replace a path in a file with another string. In Windows, it will match the path even if the casing and the path separator doesn't match.
 
 .. code-block:: python
 
@@ -518,9 +497,8 @@ tools.check_with_algorithm_sum()
 
     def check_with_algorithm_sum(algorithm_name, file_path, signature)
 
-Useful to check that some downloaded file or resource has a predefined hash, so integrity and
-security are guaranteed. Something that could be typically done in ``source()`` method after
-retrieving some file from the internet.
+Useful to check that some downloaded file or resource has a predefined hash, so integrity and security are guaranteed. Something that could
+be typically done in ``source()`` method after retrieving some file from the internet.
 
 Parameters:
     - **algorithm_name** (Required): Name of the algorithm to be checked.
@@ -543,8 +521,8 @@ For example:
     
     tools.check_sha1("myfile.zip", "eb599ec83d383f0f25691c184f656d40384f9435")
 
-Other algorithms are also possible, as long as are recognized by python ``hashlib`` implementation,
-via ``hashlib.new(algorithm_name)``. The previous is equivalent to:
+Other algorithms are also possible, as long as are recognized by python ``hashlib`` implementation, via ``hashlib.new(algorithm_name)``.
+The previous is equivalent to:
 
 .. code-block:: python
 
@@ -560,8 +538,8 @@ tools.patch()
 
     def patch(base_path=None, patch_file=None, patch_string=None, strip=0, output=None)
 
-Applies a patch from a file or from a string into the given path. The patch should be in diff (unified diff)
-format. To be used mainly in the ``source()`` method.
+Applies a patch from a file or from a string into the given path. The patch should be in diff (unified diff) format. To be used mainly in
+the ``source()`` method.
 
 .. code-block:: python
 
@@ -574,7 +552,7 @@ format. To be used mainly in the ``source()`` method.
     # to apply in subfolder
     tools.patch(base_path=mysubfolder, patch_string=patch_content)
     
-If the patch to be applied uses alternate paths that have to be stripped, like:
+If the patch to be applied uses alternate paths that have to be stripped like this example:
 
 .. code-block:: diff
 
@@ -584,7 +562,7 @@ If the patch to be applied uses alternate paths that have to be stripped, like:
     - old content
     + new content
 
-Then it can be done specifying the number of folders to be stripped from the path:
+Then, the number of folders to be stripped from the path can be specifyed :
 
 .. code-block:: python
 
@@ -599,7 +577,7 @@ Parameters:
     - **strip** (Optional, Defaulted to ``0``): Number of folders to be stripped from the path.
     - **output** (Optional, Defaulted to ``None``): Stream object.
 
-.. _environment_append_tool:
+.. _tools_environment_append:
 
 tools.environment_append()
 --------------------------
@@ -608,13 +586,12 @@ tools.environment_append()
 
     def environment_append(env_vars)
 
-This is a context manager that allows to temporary use environment variables for a specific piece of code
-in your conanfile:
+This is a context manager that allows to temporary use environment variables for a specific piece of code in your conanfile:
 
 .. code-block:: python
 
     from conans import tools
-    
+
     def build(self):
         with tools.environment_append({"MY_VAR": "3", "CXX": "/path/to/cxx"}):
             do_something()
@@ -650,20 +627,19 @@ tools.pythonpath()
 
 .. warning::
 
-    This way of reusing python code from other recipes can be improved via ``python_requires()``.
-    See this section: :ref:`Python requires: reusing python code in recipes<python_requires>`
+    This way of reusing python code from other recipes can be improved via :ref:`python_requires`.
 
-This tool is automatically applied in the conanfile methods unless :ref:`apply_env<apply_env>` is deactivated, so
-any PYTHONPATH inherited from the requirements will be automatically available.
+This tool is automatically applied in the conanfile methods unless :ref:`apply_env<apply_env>` is deactivated, so any ``PYTHONPATH``
+inherited from the requirements will be automatically available.
 
 .. code-block:: python
 
     def pythonpath(conanfile)
 
-This is a context manager that allows to load the PYTHONPATH for dependent packages, create packages
-with python code, and reuse that code into your own recipes.
+This is a context manager that allows to load the ``PYTHONPATH`` for dependent packages, create packages with Python code and reuse that
+code into your own recipes.
 
-It is automatically applied
+For example:
 
 .. code-block:: python
 
@@ -674,9 +650,7 @@ It is automatically applied
             from module_name import whatever
             whatever.do_something()
 
-
 When the :ref:`apply_env<apply_env>` is activated (default) the above code could be simplified as:
-
 
 .. code-block:: python
 
@@ -686,21 +660,18 @@ When the :ref:`apply_env<apply_env>` is activated (default) the above code could
         from module_name import whatever
         whatever.do_something()
 
-
-For that to work, one of the dependencies of the current recipe, must have a ``module_name``
-file or folder with a ``whatever`` file or object inside, and should have declared in its
-``package_info()``:
+For that to work, one of the dependencies of the current recipe, must have a ``module_name`` file or folder with a ``whatever`` file or
+object inside, and should have declared in its ``package_info()``:
 
 .. code-block:: python
 
     from conans import tools
-    
+
     def package_info(self):
         self.env_info.PYTHONPATH.append(self.package_folder)
 
 Parameters:
     - **conanfile** (Required): Current ``ConanFile`` object.
-
 
 tools.no_op()
 -------------
@@ -727,13 +698,13 @@ tools.human_size()
 
     def human_size(size_bytes)
 
-Will return a string from a given number of bytes, rounding it to the most appropriate unit: GB, MB, KB, etc.
-It is mostly used by the conan downloads and unzip progress, but you can use it if you want too.
+Will return a string from a given number of bytes, rounding it to the most appropriate unit: GB, MB, KB, etc. It is mostly used by the Conan
+downloads and unzip progress.
 
 .. code-block:: python
 
     from conans import tools
-    
+
     tools.human_size(1024)
     >> 1.0KB
 
@@ -756,7 +727,7 @@ tools.cross_building()
 
     def cross_building(settings, self_os=None, self_arch=None)
 
-Reading the settings and the current host machine it returns ``True`` if we are cross building a conan package:
+Reading the settings and the current host machine it returns ``True`` if we are cross building a Conan package:
 
 .. code-block:: python
 
@@ -796,7 +767,7 @@ tools.run_in_windows_bash()
 Runs a UNIX command inside a bash shell. It requires to have "bash" in the path.
 Useful to build libraries using ``configure`` and ``make`` in Windows. Check :ref:`Windows subsytems <windows_subsystems>` section.
 
-You can customize the path of the bash executable using the environment variable ``CONAN_BASH_PATH`` or the :ref:`conan.conf<conan_conf>` ``bash_path``
+You can customize the path of the bash executable using the environment variable ``CONAN_BASH_PATH`` or the :ref:`conan_conf` ``bash_path``
 variable to change the default bash location.
 
 .. code-block:: python
@@ -810,10 +781,12 @@ Parameters:
     - **conanfile** (Required): Current ``ConanFile`` object.
     - **bashcmd** (Required): String with the command to be run.
     - **cwd** (Optional, Defaulted to ``None``): Path to directory where to apply the command from.
-    - **subsystem** (Optional, Defaulted to ``None`` will autodetect the subsystem). Used to escape the command according to the specified subsystem.
-    - **msys_mingw** (Optional, Defaulted to ``True``) If the specified subsystem is MSYS2, will start it in MinGW mode (native windows development).
-    - **env** (Optional, Defaulted to ``None``) You can pass a dict with environment variable to be applied **at first place** so they will have more priority than others.
-
+    - **subsystem** (Optional, Defaulted to ``None`` will autodetect the subsystem). Used to escape the command according to the specified
+      subsystem.
+    - **msys_mingw** (Optional, Defaulted to ``True``) If the specified subsystem is MSYS2, will start it in MinGW mode (native windows
+      development).
+    - **env** (Optional, Defaulted to ``None``) You can pass a dictionary with environment variable to be applied **at first place** so they
+      will have more priority than others.
 
 tools.get_cased_path()
 ----------------------
@@ -822,10 +795,8 @@ tools.get_cased_path()
 
     get_cased_path(abs_path)
 
-
-For Windows, for any ``abs_path`` parameter containing a case-insensitive absolute path, returns it case-sensitive, that is, with the real cased characters.
-Useful when using Windows subsystems where the file system is case-sensitive.
-
+This function converts a case-insensitive absolute path to a case-sensitive one. That is, with the real cased characters. Useful when using
+Windows subsystems where the file system is case-sensitive.
 
 tools.remove_from_path()
 ------------------------
@@ -834,9 +805,8 @@ tools.remove_from_path()
 
     remove_from_path(command)
 
-This is a context manager that allows you to remove a tool from the PATH. Conan will locate the executable
-(using ``tools.which()``) and will remove from the PATH the directory entry that contains it.
-It's not necessary to specify the extension.
+This is a context manager that allows you to remove a tool from the ``PATH``. Conan will locate the executable (using :ref:`which`) and will
+remove from the ``PATH`` the directory entry that contains it. It's not necessary to specify the extension.
 
 .. code-block:: python
 
@@ -845,7 +815,6 @@ It's not necessary to specify the extension.
     with tools.remove_from_path("make"):
         self.run("some command")
 
-
 tools.unix_path()
 -----------------
 
@@ -853,11 +822,12 @@ tools.unix_path()
 
     def unix_path(path, path_flavor=None)
 
-Used to translate Windows paths to MSYS/CYGWIN unix paths like ``c/users/path/to/file``.
+Used to translate Windows paths to MSYS/CYGWIN Unix paths like ``c/users/path/to/file``.
 
 Parameters:
     - **path** (Required): Path to be converted.
-    - **path_flavor** (Optional, Defaulted to ``None``, will try to autodetect the subsystem): Type of unix path to be returned. Options are ``MSYS``, ``MSYS2``, ``CYGWIN``, ``WSL`` and ``SFU``.
+    - **path_flavor** (Optional, Defaulted to ``None``, will try to autodetect the subsystem): Type of Unix path to be returned. Options are
+      ``MSYS``, ``MSYS2``, ``CYGWIN``, ``WSL`` and ``SFU``.
 
 tools.escape_windows_cmd()
 --------------------------
@@ -869,7 +839,7 @@ tools.escape_windows_cmd()
 Useful to escape commands to be executed in a windows bash (msys2, cygwin etc).
 
 - Adds escapes so the argument can be unpacked by ``CommandLineToArgvW()``.
-- Adds escapes for cmd.exe so the argument survives cmd.exe's substitutions.
+- Adds escapes for *cmd.exe* so the argument survives to ``cmd.exe``'s substitutions.
 
 Parameters:
     - **command** (Required): Command to execute.
@@ -883,7 +853,7 @@ tools.sha1sum(), sha256sum(), md5sum()
     def sha1sum(file_path)
     def sha256sum(file_path)
 
-Return the respective hash or checksum for a file:
+Return the respective hash or checksum for a file.
 
 .. code-block:: python
 
@@ -902,7 +872,7 @@ tools.md5()
 
     def md5(content)
 
-Returns the MD5 hash for a string or byte object:
+Returns the MD5 hash for a string or byte object.
 
 .. code-block:: python
 
@@ -920,8 +890,7 @@ tools.save()
 
     def save(path, content, append=False)
 
-Utility function to save files in one line.
-It will manage the open and close of the file and creating directories if necessary.
+Utility function to save files in one line. It will manage the open and close of the file and creating directories if necessary.
 
 .. code-block:: python
 
@@ -941,9 +910,8 @@ tools.load()
 
     def load(path, binary=False)
 
-Utility function to load files in one line.
-It will manage the open and close of the file, and load binary encodings.
-Returns the content of the file.
+Utility function to load files in one line. It will manage the open and close of the file, and load binary encodings. Returns the content of
+the file.
 
 .. code-block:: python
 
@@ -963,12 +931,10 @@ tools.mkdir(), tools.rmdir()
     def mkdir(path)
     def rmdir(path)
 
-Utility functions to create/delete a directory.
-The existence of the specified directory is checked, so ``mkdir()`` will do nothing if the directory
-already exists and ``rmdir()`` will do nothing if the directory does not exists.
+Utility functions to create/delete a directory. The existence of the specified directory is checked, so ``mkdir()`` will do nothing if the
+directory already exists and ``rmdir()`` will do nothing if the directory does not exists.
 
-This makes it safe to use these functions in the ``package()`` method of a ``conanfile.py``
-when ``no_copy_source=True``.
+This makes it safe to use these functions in the ``package()`` method of a *conanfile.py* when ``no_copy_source=True``.
 
 .. code-block:: python
 
@@ -983,6 +949,7 @@ when ``no_copy_source=True``.
 Parameters:
     - **path** (Required): Path to the directory.
 
+.. _which:
 
 tools.which()
 -------------
@@ -1054,11 +1021,10 @@ tools.touch()
 
     def touch(fname, times=None)
 
-Updates the timestamp (last access and last modification times) of a file.
-This is similar to Unix' ``touch`` command, except the command fails if the file does not exist.
+Updates the timestamp (last access and last modification times) of a file. This is similar to Unix' ``touch`` command except that this one
+fails if the file does not exist.
 
-Optionally, a tuple of two numbers can be specified, which denotes the new values for the
-'last access' and 'last modified' times respectively.
+Optionally, a tuple of two numbers can be specified, which denotes the new values for the last access and last modified times respectively.
 
 .. code-block:: python
 
@@ -1080,8 +1046,7 @@ tools.relative_dirs()
 
     def relative_dirs(path)
 
-Recursively walks a given directory (using ``os.walk()``) and returns a list of all contained file paths
-relative to the given directory.
+Recursively walks a given directory (using ``os.walk()``) and returns a list of all contained file paths relative to the given directory.
 
 .. code-block:: python
 
@@ -1092,6 +1057,8 @@ relative to the given directory.
 Parameters:
     - **path** (Required): Path of the directory.
 
+.. _vswhere:
+
 tools.vswhere()
 ---------------
 
@@ -1100,8 +1067,8 @@ tools.vswhere()
     def vswhere(all_=False, prerelease=False, products=None, requires=None, version="",
                 latest=False, legacy=False, property_="", nologo=True)
 
-Wrapper of ``vswhere`` tool to look for details of Visual Studio installations. Its output is always
-a list with a dictionary for each installation found.
+Wrapper of ``vswhere`` tool to look for details of Visual Studio installations. Its output is always a list with a dictionary for each
+installation found.
 
 .. code-block:: python
 
@@ -1115,14 +1082,16 @@ Parameters:
     - **products** (Optional, Defaulted to ``None``): List of one or more product IDs to find. Defaults to Community, Professional, and
       Enterprise. Specify ``["*"]`` by itself to search all product instances installed.
     - **requires** (Optional, Defaulted to ``None``): List of one or more workload or component IDs required when finding instances. See
-      https://docs.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2017 for a list of workload and component IDs.
-    - **version** (Optional, Defaulted to ``""``): A version range for instances to find. Example: ``"[15.0,16.0)"`` will find versions 15.*.
+      https://docs.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2017 listing all workload and component IDs.
+    - **version** (Optional, Defaulted to ``""``): A version range of instances to find. Example: ``"[15.0,16.0)"`` will find versions 15.*.
     - **latest** (Optional, Defaulted to ``False``): Return only the newest version and last installed.
     - **legacy** (Optional, Defaulted to ``False``): Also searches Visual Studio 2015 and older products. Information is limited. This
       option cannot be used with either ``products`` or ``requires`` parameters.
     - **property_** (Optional, Defaulted to ``""``): The name of a property to return. Use delimiters ``.``, ``/``, or ``_`` to separate
       object and property names. Example: ``"properties.nickname"`` will return the "nickname" property under "properties".
     - **nologo** (Optional, Defaulted to ``True``): Do not show logo information.
+
+.. _vs_comntools:
 
 tools.vs_comntools()
 --------------------
@@ -1149,10 +1118,9 @@ tools.vs_installation_path()
 
     def vs_installation_path(version, preference=None)
 
-Returns the Visual Studio installation path for the given version. It uses ``tools.vswhere()`` and
-``tool.vs_comntools()``. It will also look for the installation paths following
-``CONAN_VS_INSTALLATION_PREFERENCE`` environment variable or the preference parameter itself. If the
-tool is not able to return the path it returns ``None``.
+Returns the Visual Studio installation path for the given version. It uses :ref:`vswhere` and :ref:`vs_comntools`. It will also look for the
+installation paths following ``CONAN_VS_INSTALLATION_PREFERENCE`` environment variable or the preference parameter itself. If the tool is
+not able to return the path it will return ``None``.
 
 .. code-block:: python
 
@@ -1161,13 +1129,11 @@ tool is not able to return the path it returns ``None``.
     vs_path_2017 = tools.vs_installation_path("15", preference=["Community", "BuildTools", "Professional", "Enterprise"])
 
 Parameters:
-    - **version** (Required): Visual Studio version to locate. Valid version numbers
-      are strings: ``"10"``, ``"11"``, ``"12"``, ``"13"``, ``"14"``, ``"15"``...
-    - **preference** (Optional, Defaulted to ``None``): Set to value of
-      ``CONAN_VS_INSTALLATION_PREFERENCE`` or defaulted to
-      ``["Enterprise", "Professional", "Community", "BuildTools"]``. If only set to one type of
-      preference, it will return the installation path only for that Visual type and version,
-      otherwise ``None``.
+    - **version** (Required): Visual Studio version to locate. Valid version numbers are strings: ``"10"``, ``"11"``, ``"12"``, ``"13"``,
+      ``"14"``, ``"15"``...
+    - **preference** (Optional, Defaulted to ``None``): Set to value of ``CONAN_VS_INSTALLATION_PREFERENCE`` or defaulted to
+      ``["Enterprise", "Professional", "Community", "BuildTools"]``. If only set to one type of preference, it will return the installation
+      path only for that Visual type and version, otherwise ``None``.
 
 tools.replace_prefix_in_pc_file()
 ---------------------------------
@@ -1176,7 +1142,7 @@ tools.replace_prefix_in_pc_file()
 
     def replace_prefix_in_pc_file(pc_file, new_prefix)
 
-Replaces the ``prefix`` variable in a package config file ``.pc`` with the specified value.
+Replaces the ``prefix`` variable in a package config file *.pc* with the specified value.
 
 .. code-block:: python
 
@@ -1191,7 +1157,7 @@ Replaces the ``prefix`` variable in a package config file ``.pc`` with the speci
 
 .. seealso::
 
-    Check section integrations/:ref:`pkg-config and pc files<pc_files>` to know more.
+    Check section :ref:`pc_files` to know more.
 
 tools.collect_libs()
 --------------------
@@ -1221,9 +1187,8 @@ For UNIX libraries staring with **lib**, like *libmath.a*, this tool will collec
 
 .. warning::
 
-    This tool collects the libraries searching directly inside the package folder and returns them
-    in no specific order. If libraries are inter-dependent, then ``package_info()`` method should order
-    them to achieve correct linking order.
+    This tool collects the libraries searching directly inside the package folder and returns them in no specific order. If libraries are
+    inter-dependent, then ``package_info()`` method should order them to achieve correct linking order.
 
 .. _pkgconfigtool:
 
@@ -1232,9 +1197,7 @@ tools.PkgConfig()
 
 .. code-block:: python
 
-    class PkgConfig(object):
-
-        def __init__(self, library, pkg_config_executable="pkg-config", static=False, msvc_syntax=False, variables=None, print_errors=True)
+    class PkgConfig(library, pkg_config_executable="pkg-config", static=False, msvc_syntax=False, variables=None, print_errors=True)
 
 Wrapper of the ``pkg-config`` tool.
 
@@ -1250,10 +1213,13 @@ Wrapper of the ``pkg-config`` tool.
 
 Parameters of the constructor:
     - **library** (Required): Library (package) name, such as ``libastral``.
-    - **pkg_config_executable** (Optional, Defaulted to ``"pkg-config"``): Specify custom pkg-config executable (e.g., for cross-compilation).
-    - **static** (Optional, Defaulted to ``False``): Output libraries suitable for static linking (adds ``--static`` to ``pkg-config`` command line).
+    - **pkg_config_executable** (Optional, Defaulted to ``"pkg-config"``): Specify custom pkg-config executable (e.g., for
+      cross-compilation).
+    - **static** (Optional, Defaulted to ``False``): Output libraries suitable for static linking (adds ``--static`` to ``pkg-config``
+      command line).
     - **msvc_syntax** (Optional, Defaulted to ``False``): MSVC compatibility (adds ``--msvc-syntax`` to ``pkg-config`` command line).
-    - **variables** (Optional, Defaulted to ``None``): Dictionary of pkg-config variables (passed as ``--define-variable=VARIABLENAME=VARIABLEVALUE``).
+    - **variables** (Optional, Defaulted to ``None``): Dictionary of pkg-config variables (passed as
+      ``--define-variable=VARIABLENAME=VARIABLEVALUE``).
     - **print_errors** (Optional, Defaulted to ``True``): Output error messages (adds --print-errors)
 
 **Properties:**
@@ -1291,50 +1257,38 @@ tools.Git()
 
 .. code-block:: python
 
-    class Git(object):
-
-        def __init__(self, folder=None, verify_ssl=True, username=None, password=None,
-                     force_english=True, runner=None):
+    class Git(folder=None, verify_ssl=True, username=None, password=None,
+              force_english=True, runner=None):
 
 Wrapper of the ``git`` tool.
 
 Parameters of the constructor:
-
-    - **folder** (Optional, Defaulted to ``None``): Specify a subfolder where the code will be cloned. If not specified it will clone in the current directory.
+    - **folder** (Optional, Defaulted to ``None``): Specify a subfolder where the code will be cloned. If not specified it will clone in the
+      current directory.
     - **verify_ssl** (Optional, Defaulted to ``True``): Verify SSL certificate of the specified **url**.
     - **username** (Optional, Defaulted to ``None``): When present, it will be used as the login to authenticate with the remote.
     - **password** (Optional, Defaulted to ``None``): When present, it will be used as the password to authenticate with the remote.
-    - **force_english** (Optional, Defaulted to ``True``): The encoding of the tool will be forced to use ``en_US.UTF-8`` to ease the output parsing.
+    - **force_english** (Optional, Defaulted to ``True``): The encoding of the tool will be forced to use ``en_US.UTF-8`` to ease the output
+      parsing.
     - **runner** (Optional, Defaulted to ``None``): By default ``subprocess.check_output`` will be used to invoke the ``git`` tool.
 
 Methods:
-
-- **run(command)**:
-    Run any "git" command, e.g., ``run("status")``
-- **get_url_with_credentials(url)**:
-    Returns the passed url but containing the ``username`` and ``password`` in the URL to authenticate (only if ``username`` and ``password`` is specified)
-- **clone(url, branch=None)**:
-    Clone a repository. Optionally you can specify a branch. Note: If you want to clone a repository and the specified **folder** already exist you have to specify a ``branch``.
-- **checkout(element, submodule=None)**:
-    Checkout a branch, commit or tag given by ``element``. Argument ``submodule`` can get values in
-    ``shallow`` or ``recursive`` to instruct what to do with submodules.
-- **get_remote_url(remote_name=None)**:
-    Returns the remote url of the specified remote. If not ``remote_name`` is specified ``origin`` will be used.
-- **get_qualified_remote_url()**:
-    Returns the remote url (see ``get_remote_url()``) but with forward slashes if it is a local folder.
-- **get_revision(), get_commit()**:
-    Gets the current commit hash.
-- **get_branch()**:
-    Gets the current branch.
-- **excluded_files()**:
-    Gets a list of the files and folders that would be excluded by *.gitignore* file.
-- **is_local_repository()**:
-    Returns `True` if the remote is a local folder.
-- **is_pristine()**:
-    Returns `True` if there aren't modified or uncommitted files in the working copy.
-- **get_repo_root()**:
-    Returns the root folder of the working copy.
-
+    - **run(command)**: Run any "git" command, e.g., ``run("status")``
+    - **get_url_with_credentials(url)**: Returns the passed URL but containing the ``username`` and ``password`` in the URL to authenticate
+      (only if ``username`` and ``password`` is specified)
+    - **clone(url, branch=None)**: Clone a repository. Optionally you can specify a branch. Note: If you want to clone a repository and the
+      specified **folder** already exist you have to specify a ``branch``.
+    - **checkout(element, submodule=None)**: Checkout a branch, commit or tag given by ``element``. Argument ``submodule`` can get values in
+      ``shallow`` or ``recursive`` to instruct what to do with submodules.
+    - **get_remote_url(remote_name=None)**: Returns the remote URL of the specified remote. If not ``remote_name`` is specified ``origin``
+      will be used.
+    - **get_qualified_remote_url()**: Returns the remote url (see ``get_remote_url()``) but with forward slashes if it is a local folder.
+    - **get_revision(), get_commit()**: Gets the current commit hash.
+    - **get_branch()**: Gets the current branch.
+    - **excluded_files()**: Gets a list of the files and folders that would be excluded by *.gitignore* file.
+    - **is_local_repository()**: Returns `True` if the remote is a local folder.
+    - **is_pristine()**: Returns `True` if there aren't modified or uncommitted files in the working copy.
+    - **get_repo_root()**: Returns the root folder of the working copy.
 
 .. _tools_svn:
 
@@ -1343,66 +1297,47 @@ tools.SVN()
 
 .. code-block:: python
 
-    class SVN(object):
-
-        def __init__(self, folder=None, verify_ssl=True, username=None, password=None,
-                     force_english=True, runner=None):
+    class SVN(folder=None, verify_ssl=True, username=None, password=None,
+              force_english=True, runner=None):
 
 Wrapper of the ``svn`` tool.
 
 Parameters of the constructor:
-
-    - **folder** (Optional, Defaulted to ``None``): Specify a subfolder where the code will be cloned. If not specified it will clone in the current directory.
+    - **folder** (Optional, Defaulted to ``None``): Specify a subfolder where the code will be cloned. If not specified it will clone in the
+      current directory.
     - **verify_ssl** (Optional, Defaulted to ``True``): Verify SSL certificate of the specified **url**.
     - **username** (Optional, Defaulted to ``None``): When present, it will be used as the login to authenticate with the remote.
     - **password** (Optional, Defaulted to ``None``): When present, it will be used as the password to authenticate with the remote.
-    - **force_english** (Optional, Defaulted to ``True``): The encoding of the tool will be forced to use ``en_US.UTF-8`` to ease the output parsing.
+    - **force_english** (Optional, Defaulted to ``True``): The encoding of the tool will be forced to use ``en_US.UTF-8`` to ease the output
+      parsing.
     - **runner** (Optional, Defaulted to ``None``): By default ``subprocess.check_output`` will be used to invoke the ``svn`` tool.
 
 Methods:
-
-- **version()**:
-    Retrieve version from the installed SVN client.
-- **run(command)**:
-    Run any "svn" command, e.g., ``run("status")``
-- **get_url_with_credentials(url)**:
-    Return the passed url but containing the ``username`` and ``password`` in the URL to authenticate (only if ``username`` and ``password`` is specified)
-- **checkout(url, revision="HEAD")**:
-    Checkout the revision number given by ``revision`` from the specified ``url``.
-- **update(revision="HEAD")**:
-    Update working copy to revision number given by ``revision``.
-- **get_remote_url()**:
-    Returns the remote url of working copy.
-- **get_qualified_remote_url()**:
-    Returns the remote url of the working copy with the
-    `peg revision <http://svnbook.red-bean.com/en/1.7/svn.advanced.pegrevs.html>`_ appended to it.
-- **get_revision()**:
-    Gets the current revision number from the repo server.
-- **get_last_changed_revision(use_wc_root=True)**:
-    Returns the revision number corresponding to the last changed item in the working folder
-    (``use_wc_root=False``) or in the working copy root (``use_wc_root=True``).
-- **get_branch()**:
-    Tries to deduce the branch name from the
-    `standard SVN layout <http://svnbook.red-bean.com/en/1.7/svn.branchmerge.maint.html>`_. Will
-    raise if cannot resolve it.
-- **excluded_files()**:
-    Gets a list of the files and folders that are marked to be ignored.
-- **is_local_repository()**:
-    Returns `True` if the remote is a local folder.
-- **is_pristine()**:
-    Returns `True` if there aren't modified or uncommitted files in the working copy.
-- **get_repo_root()**:
-    Returns the root folder of the working copy.
+    - **version()**: Retrieve version from the installed SVN client.
+    - **run(command)**: Run any "svn" command, e.g., ``run("status")``
+    - **get_url_with_credentials(url)**: Return the passed url but containing the ``username`` and ``password`` in the URL to authenticate
+      (only if ``username`` and ``password`` is specified)
+    - **checkout(url, revision="HEAD")**: Checkout the revision number given by ``revision`` from the specified ``url``.
+    - **update(revision="HEAD")**: Update working copy to revision number given by ``revision``.
+    - **get_remote_url()**: Returns the remote url of working copy.
+    - **get_qualified_remote_url()**: Returns the remote url of the working copy with the
+      `peg revision <http://svnbook.red-bean.com/en/1.7/svn.advanced.pegrevs.html>`_ appended to it.
+    - **get_revision()**: Gets the current revision number from the repo server.
+    - **get_last_changed_revision(use_wc_root=True)**: Returns the revision number corresponding to the last changed item in the working
+      folder (``use_wc_root=False``) or in the working copy root (``use_wc_root=True``).
+    - **get_branch()**: Tries to deduce the branch name from the
+      `standard SVN layout <http://svnbook.red-bean.com/en/1.7/svn.branchmerge.maint.html>`_. Will raise if cannot resolve it.
+    - **excluded_files()**: Gets a list of the files and folders that are marked to be ignored.
+    - **is_local_repository()**: Returns `True` if the remote is a local folder.
+    - **is_pristine()**: Returns `True` if there aren't modified or uncommitted files in the working copy.
+    - **get_repo_root()**: Returns the root folder of the working copy.
 
 .. warning::
 
-    SVN allows to checkout a subdirectory of the remote repository, take into account that the
-    return value of some of these functions may depend on the root of the working copy that has been
-    checked out.
-
+    SVN allows to checkout a subdirectory of the remote repository, take into account that the return value of some of these functions may
+    depend on the root of the working copy that has been checked out.
 
 .. _tools_apple:
-
 
 tools.is_apple_os()
 -------------------
@@ -1415,7 +1350,6 @@ Returns ``True`` if OS is an Apple one: macOS, iOS, watchOS or tvOS.
 
 Parameters:
     - **os_** (Required): OS to perform the check. Usually this would be ``self.settings.os``.
-
 
 tools.to_apple_arch()
 ---------------------
@@ -1440,7 +1374,6 @@ Returns proper SDK name suitable for OS and architecture you are building for (c
 
 Parameters:
     - **settings** (Required): Conanfile settings.
-
 
 tools.apple_deployment_target_env()
 -----------------------------------
@@ -1500,7 +1433,6 @@ tools.latest_vs_version_installed()
 
 Returns a string with the major version of latest Microsoft Visual Studio available on machine. If no Microsoft Visual Studio installed,
 it returns ``None``.
-
 
 tools.apple_dot_clean()
 -----------------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1393,7 +1393,7 @@ Methods:
     SVN allows to checkout a subdirectory of the remote repository, take into account that the return value of some of these functions may
     depend on the root of the working copy that has been checked out.
 
-.. _tools_apple:
+.. _tools_is_apple_os:
 
 tools.is_apple_os()
 -------------------
@@ -1407,6 +1407,8 @@ Returns ``True`` if OS is an Apple one: macOS, iOS, watchOS or tvOS.
 Parameters:
     - **os_** (Required): OS to perform the check. Usually this would be ``self.settings.os``.
 
+.. _tools_to_apple_arch:
+
 tools.to_apple_arch()
 ---------------------
 
@@ -1414,10 +1416,12 @@ tools.to_apple_arch()
 
     def to_apple_arch(arch)
 
-Converts conan-style architecture into Apple-style architecture.
+Converts Conan style architecture into Apple style architecture.
 
 Parameters:
     - **arch** (Required): arch to perform the conversion. Usually this would be ``self.settings.arch``.
+
+.. _tools_apple_sdk_name:
 
 tools.apple_sdk_name()
 ----------------------
@@ -1430,6 +1434,9 @@ Returns proper SDK name suitable for OS and architecture you are building for (c
 
 Parameters:
     - **settings** (Required): Conanfile settings.
+
+
+.. _tools_apple_deployment_target_env:
 
 tools.apple_deployment_target_env()
 -----------------------------------
@@ -1445,6 +1452,8 @@ Parameters:
     - **os_** (Required): OS of the settings. Usually ``self.settings.os``.
     - **os_version** (Required): OS version.
 
+.. _tools_apple_deployment_target_flag:
+
 tools.apple_deployment_target_flag()
 ------------------------------------
 
@@ -1457,6 +1466,8 @@ Compiler flag name which controls deployment target. For example: ``-mappletvos-
 Parameters:
     - **os_** (Required): OS of the settings. Usually ``self.settings.os``.
     - **os_version** (Required): OS version.
+
+.. _tools_xcrun:
 
 tools.XCRun()
 -------------
@@ -1480,6 +1491,8 @@ Properties:
     - **ranlib**: Path to archive indexer (RANLIB).
     - **strip**: Path to symbol removal utility (STRIP).
 
+.. _tools_latest_vs_version_installed:
+
 tools.latest_vs_version_installed()
 -----------------------------------
 
@@ -1489,6 +1502,8 @@ tools.latest_vs_version_installed()
 
 Returns a string with the major version of latest Microsoft Visual Studio available on machine. If no Microsoft Visual Studio installed,
 it returns ``None``.
+
+.. _tools.apple_dot_clean:
 
 tools.apple_dot_clean()
 -----------------------

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -166,8 +166,8 @@ Parameters:
     - **sln_path** (Required):  Visual Studio project file path.
     - **targets** (Optional, Defaulted to ``None``):  List of targets to build.
     - **upgrade_project** (Optional, Defaulted to ``True``): If ``True``, the project file will be upgraded if the project's VS version is
-      older than current. When :ref:`CONAN_SKIP_VS_PROJECTS_UPGRADE<env_var_conan_skip_vs_project_upgrade>` environment variable is set to
-      ``True``/``1``, this parameter will be ignored and the project won't be upgraded.
+      older than current. When :ref:`env_vars_conan_skip_vs_project_upgrade` environment variable is set to ``True``/``1``, this parameter
+      will be ignored and the project won't be upgraded.
     - **build_type** (Optional, Defaulted to ``None``): Override the build type defined in the settings (``settings.build_type``).
     - **arch** (Optional, Defaulted to ``None``): Override the architecture defined in the settings (``settings.arch``).
     - **parallel** (Optional, Defaulted to ``True``): Enables Visual Studio parallel build with ``/m:X`` argument, where X is defined by

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -31,7 +31,7 @@ tools.cpu_count()
 Returns the number of CPUs available, for parallel builds. If processor detection is not enabled, it will safely return 1. Can be
 overwritten with the environment variable ``CONAN_CPU_COUNT`` and configured in the :ref:`conan_conf`.
 
-.. _vcvars_command:
+.. _tools_vcvars_command:
 
 tools.vcvars_command()
 ----------------------
@@ -88,9 +88,10 @@ tools.vcvars_dict()
     vcvars_dict(settings, arch=None, compiler_version=None, force=False, filter_known_paths=False,
                 vcvars_ver=None, winsdk_version=None, only_diff=True)
 
-Returns a dictionary with the variables set by the :ref:`vcvars_command` that can be directly applied to :ref:`tools_environment_append`.
+Returns a dictionary with the variables set by the :ref:`tools_vcvars_command` that can be directly applied to
+:ref:`tools_environment_append`.
 
-The values of the variables ``INCLUDE``,  ``LIB``, ``LIBPATH`` and ``PATH`` will be returned as a list. When used with
+The values of the variables ``INCLUDE``, ``LIB``, ``LIBPATH`` and ``PATH`` will be returned as a list. When used with
 :ref:`tools_environment_append`, the previous environment values that these variables may have will be appended automatically.
 
 .. code-block:: python
@@ -103,7 +104,7 @@ The values of the variables ``INCLUDE``,  ``LIB``, ``LIBPATH`` and ``PATH`` will
             # Do something
 
 Parameters:
-    - Same as :ref:`vcvars_command`.
+    - Same as :ref:`tools_vcvars_command`.
     - **filter_known_paths** (Optional, Defaulted to ``False``): When True, the function will only keep the ``PATH`` entries that follows
       some known patterns, filtering all the non-Visual Studio ones. When False, it will keep the ``PATH`` will all the system entries.
     - **only_diff** (Optional, Defaulted to ``True``): When True, the command will return only the variables set by ``vcvarsall`` and not
@@ -122,7 +123,7 @@ tools.vcvars()
     This context manager tool has no effect if used in a platform different from Windows.
 
 This is a context manager that allows to append to the environment all the variables set by the :ref:`vcvars_dict`. You can replace
-:ref:`vcvars_command` and use this context manager to get a cleaner way to activate the Visual Studio environment:
+:ref:`tools_vcvars_command` and use this context manager to get a cleaner way to activate the Visual Studio environment:
 
 .. code-block:: python
 
@@ -146,8 +147,8 @@ tools.build_sln_command() [DEPRECATED]
     def build_sln_command(settings, sln_path, targets=None, upgrade_project=True, build_type=None,
                           arch=None, parallel=True, toolset=None, platforms=None)
 
-Returns the command to call `devenv` and `msbuild` to build a Visual Studio project. It's recommended to use it with :ref:`vcvars_command`,
-so that the Visual Studio tools will be in path.
+Returns the command to call `devenv` and `msbuild` to build a Visual Studio project. It's recommended to use it with
+:ref:`tools_vcvars_command`, so that the Visual Studio tools will be in path.
 
 .. code-block:: python
 
@@ -196,7 +197,7 @@ tools.msvc_build_command() [DEPRECATED]
                            arch=None, parallel=True, force_vcvars=False, toolset=None, platforms=None)
 
 Returns a string with a joint command consisting in setting the environment variables via ``vcvars.bat`` with the above
-:ref:`vcvars_command` function, and building a Visual Studio project with the ``tools.build_sln_command()`` function.
+:ref:`tools_vcvars_command` function, and building a Visual Studio project with the ``tools.build_sln_command()`` function.
 
 Parameters:
     - Same parameters as the above :ref:`build_sln_command`.

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -111,6 +111,8 @@ Parameters:
       the whole environment. If `vcvars` modifies an environment variable by appending values to the old value (separated by ``;``), only
       the new values will be returned, as a list.
 
+.. tools_vcvars:
+
 tools.vcvars()
 --------------
 
@@ -133,7 +135,7 @@ This is a context manager that allows to append to the environment all the varia
         with tools.vcvars(self.settings):
             do_something()
 
-.. _build_sln_command:
+.. _tools_build_sln_command:
 
 tools.build_sln_command() [DEPRECATED]
 --------------------------------------
@@ -197,10 +199,10 @@ tools.msvc_build_command() [DEPRECATED]
                            arch=None, parallel=True, force_vcvars=False, toolset=None, platforms=None)
 
 Returns a string with a joint command consisting in setting the environment variables via ``vcvars.bat`` with the above
-:ref:`tools_vcvars_command` function, and building a Visual Studio project with the ``tools.build_sln_command()`` function.
+:ref:`tools_vcvars_command` function, and building a Visual Studio project with the :ref:`tools_build_sln_command` function.
 
 Parameters:
-    - Same parameters as the above :ref:`build_sln_command`.
+    - Same parameters as the above :ref:`tools_build_sln_command`.
     - **force_vcvars**: Optional. Defaulted to False. Will set ``tools.vcvars_command(force=force_vcvars)``.
 
 .. _tools_unzip:

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -78,7 +78,7 @@ Parameters:
     When cross-building from x64 to x86 the toolchain by default is ``x86``. If you want to use ``amd64_x86`` instead, set the environment
     variable ``PreferredToolArchitecture=x64``.
 
-.. _vcvars_dict:
+.. _tools_vcvars_dict:
 
 tools.vcvars_dict()
 -------------------
@@ -122,7 +122,7 @@ tools.vcvars()
 
     This context manager tool has no effect if used in a platform different from Windows.
 
-This is a context manager that allows to append to the environment all the variables set by the :ref:`vcvars_dict`. You can replace
+This is a context manager that allows to append to the environment all the variables set by the :ref:`tools_vcvars_dict`. You can replace
 :ref:`tools_vcvars_command` and use this context manager to get a cleaner way to activate the Visual Studio environment:
 
 .. code-block:: python

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -104,8 +104,8 @@ The values of the variables ``INCLUDE``,  ``LIB``, ``LIBPATH`` and ``PATH`` will
 
 Parameters:
     - Same as :ref:`vcvars_command`.
-    - **filter_known_paths** (Optional, Defaulted to ``False``): When True, the function will only keep the PATH entries that follows some
-      known patterns, filtering all the non-Visual Studio ones. When False, it will keep the PATH will all the system entries.
+    - **filter_known_paths** (Optional, Defaulted to ``False``): When True, the function will only keep the ``PATH`` entries that follows
+      some known patterns, filtering all the non-Visual Studio ones. When False, it will keep the ``PATH`` will all the system entries.
     - **only_diff** (Optional, Defaulted to ``True``): When True, the command will return only the variables set by ``vcvarsall`` and not
       the whole environment. If `vcvars` modifies an environment variable by appending values to the old value (separated by ``;``), only
       the new values will be returned, as a list.

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -19,7 +19,7 @@ Under the tools module there are several functions and utilities that can be use
     class ExampleConan(ConanFile):
         ...
 
-.. _cpu_count:
+.. _tools_cpu_count:
 
 tools.cpu_count()
 -----------------

--- a/systems_cross_building/windows_subsystems.rst
+++ b/systems_cross_building/windows_subsystems.rst
@@ -41,7 +41,7 @@ self.run()
 __________
 
 In a Conan recipe, you can use the ``self.run`` method specifying the parameter ``win_bash=True``
-that will call automatically to the tool :ref:`tools.run_in_windows_bash<run_in_windows_bash_tool>`.
+that will call automatically to the tool :ref:`tools.run_in_windows_bash<tools_run_in_windows_bash>`.
 
 It will use the **bash** in the path or the **bash** specified for the environment variable :ref:`CONAN_BASH_PATH<conan_bash_path_env>`
 to run the specified command.


### PR DESCRIPTION
This PR does not modify the content of any section in the docs.

Tasks done:

- Fromatting: Line lenght, text style and casing
- Hyperlinks for every entry in now starting with **tools_**
- Environment variables hyperlinks also renamed starting with **env_vars_**
- Cross-reference to environment variables
- Use of hyperlinks in the rest of the documentation to avoid writing titles again:
  Instead of using
  ```
  :ref:`tools.cpu_count()<tools_cpu_count>`
  ```
  now it is
  ```
  :ref:`tools_cpu_count`
  ```

⚠️ ❗️  Please remember to merge this PR to **develop** too once it is merged to avoid last minute conflicts in the next release