### PR TITLE
Add note about editable package pitfall (#4749)

### DIFF
--- a/developing_packages/editable_packages.rst
+++ b/developing_packages/editable_packages.rst
@@ -248,6 +248,12 @@ time, without any Conan command.
 
     When a package is in editable mode, most of the commands will not work. It is not possible to :command:`conan upload`,
     :command:`conan export` or :command:`conan create` when a package is in editable mode.
+    
+.. note::
+
+   CMake-based consumer projects may not pick up on modifications made to header files in the editable package. In this 
+   case, a full rebuild is necessary to pick up on the changes in the package's source files. Using :ref:`workspaces`
+   may provide a better workflow in this specific case.
 
 Revert the editable mode
 ------------------------


### PR DESCRIPTION
This is a tiny update to the documentation, pointing out the small pitfall with editable packages I encountered in conan-io/conan#4749.

I hope this helps! Please do feel free to reject if you feel this is not a good place and/or wording.