### PR TITLE
discourage private requirements

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -527,10 +527,9 @@ You can specify further information about the package requirements:
 Requirements can be complemented by 2 different parameters:
 
 **private**: a dependency can be declared as private if it is going to be fully embedded and hidden
-from consumers of the package. Typical examples could be a header only library which is not exposed
-through the public interface of the package, or the linking of a static library inside a dynamic
-one, in which the functionality or the objects of the linked static library are not exposed through
-the public interface of the dynamic library.
+from consumers of the package. It might be necessary in some extreme cases, like having to use two
+different versions of the same library (provided that they are totally hidden in a shared library, for
+example), but it is mostly discouraged otherwise.
 
 **override**: packages can define overrides of their dependencies, if they require the definition of
 specific versions of the upstream required libraries, but not necessarily direct dependencies. For example,

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -469,8 +469,9 @@ It also has optional parameters that allow defining the special cases, as is sho
 ``self.requires()`` parameters:
     - **override** (Optional, Defaulted to ``False``): True means that this is not an actual requirement, but something to be passed
       upstream and override possible existing values.
-    - **private** (Optional, Defaulted to ``False``): True means that this requirement will be somewhat embedded (like a static lib linked
-      into a shared lib), so it is not required to link.
+    - **private** (Optional, Defaulted to ``False``): True means that this requirement will be somewhat embedded, and totally hidden. It might be necessary in some extreme cases, like having to use two
+    different versions of the same library (provided that they are totally hidden in a shared library, for
+    example), but it is mostly discouraged otherwise.
 
 .. note::
 


### PR DESCRIPTION
Biten again by some corner and weird case of private requirements abuse. I think at least we should discourage their use in the docs.