### PR TITLE
Update cross_building.rst

### DIFF
--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -1,15 +1,16 @@
 .. _cross_building:
 
-Cross building
+Cross-building
 ==============
 
-Cross building is compiling a library or executable in one platform to be used in a different one.
+Cross-building is compiling a library or executable in one platform to be used in a different one.
 
-Cross-compilation is used to build software for embedded devices where you don't have an operating system
-nor a compiler available. Also for building software for not too fast devices, like an Android machine, a Raspberry PI etc.
+Cross-compilation is used to build software for an alien device, such as an embedded device where you don't have an operating system
+nor a compiler available. It's also for building software for slower devices, like an Android machine, a Raspberry Pi etc.
 
-To cross build code you need the right toolchain.
-A toolchain is basically a compiler with a set of libraries matching the ``host`` platform.
+To cross-build code you need the right toolchain.
+
+A toolchain is basically a compiler and linker with a set of libraries matching the ``host`` platform.
 
 
 GNU triplet convention
@@ -19,18 +20,18 @@ According to the GNU convention, there are three platforms involved in the softw
 
 - **Build platform:** The platform on which the compilation tools are executed
 - **Host platform:** The platform on which the code will run
-- **Target platform:** Only when building a compiler, this is the platform that the compiler will
-  generate code for
+- **Target platform:** Only when building a compiler, this is the platform for which the compiler will
+  generate code
 
 
 When you are building code for your own machine it's called **native building**, where the ``build``
 and the ``host`` platforms are the same. The ``target`` platform is not defined in this situation.
 
-When you are building code for a different platform, it's called **cross building**, where the ``build``
+When you are building code for a different platform, it's called **cross-building**, where the ``build``
 platform is different from the ``host`` platform. The ``target`` platform is not defined in this situation.
 
-The use of the ``target`` platform is rarely needed, only makes sense when you are building a compiler. For instance,
-when you are building in your Linux machine a GCC compiler that will run on Windows, to generate code for Android.
+The use of the ``target`` platform is rarely needed. It only makes sense when you are building a compiler. For instance,
+when you are building on your Linux machine a GCC compiler that will run on Windows, to generate code for Android.
 Here, the ``build`` is your Linux computer, the ``host`` is the Windows computer and the ``target`` is Android.
 
 
@@ -45,8 +46,8 @@ From version 1.0, Conan introduces new settings to model the GNU convention trip
     - **arch_build**: Architecture system of the ``build`` system.
 
     These settings are detected the first time you run Conan with the same values than the ``host`` settings,
-    so by default, we are doing **native building**. Probably you will never need to change the value
-    of this settings because they describe where are you running Conan.
+    so by default, we are doing **native building**. You will probably never need to change the value
+    of this setting because they describe where are you running Conan.
 
 
 ``host`` platform settings:
@@ -56,8 +57,8 @@ From version 1.0, Conan introduces new settings to model the GNU convention trip
     - **compiler**: Compiler of the ``host`` system (to declare compatibility of libs in the host platform)
     - ... (all the regular settings)
 
-    These settings are the regular Conan settings, already present before supporting the GNU triplet convention.
-    If you are cross building you have to change them according to the ``host`` platform.
+    These settings are the regular Conan settings; already present before supporting the GNU triplet convention.
+    If you are cross-building, you have to change them according to the ``host`` platform.
 
 
 ``target`` platform:
@@ -65,14 +66,14 @@ From version 1.0, Conan introduces new settings to model the GNU convention trip
     - **os_target**: Operating system of the ``target`` system.
     - **arch_target**: Architecture of the ``target`` system.
 
-    If you are building a compiler, specify with these settings where the compiled code will run.
+    If you are building a compiler, these settings specify where the compiled code will run.
 
 
-Cross building with Conan
+Cross-building with Conan
 -------------------------
 
-If you want to cross-build a Conan package, for example, in your Linux machine, build the `zlib`
-Conan package for Windows, you need to indicate to Conan where to find your cross-compiler/toolchain.
+If you want to cross-build a Conan package (for example on your Linux machine) to build the `zlib`
+Conan package for Windows, you need to tell Conan where to find your cross-compiler/toolchain.
 
 There are two approaches:
 
@@ -99,7 +100,7 @@ Create a profile with:
 Linux to Windows
 ................
 
-- Install the needed toolchain, in ubuntu:
+- Install the needed toolchain, in Ubuntu:
 
     ``sudo apt-get install g++-mingw-w64 gcc-mingw-w64``
 
@@ -128,7 +129,7 @@ Linux to Windows
     os_build=Linux
     arch_build=x86_64
 
-    # We are cross building to Windows
+    # We are cross-building to Windows
     os=Windows
     arch=x86_64
     compiler=gcc
@@ -156,11 +157,11 @@ Linux to Windows
 
 A *bin/example.exe* for Win64 platform has been built.
 
-Windows to Raspberry PI (Linux/ARM)
+Windows to Raspberry Pi (Linux/ARM)
 ...................................
 
 - Install the toolchain: http://gnutoolchains.com/raspberry/
-  You can choose different versions of the GCC cross compiler, choose one and adjust the following
+  You can choose different versions of the GCC cross compiler. Choose one and adjust the following
   settings in the profile accordingly.
 
 - Create a file named **win_to_rpi** with the contents:
@@ -195,8 +196,8 @@ Windows to Raspberry PI (Linux/ARM)
     CXX=$target_host-$cxx_compiler
     CXXFLAGS=-I"$standalone_toolchain/$target_host/lib/include"
 
-The profiles to target Linux are all very similar, probably you just need to adjust the variables
-declared in the top of the profile:
+The profiles to target Linux are all very similar. You probably just need to adjust the variables
+declared at the top of the profile:
 
     - **target_host**: All the executables in the toolchain starts with this prefix.
     - **standalone_toolchain**: Path to the toolchain installation.
@@ -226,7 +227,7 @@ A *bin/example* for Raspberry PI (Linux/armv7hf) platform has been built.
 Linux/Windows/macOS to Android
 ..............................
 
-Cross building a library for Android is very similar to the previous examples, except the complexity of managing different
+Cross-building a library for Android is very similar to the previous examples, except the complexity of managing different
 architectures (armeabi, armeabi-v7a, x86, arm64-v8a) and the Android API levels.
 
 Download the Android NDK `here <https://developer.android.com/ndk/downloads>`_ and unzip it.
@@ -235,8 +236,8 @@ Download the Android NDK `here <https://developer.android.com/ndk/downloads>`_ a
 
     If you are in Windows the process will be almost the same, but unzip the file in the root folder of your hard disk (``C:\``) to avoid issues with path lengths.
 
-Now you have to build a `standalone toolchain <https://developer.android.com/ndk/guides/standalone_toolchain>`_,
-we are going to target "arm" architecture and the Android API level 21, change the ``--install-dir`` to any other place that works
+Now you have to build a `standalone toolchain <https://developer.android.com/ndk/guides/standalone_toolchain>`_.
+We are going to target the "arm" architecture and the Android API level 21. Change the ``--install-dir`` to any other place that works
 for you:
 
 .. code-block:: bash
@@ -247,7 +248,7 @@ for you:
 
 .. note::
 
-    You can generate the standalone toolchain with several different options to target different architectures, api levels etc.
+    You can generate the standalone toolchain with several different options to target different architectures, API levels etc.
 
     Check the Android docs: `standalone toolchain <https://developer.android.com/ndk/guides/standalone_toolchain>`_
 
@@ -348,7 +349,7 @@ A **bin/enough** for Android ARM platform has been built.
 Using build requires
 ++++++++++++++++++++
 
-Instead of downloading manually the toolchain and creating a profile, you can create a Conan package
+Instead of manually downloading the toolchain and creating a profile, you can create a Conan package
 with it. The toolchain Conan package needs to fill the ``env_info`` object
 in the :ref:`package_info()<method_package_info>` method with the same variables we've specified in the examples
 above in the ``[env]`` section of profiles.
@@ -384,9 +385,9 @@ A layout of a Conan package for a toolchain could looks like this:
            self.env_info.CXX = os.path.join(bin_folder, "mycompiler-cxx")
            self.env_info.SYSROOT = self.package_folder
 
-Finally, when you want to cross-build a library, the profile to be used, will include a ``[build_requires]``
-section with the reference to our new packaged toolchain. Also will contain a ``[settings]`` section
-with the same settings of the examples above.
+Finally, when you want to cross-build a library, the profile to be used will include a ``[build_requires]``
+section with the reference to our new packaged toolchain. This will also contain a ``[settings]`` section
+with the same settings from the examples above.
 
 
 .. _darwin_toolchain:
@@ -395,7 +396,7 @@ Example: Darwin Toolchain
 .........................
 
 Check the `Darwin Toolchain <https://github.com/theodelrieu/conan-darwin-toolchain>`_  package in conan-center.
-You can use a profile like the following to cross build your packages for ``iOS``,  ``watchOS`` and ``tvOS``:
+You can use a profile like the following to cross-build your packages for ``iOS``,  ``watchOS`` and ``tvOS``:
 
 .. code-block:: text
     :caption: ios_profile
@@ -426,8 +427,8 @@ You can use a profile like the following to cross build your packages for ``iOS`
 Using Docker images
 +++++++++++++++++++
 
-You can use some :ref:`available docker images with Conan preinstalled images<available_docker_images>` to cross build conan packages.
-Currently there are ``i386``, ``armv7`` and ``armv7hf`` images with the needed packages and toolchains installed to cross build.
+You can use some :ref:`available Docker images with Conan preinstalled images<available_docker_images>` to cross-build Conan packages.
+Currently there are ``i386``, ``armv7`` and ``armv7hf`` images with the needed packages and toolchains installed to cross-build.
 
 **Example**: Cross-building and uploading a package along with all its missing dependencies for ``Linux/armv7hf`` is done in few steps:
 
@@ -459,7 +460,7 @@ If don't, you can always check the ``self.settings.os``, ``self.settings.build_o
 ``self.settings.arch`` and ``self.settings.build_arch`` settings values and inject the needed flags to your
 build system script.
 
-You can use this tool to check if you are cross building:
+You can use this tool to check if you are cross-building:
 
 - :ref:`tools.cross_building(self.settings)<cross_building_reference>` (returns True or False)
 
@@ -467,11 +468,11 @@ You can use this tool to check if you are cross building:
 ARM architecture reference
 --------------------------
 
-Remember that the conan settings are intended to unify the different names for operating systems, compilers,
+Remember that the Conan settings are intended to unify the different names for operating systems, compilers,
 architectures etc.
 
 Conan has different architecture settings for ARM: ``armv6``, ``armv7``, ``armv7hf``, ``armv8``.
-The "problem" with ARM architecture is that frequently are named in different ways, so maybe you are wondering what setting
+The "problem" with ARM architecture is that it's frequently named in different ways, so maybe you are wondering what setting
 do you need to specify in your case.
 
 Here is a table with some typical ARM platforms:
@@ -517,4 +518,4 @@ Here is a table with some typical ARM platforms:
     - See :ref:`conan.conf file<conan_conf>` and :ref:`Environment variables <env_vars>` sections to know more.
     - See :ref:`AutoToolsBuildEnvironment build helper<autotools_reference>` reference.
     - See :ref:`CMake build helper<cmake_reference>` reference.
-    - See `CMake cross building wiki <https://vtk.org/Wiki/CMake_Cross_Compiling>`_ to know more about cross building with CMake.
+    - See `CMake cross-building wiki <https://vtk.org/Wiki/CMake_Cross_Compiling>`_ to know more about cross-building with CMake.


### PR DESCRIPTION
Change "Cross building" to "Cross-building" to be consistent. Update definition of cross-compiling to be more precise. Fix capitalization of "Pi". Update definition of toolchain to include linker. Fix dangling participle. Fix awkward sentences. Capitalize proper noun "Ubuntu". Capitalize "API". Remove unnecessary comma. Capitalize proper noun "Conan". Capitalize proper noun "Docker".