### PR TITLE
Explain about SystemPackageTool and sudo

### DIFF
--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -573,7 +573,7 @@ Methods:
 The use of ``sudo`` in the internals of the ``install()`` and ``update()`` methods is controlled by the ``CONAN_SYSREQUIRES_SUDO``
 environment variable, so if the users don't need sudo permissions, it is easy to opt-in/out.
 
-When ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will mimic if it is possible to use ``sudo`` based on:
+When the environemtn variable ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will try to use :command:`sudo` if the following conditions are met:
 
     - Is ``sudo`` available in ``PATH``
     - The platform name should be ``posix`` and the UID (user id) should not be ``0``

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -573,7 +573,7 @@ Methods:
 The use of ``sudo`` in the internals of the ``install()`` and ``update()`` methods is controlled by the ``CONAN_SYSREQUIRES_SUDO``
 environment variable, so if the users don't need sudo permissions, it is easy to opt-in/out.
 
-When ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will mimic if it is possible to use it based on:
+When ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will mimic if it is possible to use ``sudo`` based on:
 
     - Is ``sudo`` available in ``PATH``
     - The platform name should be ``posix``

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -576,7 +576,7 @@ environment variable, so if the users don't need sudo permissions, it is easy to
 When the environemtn variable ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will try to use :command:`sudo` if the following conditions are met:
 
     - :command:`sudo` is available in the ``PATH``.
-    - The platform name should be ``posix`` and the UID (user id) should not be ``0``
+    - The platform name is ``posix`` and the UID (user id) is not ``0``
 
 Conan will keep track of the execution of this method, so that it is not invoked again and again at every Conan command. The execution is
 done per package, since some packages of the same library might have different system dependencies. If you are sure that all your binary

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -573,6 +573,12 @@ Methods:
 The use of ``sudo`` in the internals of the ``install()`` and ``update()`` methods is controlled by the ``CONAN_SYSREQUIRES_SUDO``
 environment variable, so if the users don't need sudo permissions, it is easy to opt-in/out.
 
+When ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will mimic if it is possible to use it based on:
+
+    - Is ``sudo`` available in ``PATH``
+    - The platform name should be ``posix``
+    - UID (user id) should be ``0``
+
 Conan will keep track of the execution of this method, so that it is not invoked again and again at every Conan command. The execution is
 done per package, since some packages of the same library might have different system dependencies. If you are sure that all your binary
 packages have the same system requirements, just add the following line to your method:

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -576,8 +576,7 @@ environment variable, so if the users don't need sudo permissions, it is easy to
 When ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will mimic if it is possible to use ``sudo`` based on:
 
     - Is ``sudo`` available in ``PATH``
-    - The platform name should be ``posix``
-    - UID (user id) should be ``0``
+    - The platform name should be ``posix`` and the UID (user id) should not be ``0``
 
 Conan will keep track of the execution of this method, so that it is not invoked again and again at every Conan command. The execution is
 done per package, since some packages of the same library might have different system dependencies. If you are sure that all your binary

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -575,7 +575,7 @@ environment variable, so if the users don't need sudo permissions, it is easy to
 
 When the environemtn variable ``CONAN_SYSREQUIRES_SUDO`` is not defined, Conan will try to use :command:`sudo` if the following conditions are met:
 
-    - Is ``sudo`` available in ``PATH``
+    - :command:`sudo` is available in the ``PATH``.
     - The platform name should be ``posix`` and the UID (user id) should not be ``0``
 
 Conan will keep track of the execution of this method, so that it is not invoked again and again at every Conan command. The execution is


### PR DESCRIPTION
How does SystemPackageTool use sudo when CONAN_SYSREQUIRES_SUDO is not defined?

related issue: https://github.com/conan-io/conan/issues/4770
related PR: https://github.com/conan-io/conan/pull/4774
