### PR TITLE
conan-io/conan#4265 Revert default cmake gen on Windows

### DIFF
--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -421,3 +421,9 @@ The following example of ``conanfile.py`` shows you how to manage a project with
     def package(self):
         cmake = self.configure_cmake()
         cmake.install()
+
+Default used generators
+-----------------------
+
+When a compiler or its version is not detected, the CMake helper uses a default generator based on the platform operating system.
+For Unix systems it generates ``Unix Makefiles``. For Windows there is no default generator, it will be detected by CMake automatically.

--- a/reference/generators/cmake.rst
+++ b/reference/generators/cmake.rst
@@ -188,9 +188,3 @@ These targets are:
   targets from its ``requires``)
 - Each ``CONAN_LIB`` depends on the direct public dependencies ``CONAN_PKG`` targets of its container package. This guarantees
   correct link order.
-
-Default used generators
------------------------
-
-When a compiler or its version is not detected, the CMake helper uses a default generator based on the platform operating system.
-For Unix systems it generates ``Unix Makefiles``. For Windows there is no default generator, it will be detected by CMake automatically.

--- a/reference/generators/cmake.rst
+++ b/reference/generators/cmake.rst
@@ -193,4 +193,4 @@ Default used generators
 -----------------------
 
 When a compiler or its version is not detected, the CMake helper uses a default generator based on the platform operating system.
-For Windows it generates ``MinGW Makefiles``, otherwise it will generate ``Unix Makefiles``.
+For Unix systems it generates ``Unix Makefiles``. For Windows there is no default generator, it will be detected by CMake automatically.


### PR DESCRIPTION
Related PR: https://github.com/conan-io/conan/pull/4509

Hi!

This PR reverts the documentation about default CMake generator on Windows.