### PR TITLE
Update clion.rst

### DIFF
--- a/integrations/clion.rst
+++ b/integrations/clion.rst
@@ -44,12 +44,12 @@ the ``zlib`` conan package.
 |cmakelists|
 
 3. CLion will reload your CMake project and you will be able to see a Warning in the console, because the
-``conanbuildinfo.cmake`` file still doesn't exists:
+``conanbuildinfo.cmake`` file still doesn't exist:
 
 |configure_warning_info|
 
-4. Create a ``conanfile.txt`` with all your requirements and use the ``cmake`` generator. In this case we are only
-requiring zlib library from a conan package:
+4. Create a ``conanfile.txt`` with all your requirements and use the ``cmake`` generator. In this case we only
+require the zlib library from a Conan package:
 
 .. code-block:: text
 
@@ -64,7 +64,7 @@ requiring zlib library from a conan package:
 
 .. _step_five:
 
-5. Now you can :command:`conan install` for debug in the ``cmake-build-debug`` folder to install your requirements and
+5. Now you can run :command:`conan install` for debug in the ``cmake-build-debug`` folder to install your requirements and
 generate the ``conanbuildinfo.cmake`` file there:
 
 
@@ -72,20 +72,20 @@ generate the ``conanbuildinfo.cmake`` file there:
 
    $ conan install . -s build_type=Debug --install-folder=cmake-build-debug
 
-6. Repeat the last step if you have the release build types configured in your CLion IDE, but changing the build_type
+6. Repeat the last step if you have the release build types configured in your CLion IDE, but change the build_type
 setting accordingly:
 
 .. code-block:: bash
 
    $ conan install . -s build_type=Release --install-folder=cmake-build-release
 
-7. Now reconfigure your CLion project, the Warning message is not shown anymore:
+7. Now reconfigure your CLion project. The Warning message is not shown anymore:
 
 |configure_ok|
 
 
-8. Open the ``library.cpp`` file and include the ``zlib.h``, if you follow the link you can see that CLion automatically
-detect the ``zlib.h`` header file from the local conan cache.
+8. Open the ``library.cpp`` file and include ``zlib.h``. If you follow the link, you can see that CLion automatically
+detects the ``zlib.h`` header file from the local Conan cache.
 
 |library_cpp|
 
@@ -94,13 +94,13 @@ detect the ``zlib.h`` header file from the local conan cache.
 |built_ok|
 
 
-You can check a full example of a CLion project reusing conan packages in this github repository: `lasote/clion-conan-consumer <https://github.com/lasote/clion-conan-consumer>`_.
+You can check a complete example of a CLion project reusing conan packages in this github repository: `lasote/clion-conan-consumer <https://github.com/lasote/clion-conan-consumer>`_.
 
 
-Creating conan packages in a CLion project
+Creating Conan packages in a CLion project
 ==========================================
 
-Now we are going to see how to create a conan package from the previous library.
+Now we are going to see how to create a Conan package from the previous library.
 
 1. Create a new CLion project
 
@@ -126,18 +126,18 @@ Now we are going to see how to create a conan package from the previous library.
 
    $ conan new mylibrary/1.0@myuser/channel
 
-And edit the ``conanfile.py``:
+Edit the ``conanfile.py``:
 
-- We are removing the ``source`` method because we have the sources in the same project, so we can use the
+- We are removing the ``source`` method because we have the sources in the same project; so we can use the
   ``exports_sources``.
 
-- In the ``package_info`` method adjust the library name, in this case our ``CMakeLists.txt`` is creating a target library called
+- In the ``package_info`` method, adjust the library name. In this case our ``CMakeLists.txt`` creates a target library called
   ``mylibrary``.
 
-- Adjust the CMake helper in the ``build()`` method, the ``cmake.configure()`` doesn't need to specify the ``source_folder``, because
+- Adjust the CMake helper in the ``build()`` method. The ``cmake.configure()`` doesn't need to specify the ``source_folder``, because
   we have the ``library.*`` files in the root directory.
 
-- Adjust the ``copy`` function calls in the ``package`` method to ensure that all your headers and libraries are copied to the conan package.
+- Adjust the ``copy`` function calls in the ``package`` method to ensure that all your headers and libraries are copied to the Conan package.
 
 .. code-block:: python
 
@@ -179,23 +179,23 @@ And edit the ``conanfile.py``:
 
 
 
-4. To build your library with CLion follow the guide of :ref:`Using packages from the step 5<step_five>`.
+4. To build your library with CLion, follow the guide of :ref:`Using packages from step 5<step_five>`.
 
-5. To package your library use the :command:`conan export-pkg` command passing the used build-folder. It
-will call your ``package()`` method to extract the artifacts and push the conan package to the local
+5. To package your library, use the :command:`conan export-pkg` command passing the used build-folder. It
+will call your ``package()`` method to extract the artifacts and push the Conan package to the local
 cache:
 
 .. code-block:: bash
 
    $ conan export-pkg . mylibrary/1.0@myuser/channel --build-folder cmake-build-debug -pr=myprofile
 
-7. Now you can upload it to a conan server if needed:
+7. Now you can upload it to a Conan server if needed:
 
 .. code-block:: bash
 
    $ conan upload mylibrary/1.0@myuser/channel # This will upload only the recipe, use --all to upload all the generated binary packages.
 
-8. If you would like to see how the package looks like before exporting it to the local cache (conan export-pkg)
+8. If you would like to see how the package looks like before exporting it to the local cache (:command:`conan export-pkg`)
 you can use the :command:`conan package` command to create the package in a local directory:
 
 
@@ -211,7 +211,7 @@ If we list the ``mypackage`` folder we can see:
     - A ``conaninfo.txt`` and ``conanmanifest.txt`` conan files, always present in all packages.
 
 
-You can check a full example of a CLion project for creating a conan package in this github repository: `lasote/clion-conan-package <https://github.com/lasote/clion-conan-package>`_.
+You can check a full example of a CLion project for creating a Conan package in this github repository: `lasote/clion-conan-package <https://github.com/lasote/clion-conan-package>`_.
 
 
 .. |clion_logo| image:: ../images/clion/icon_CLion.png


### PR DESCRIPTION
Fix tense of "exist". Fix sentence tense of "only require the". Capitalize proper noun, "Conan". Add word, "run".  Fix tense of "change". Fix run-on sentences. Remove superfluous word, "the". Fix tense of "detects". Change "full" to "complete". Prefer not to start a sentence with "And". Change comma to semicolon. Add missing comma. Remove superfluous word "the". Fix display of command "conan export-pkg".