### PR TITLE
updated the INCLUDE and LIB variables

### DIFF
--- a/integrations/make.rst
+++ b/integrations/make.rst
@@ -84,9 +84,9 @@ In order to use this generator within your project, use the following Makefile a
 
     CFLAGS          += $(CONAN_CFLAGS)
     CXXFLAGS        += $(CONAN_CXXFLAGS)
-    CPPFLAGS        += $(addprefix -I, $(CONAN_INCLUDE_DIRS))
+    CPPFLAGS        += $(addprefix -I, $(CONAN_INCLUDE_PATHS))
     CPPFLAGS        += $(addprefix -D, $(CONAN_DEFINES))
-    LDFLAGS         += $(addprefix -L, $(CONAN_LIB_DIRS))
+    LDFLAGS         += $(addprefix -L, $(CONAN_LIB_PATHS))
     LDLIBS          += $(addprefix -l, $(CONAN_LIBS))
 
 


### PR DESCRIPTION
conanbuildinfo.mak  generated different INCLUDE and LIB variables (_PATHS) than the example had (_DIRS)