### PR TITLE
Missing import tools in autotools build helper

### DIFF
--- a/reference/build_helpers/autotools.rst
+++ b/reference/build_helpers/autotools.rst
@@ -30,7 +30,7 @@ calling `configure` and `make` manually:
 
 .. code-block:: python
 
-    from conans import ConanFile, AutoToolsBuildEnvironment
+    from conans import ConanFile, AutoToolsBuildEnvironment, tools
 
     class ExampleConan(ConanFile):
         ...


### PR DESCRIPTION
closes #1071 