### PR TITLE
 Refactorize and complete cmake generator section

### DIFF
--- a/reference/config_files/conan.conf.rst
+++ b/reference/config_files/conan.conf.rst
@@ -36,7 +36,7 @@ The typical location of the **conan.conf** file is the directory ``~/.conan/``:
     # conan_cmake_program = cmake         # environment CONAN_CMAKE_PROGRAM (overrides the make program used in CMake.cmake_program)
 
     # cmake_generator                     # environment CONAN_CMAKE_GENERATOR
-    # http://www.vtk.org/Wiki/CMake_Cross_Compiling
+    # https://vtk.org/Wiki/CMake_Cross_Compiling
     # cmake_toolchain_file                # environment CONAN_CMAKE_TOOLCHAIN_FILE
     # cmake_system_name                   # environment CONAN_CMAKE_SYSTEM_NAME
     # cmake_system_version                # environment CONAN_CMAKE_SYSTEM_VERSION

--- a/reference/generators/cmake.rst
+++ b/reference/generators/cmake.rst
@@ -1,190 +1,220 @@
 .. _cmake_generator:
 
-
-`cmake`
-=======
+cmake
+=====
 
 .. container:: out_reference_box
 
     This is the reference page for ``cmake`` generator.
     Go to :ref:`Integrations/CMake<cmake>` if you want to learn how to integrate your project or recipes with CMake.
 
-
-It generates a file named ``conanbuildinfo.cmake`` and declares some variables and methods
+It generates a file named *conanbuildinfo.cmake* and declares some variables and methods.
 
 .. _conanbuildinfocmake_variables:
 
-Variables in conanbuildinfo.cmake
----------------------------------
+Variables in *conanbuildinfo.cmake*
+-----------------------------------
 
-- **Package declared vars**
+- **Package declared variables**:
 
-For each requirement ``conanbuildinfo.cmake`` file declares the following variables.
-``XXX`` is the name of the require in uppercase. e.k "ZLIB" for ``zlib/1.2.8@lasote/stable`` requirement:
+  For each requirement *conanbuildinfo.cmake* file declares the following variables. ``XXX`` is the name of the require in uppercase. e.g.
+  "ZLIB" for ``zlib/1.2.8@lasote/stable`` requirement:
 
-+--------------------------------+----------------------------------------------------------------------+
-| NAME                           | VALUE                                                                |
-+================================+======================================================================+
-| CONAN_XXX_ROOT                 | Abs path to root package folder.                                     |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_INCLUDE_DIRS_XXX         | Header's folders                                                     |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_LIB_DIRS_XXX             | Library folders  (default {CONAN_XXX_ROOT}/lib)                      |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_BIN_DIRS_XXX             | Binary folders  (default {CONAN_XXX_ROOT}/bin)                       |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_SRC_DIRS_XXX             | Sources folders                                                      |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_LIBS_XXX                 | Library names to link                                                |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_DEFINES_XXX              | Library defines                                                      |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_COMPILE_DEFINITIONS_XXX  | Compile definitions                                                  |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_CXX_FLAGS_XXX            | CXX flags                                                            |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_SHARED_LINK_FLAGS_XXX    | Shared link flags                                                    |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_C_FLAGS_XXX              | C flags                                                              |
-+--------------------------------+----------------------------------------------------------------------+
+  +--------------------------------+----------------------------------------------------------------------+
+  | NAME                           | VALUE                                                                |
+  +================================+======================================================================+
+  | CONAN_XXX_ROOT                 | Abs path to root package folder.                                     |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_INCLUDE_DIRS_XXX         | Header's folders                                                     |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_LIB_DIRS_XXX             | Library folders  (default {CONAN_XXX_ROOT}/lib)                      |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_BIN_DIRS_XXX             | Binary folders  (default {CONAN_XXX_ROOT}/bin)                       |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_SRC_DIRS_XXX             | Sources folders                                                      |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_LIBS_XXX                 | Library names to link                                                |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_DEFINES_XXX              | Library defines                                                      |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_COMPILE_DEFINITIONS_XXX  | Compile definitions                                                  |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_CXX_FLAGS_XXX            | CXX flags                                                            |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_SHARED_LINK_FLAGS_XXX    | Shared link flags                                                    |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_C_FLAGS_XXX              | C flags                                                              |
+  +--------------------------------+----------------------------------------------------------------------+
 
+- **Global declared variables**:
 
-- **Global declared vars**
+  This generator also declares some global variables with the aggregated values of all our requirements. The values are ordered in the right
+  order according to the dependency tree.
 
-Conan also declares some global variables with the aggregated values of all our requirements.
-The values are ordered in the right order according to the dependency tree.
+  +--------------------------------+----------------------------------------------------------------------+
+  | NAME                           | VALUE                                                                |
+  +================================+======================================================================+
+  | CONAN_INCLUDE_DIRS             | Aggregated header's folders                                          |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_LIB_DIRS                 | Aggregated library folders                                           |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_BIN_DIRS                 | Aggregated binary folders                                            |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_SRC_DIRS                 | Aggregated sources folders                                           |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_LIBS                     | Aggregated library names to link                                     |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_DEFINES                  | Aggregated library defines                                           |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_COMPILE_DEFINITIONS      | Aggregated compile definitions                                       |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_CXX_FLAGS                | Aggregated CXX flags                                                 |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_SHARED_LINK_FLAGS        | Aggregated Shared link flags                                         |
+  +--------------------------------+----------------------------------------------------------------------+
+  | CONAN_C_FLAGS                  | Aggregated C flags                                                   |
+  +--------------------------------+----------------------------------------------------------------------+
 
-+--------------------------------+----------------------------------------------------------------------+
-| NAME                           | VALUE                                                                |
-+================================+======================================================================+
-| CONAN_INCLUDE_DIRS             | Aggregated header's folders                                          |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_LIB_DIRS                 | Aggregated library folders                                           |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_BIN_DIRS                 | Aggregated binary folders                                            |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_SRC_DIRS                 | Aggregated sources folders                                           |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_LIBS                     | Aggregated library names to link                                     |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_DEFINES                  | Aggregated library defines                                           |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_COMPILE_DEFINITIONS      | Aggregated compile definitions                                       |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_CXX_FLAGS                | Aggregated CXX flags                                                 |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_SHARED_LINK_FLAGS        | Aggregated Shared link flags                                         |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_C_FLAGS                  | Aggregated C flags                                                   |
-+--------------------------------+----------------------------------------------------------------------+
+- **User information declared variables**:
 
+  If any of the requirements is filling the :ref:`user_info<method_package_info_user_info>` object in the
+  :ref:`package_info<method_package_info>` method a set of variables will be declared following this naming:
 
-- **Variables from user_info**
+  +--------------------------------+----------------------------------------------------------------------+
+  | NAME                           | VALUE                                                                |
+  +================================+======================================================================+
+  | CONAN_USER_XXXX_YYYY           | User declared value                                                  |
+  +--------------------------------+----------------------------------------------------------------------+
 
-If any of the requirements is filling the :ref:`user_info<method_package_info_user_info>` object in the :ref:`package_info<method_package_info>`
-method a set of variables will be declared following this naming:
+  Where ``XXXX`` means the name of the requirement in uppercase and ``YYYY`` the variable name. For example, if this recipe declares:
 
-+--------------------------------+----------------------------------------------------------------------+
-| NAME                           | VALUE                                                                |
-+================================+======================================================================+
-| CONAN_USER_XXXX_YYYY           | User declared value                                                  |
-+--------------------------------+----------------------------------------------------------------------+
+  .. code-block:: python
 
-``XXXX`` is the name of the requirement in uppercase and ``YYYY`` the variable name, e.g.:
+      class MyLibConan(ConanFile):
+          name = "MyLib"
+          version = "1.6.0"
 
+          # ...
 
-.. code-block:: python
+          def package_info(self):
+              self.user_info.var1 = 2
 
+  Other library requiring ``MyLib`` and using this generator will get:
 
-   class MyLibConan(ConanFile):
-       name = "MyLib"
-       version = "1.6.0"
+  .. code-block:: cmake
+     :caption: *conanbuildinfo.cmake*
 
-       # ...
+      # ...
+      set(CONAN_USER_MYLIB_var1 "2")
 
-       def package_info(self):
-           self.user_info.var1 = 2
+.. _conanbuildinfocmake_macros:
 
+Macros available in *conanbuildinfo.cmake*
+------------------------------------------
 
-When other library requires ``MyLib`` and uses the cmake generator:
+conan_basic_setup()
++++++++++++++++++++
 
-**conanbuildinfo.cmake**:
+This is a helper and general purpose macro that uses all the macros below to set all the CMake variables according to the Conan generated
+variables. See the macros below for detailed information.
 
-.. code-block:: python
+.. code-block:: cmake
 
-    # ...
-    set(CONAN_USER_MYLIB_var1 "2")
+    macro(conan_basic_setup)
+        set(options TARGETS NO_OUTPUT_DIRS SKIP_RPATH KEEP_RPATHS SKIP_STD SKIP_FPIC)
 
+Parameters:
+    - ``TARGETS`` (Optional): Setup all the CMake variables by target (only CMake > 3.1.2). Activates the call to the macro
+      ``conan_target_link_libraries()``.
+    - ``NO_OUTPUT_DIRS`` (Optional): Do not adjust the output directories. Deactivates the call to the macro ``conan_output_dirs_setup()``.
+    - ``SKIP_RPATH`` (Optional): **[DEPRECATED]** Use ``KEEP_RPATHS`` instead. Activate ``CMAKE_SKIP_RPATH`` variable in OSX.
+    - ``KEEP_RPATHS`` (Optional): Do not adjust the ``CMAKE_SKIP_RPATH`` variable in OSX. Activates the call to the macro ``conan_set_rpath()``
+    - ``SKIP_STD`` (Optional): Do not adjust the C++ standard flag in ``CMAKE_CXX_FLAGS``. Deactivates the call to the macro
+      ``conan_set_std()``.
+    - ``SKIP_FPIC`` (Optional): Do not adjust the ``CMAKE_POSITION_INDEPENDENT_CODE`` flag. Deactivates the call to the macro
+      ``conan_set_fpic()``.
 
+.. note::
 
-.. _conanbuildinfocmake_methods:
+    You can also call each of the following macros individually instead of using the ``conan_basic_setup()``.
 
-Methods available in conanbuildinfo.cmake
------------------------------------------
-
-conan_basic_setup
-_________________
-
-Setup all the CMake vars according to our settings, by default with the global approach (no targets).
-
-**parameters**: You can combine several parameters to the ``conan_basic_setup`` macro, e.g., ``conan_basic_setup(TARGETS KEEP_RPATHS)``
-
-    - ``TARGETS``:  Setup all the CMake vars by target (only CMake > 3.1.2)
-    - ``NO_OUTPUT_DIRS``: Do not adjust the output directories
-    - ``KEEP_RPATHS``: Do not adjust the CMAKE_SKIP_RPATH variable in OSX
-
-
-conan_target_link_libraries
-___________________________
+conan_target_link_libraries()
++++++++++++++++++++++++++++++
 
 Helper to link all libraries to a specified target.
 
-Other optional methods and variables
-____________________________________
-
-There are other methods automatically called by ``conan_basic_setup()`` but you can use them directly:
-
-+--------------------------------+----------------------------------------------------------------------+
-| NAME                           | DESCRIPTION                                                          |
-+================================+======================================================================+
-| conan_check_compiler()         |  Checks that your compiler matches the one declared in settings      |
-|                                |                                                                      |
-|                                |  Can be disabled setting ``CONAN_DISABLE_CHECK_COMPILER`` CMake var  |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_output_dirs_setup()      |  Adjust the bin/ and lib/ output directories                         |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_set_find_library_paths() |  Set CMAKE_INCLUDE_PATH and CMAKE_INCLUDE_PATH                       |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_global_flags()           |  Set include_directories, link_directories, link_directories, flags  |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_define_targets()         |  Define the targets (target flags instead of global flags)           |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_set_rpath()              |  Set CMAKE_SKIP_RPATH=1  if APPLE                                    |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_set_vs_runtime()         |  Adjust the runtime flags (/MD /MDd /MT /MTd)                        |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_set_libcxx(TARGETS)      |  Adjust the standard library flags (libstdc++, libc++, libstdc++11)  |
-+--------------------------------+----------------------------------------------------------------------+
-| conan_set_find_paths()         |  Adjust CMAKE_MODULE_PATH and CMAKE_PREFIX_PATH                      |
-+--------------------------------+----------------------------------------------------------------------+
-| CONAN_CMAKE_SILENT_OUTPUT      |  Silences the Conan message output                                   |
-+--------------------------------+----------------------------------------------------------------------+
-
-Targets generated by conanbuildinfo.cmake
------------------------------------------
-
-If you use ``conan_basic_setup(TARGETS)``, then some cmake targets will be generated (this only works for CMake > 3.1.2)
-
 These targets are:
 
-- A ``CONAN_PKG::PkgName`` target per package in the dependency graph. This is an ``IMPORTED INTERFACE`` target. IMPORTED
-  because it is external, a pre-compiled library. INTERFACE, because it doesn't necessarily match a library,
-  it could be a header-only library, or the package could even contain several libraries. It contains all the
-  properties (include paths, compile flags, etc) that are defined in the ``package_info()`` method of the package.
-- Inside each package a ``CONAN_LIB::PkgName_LibName`` target will be generated for each library. Its type is ``IMPORTED
-  UNKNOWN``, its main purpose is to provide a correct link order. Their only properties are the location and the
-  dependencies
-- A ``CONAN_PKG`` depends on every ``CONAN_LIB`` that belongs to it, and to its direct public dependencies (i.e. other ``CONAN_PKG``
-  targets from its ``requires``)
-- Each ``CONAN_LIB`` depends on the direct public dependencies ``CONAN_PKG`` targets of its container package. This guarantees
-  correct link order.
+- A ``CONAN_PKG::PkgName`` target per package in the dependency graph. This is an ``IMPORTED INTERFACE`` target. ``IMPORTED`` because it is
+  external, a pre-compiled library. ``INTERFACE``, because it doesn't necessarily match a library, it could be a header-only library, or the
+  package could even contain several libraries. It contains all the properties (include paths, compile flags, etc.) that are defined in the
+  ``package_info()`` method of the recipe.
+
+- Inside each package a ``CONAN_LIB::PkgName_LibName`` target will be generated for each library. Its type is ``IMPORTED UNKNOWN`` and its
+  main purpose is to provide a correct link order. Their only properties are the location and the dependencies.
+
+- A ``CONAN_PKG`` depends on every ``CONAN_LIB`` that belongs to it, and to its direct public dependencies (e.g. other ``CONAN_PKG`` targets
+  from its requirements).
+
+- Each ``CONAN_LIB`` depends on the direct public dependencies ``CONAN_PKG`` targets of its container package. This guarantees correct link
+  order.
+
+conan_check_compiler()
+++++++++++++++++++++++
+
+Checks that your compiler matches the one declared in settings.
+
+conan_output_dirs_setup()
++++++++++++++++++++++++++
+
+Adjust the *bin/* and *lib/* output directories.
+
+conan_set_find_library_paths()
+++++++++++++++++++++++++++++++
+
+Set ``CMAKE_INCLUDE_PATH`` and ``CMAKE_INCLUDE_PATH``.
+
+conan_global_flags()
+++++++++++++++++++++
+
+Set the corresponding variables to CMake's ``include_directories()`` and ``link_directories()``.
+
+conan_define_targets()
+++++++++++++++++++++++
+
+Define the targets for each dependency (target flags instead of global flags).
+
+conan_set_rpath()
++++++++++++++++++
+
+Set ``CMAKE_SKIP_RPATH=1`` in the case of working in OSX.
+
+conan_set_vs_runtime()
+++++++++++++++++++++++
+
+Adjust the runtime flags ``/MD``, ``/MDd``, ``/MT`` or ``/MTd`` for Visual Studio.
+
+conan_set_std()
++++++++++++++++
+
+Set ``CMAKE_CXX_STANDARD`` and ``CMAKE_CXX_EXTENSIONS`` to the appropriate values.
+
+conan_set_libcxx()
+++++++++++++++++++
+
+Adjust the standard library flags (``libc++```, ``libstdc++``, ``libstdc++11``) in ``CMAKE_CXX_FLAGS``.
+
+conan_set_find_paths()
+++++++++++++++++++++++
+
+Adjust ``CMAKE_MODULE_PATH`` and ``CMAKE_PREFIX_PATH`` to the values of ``deps_cpp_info.build_paths``.
+
+Input variables for *conanbuildinfo.cmake*
+------------------------------------------
+
+CONAN_CMAKE_SILENT_OUTPUT
++++++++++++++++++++++++++
+
+**Default to**: ``FALSE``
+
+Activate it to silence the Conan message output.

--- a/reference/generators/cmakemulti.rst
+++ b/reference/generators/cmakemulti.rst
@@ -38,4 +38,4 @@ Same as :ref:`conanbuildinfo.cmake<conanbuildinfocmake_variables>` with suffix `
 Available Methods
 -----------------
 
-Same as :ref:`conanbuildinfo.cmake<conanbuildinfocmake_methods>`
+Same as :ref:`conanbuildinfo.cmake<conanbuildinfocmake_macros>`


### PR DESCRIPTION
Before writing the docs for conan-io/conan#4721, I took a look at the cmake generator one and found some missing pieces.

This PRs documents the missing parts and structures and homogenizes the whole section similarly to the build helpers one.