### PR TITLE
All references to cpp_info.cppflags are being changed to cxxflags

### DIFF
--- a/integrations/other.rst
+++ b/integrations/other.rst
@@ -180,7 +180,7 @@ and much more reusable to create a generator to simplify the task for your build
          print(self.deps_cpp_info.libs)
          print(self.deps_cpp_info.defines)
          print(self.deps_cpp_info.cflags)
-         print(self.deps_cpp_info.cppflags)
+         print(self.deps_cpp_info.cxxflags)
          print(self.deps_cpp_info.sharedlinkflags)
          print(self.deps_cpp_info.exelinkflags)
    
@@ -192,7 +192,7 @@ and much more reusable to create a generator to simplify the task for your build
          print(self.deps_cpp_info["OpenSSL"].libs)
          print(self.deps_cpp_info["OpenSSL"].defines)
          print(self.deps_cpp_info["OpenSSL"].cflags)
-         print(self.deps_cpp_info["OpenSSL"].cppflags)
+         print(self.deps_cpp_info["OpenSSL"].cxxflags)
          print(self.deps_cpp_info["OpenSSL"].sharedlinkflags)
          print(self.deps_cpp_info["OpenSSL"].exelinkflags)
    
@@ -204,7 +204,7 @@ and much more reusable to create a generator to simplify the task for your build
          print(self.deps_cpp_info["Poco"].libs)
          print(self.deps_cpp_info["Poco"].defines)
          print(self.deps_cpp_info["Poco"].cflags)
-         print(self.deps_cpp_info["Poco"].cppflags)
+         print(self.deps_cpp_info["Poco"].cxxflags)
          print(self.deps_cpp_info["Poco"].sharedlinkflags)
          print(self.deps_cpp_info["Poco"].exelinkflags)
    

--- a/reference/build_helpers/visual_studio.rst
+++ b/reference/build_helpers/visual_studio.rst
@@ -262,7 +262,7 @@ List with flags from requirements' ``cpp_info.cflags``.
 cxx_flags
 +++++++++
 
-List with cxx flags from requirements' ``cpp_info.cppflags``.
+List with cxx flags from requirements' ``cpp_info.cxxflags``.
 
 link_flags
 ++++++++++

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -817,7 +817,7 @@ This object should be filled in ``package_info()`` method.
 +--------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.cflags           | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                             |
 +--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cppflags         | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
+| self.cpp_info.cxxflags         | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
 +--------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.sharedlinkflags  | Ordered list with linker flags (shared libs). Defaulted to ``[]`` (empty)                               |
 +--------------------------------+---------------------------------------------------------------------------------------------------------+

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -817,6 +817,8 @@ This object should be filled in ``package_info()`` method.
 +--------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.cflags           | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                             |
 +--------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cppflags         | [DEPRECATED: use cxxflags instead]                                                                      |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.cxxflags         | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
 +--------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.sharedlinkflags  | Ordered list with linker flags (shared libs). Defaulted to ``[]`` (empty)                               |

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -209,7 +209,7 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
     self.cpp_info.srcdirs = []  # Directories where sources can be found (debugging, reusing sources)
     self.cpp_info.defines = []  # preprocessor definitions
     self.cpp_info.cflags = []  # pure C flags
-    self.cpp_info.cppflags = []  # C++ compilation flags
+    self.cpp_info.cxxflags = []  # C++ compilation flags
     self.cpp_info.sharedlinkflags = []  # linker flags
     self.cpp_info.exelinkflags = []  # linker flags
 
@@ -237,7 +237,7 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
   them in other packages too).
 - **defines**: Ordered list of preprocessor directives. It is common that the consumers have to specify some sort of defines in some cases,
   so that including the library headers matches the binaries:
-- **cflags**, **cppflags**, **sharedlinkflags**, **exelinkflags**: List of flags that the consumer should activate for proper behavior.
+- **cflags**, **cxxflags**, **sharedlinkflags**, **exelinkflags**: List of flags that the consumer should activate for proper behavior.
   Usage of C++11 could be configured here, for example, although it is true that the consumer may want to do some flag processing to check
   if different dependencies are setting incompatible flags (c++11 after c++14).
 
@@ -249,7 +249,7 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
         self.cpp_info.defines = ["ZMQ_STATIC"]
 
         if not self.settings.os == "Windows":
-            self.cpp_info.cppflags = ["-pthread"]
+            self.cpp_info.cxxflags = ["-pthread"]
 
 Note that due to the way that some build systems, like CMake, manage forward and back slashes, it might
 be more robust passing flags for Visual Studio compiler with dash instead. Using ``"/NODEFAULTLIB:MSVCRT"``,

--- a/reference/generators/compiler_args.rst
+++ b/reference/generators/compiler_args.rst
@@ -66,7 +66,7 @@ You can use the **compiler_args** generator directly to build simple programs:
 +--------------------------------+----------------------------------------------------------------------+
 | -D_GLIBCXX_USE_CXX11_ABI=1     | When setting libcxx == "libstdc++11"                                 |
 +--------------------------------+----------------------------------------------------------------------+
-| Other flags                    | cppflags, cflags, sharedlinkflags, exelinkflags (applied directly)   |
+| Other flags                    | cxxflags, cflags, sharedlinkflags, exelinkflags (applied directly)   |
 +--------------------------------+----------------------------------------------------------------------+
 
 

--- a/reference/generators/make.rst
+++ b/reference/generators/make.rst
@@ -81,7 +81,7 @@ according to the dependency tree.
 
 .. important::
 
-    Note that the mapping of the Conan variables to the Make ones is done taking the following rules into account and we suggest to use the
+    Note that the mapping of the Conan variables to the Make ones is done taking the following rules and we suggest to use the
     variables indicated under the *Makefile* column to apply to a common naming:
 
     +--------------+----------------------+------------+
@@ -97,5 +97,5 @@ according to the dependency tree.
     +--------------+----------------------+------------+
     | cflags       | CONAN_CFLAGS         | CFLAGS     |
     +--------------+----------------------+------------+
-    | cppflags     | CONAN_CXXFLAGS       | CXXFLAGS   |
+    | cxxflags     | CONAN_CXXFLAGS       | CXXFLAGS   |
     +--------------+----------------------+------------+


### PR DESCRIPTION
Docs for https://github.com/conan-io/conan/pull/4611

As we are deprecating member `cppflags` of `CppInfo` in favor of `cxxflags` all the references to it should be changed.