### PR TITLE
fix typo

### DIFF
--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -108,7 +108,7 @@ Linux to Windows
 
 .. code-block:: text
 
-    $toolchain=/usr/x86_64-w64-mingw32 # Adjust this path
+    toolchain=/usr/x86_64-w64-mingw32 # Adjust this path
     target_host=x86_64-w64-mingw32
     cc_compiler=gcc
     cxx_compiler=g++


### PR DESCRIPTION
Hi!

Seems there was a minor typo in the linux-to-windows profile exemple.
Forked and fixed from master branch as it was ahead of develop, can change if needed.

Thanks for the great documentation job !