### PR TITLE
Improve documentation intended for package consumers

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -3,7 +3,7 @@
 Getting Started
 ===============
 
-Let's get started with an example: We are going to create a an MD5 encrypter app that uses one of the most popular C++ libraries: Poco_.
+Let's get started with an example: We are going to create an MD5 encrypter app that uses one of the most popular C++ libraries: Poco_.
 
 We'll use CMake as build system in this case but keep in mind that Conan **works with any build system** and is not limited to using CMake.
 
@@ -12,8 +12,8 @@ An MD5 Encrypter using the Poco Libraries
 
 .. note::
 
-    The source files to recreate this project are available in the following GitHub repository.
-    You can skip the manual creation of folder an sources with this command:
+    The source files to recreate this project are available in the `example repository`_ in GitHub.
+    You can skip the manual creation of the folder and sources with this command:
 
     .. code-block:: bash
 
@@ -55,6 +55,8 @@ An MD5 Encrypter using the Poco Libraries
         Poco/1.8.0@pocoproject/stable
         Poco/1.8.1@pocoproject/stable
         Poco/1.9.0@pocoproject/stable
+        Poco/1.9.1@pocoproject/stable
+        Poco/1.9.2@pocoproject/stable
 
 3. We got some interesting references for Poco. Let's inspect the metadata of the 1.9.0 version:
 
@@ -205,7 +207,7 @@ command line or taken from the defaults in *<userhome>/.conan/profiles/default* 
    :width: 500 px
    :align: center
 
-For example, the command :command:`conan install . --settings os="Linux" --settings compiler="gcc"`, performs these steps:
+For example, the command :command:`conan install .. --settings os="Linux" --settings compiler="gcc"`, performs these steps:
 
 - Checks if the package recipe (for ``Poco/1.9.0@pocoproject/stable`` package) exists in the local cache. If we are just starting, the
   cache is empty.
@@ -217,7 +219,7 @@ For example, the command :command:`conan install . --settings os="Linux" --setti
 
 There are binaries for several mainstream compilers and versions available in Conan Center repository in Bintray, such as Visual Studio 14,
 15, Linux GCC 4.9 and Apple Clang 3.5... Conan will throw an error if the binary package required for specific settings doesn't exist. You
-can build the binary package from sources using :command:`conan install --build=missing`, it will succeed if your configuration is
+can build the binary package from sources using :command:`conan install .. --build=missing`, it will succeed if your configuration is
 supported by the recipe. You will find more info in the :ref:`getting_started_other_configurations` section.
 
 Inspecting Dependencies
@@ -371,7 +373,7 @@ For example, if we have a profile with a 32-bit GCC configuration in a profile c
 
 .. code-block:: bash
 
-    $ conan install . --profile=gcc_x86
+    $ conan install .. --profile=gcc_x86
 
 .. tip::
 
@@ -382,7 +384,7 @@ parameter. As an exercise, try building the 32-bit version of the Encrypter proj
 
 .. code-block:: bash
 
-    $ conan install . --settings arch=x86
+    $ conan install .. --settings arch=x86
 
 The above command installs a different package, using the :command:`--settings arch=x86` instead of the one of the default profile used
 previously.
@@ -408,3 +410,5 @@ Got any doubts? Check our :ref:`faq`, |write_us| or join the community in `Cppla
 .. _`Bintray`: https://bintray.com/conan/conan-center
 
 .. _`Cpplang Slack`: https://cpplang.now.sh/
+
+.. _`example repository`: https://github.com/conan-io/examples

--- a/installation.rst
+++ b/installation.rst
@@ -10,7 +10,7 @@ There are three ways to install Conan:
 
 1. The preferred and **strongly recommended way to install Conan** is from PyPI, the Python Package Index, using the ``pip`` command.
 2. There are other available installers for different systems, which might come with a bundled python interpreter, so that you don't have to
-   install python first. Note that some of **these installers might have some limitations**, specially those created with pyinstaller
+   install python first. Note that some of **these installers might have some limitations**, especially those created with pyinstaller
    (such as Windows exe & Linux deb).
 3. Running Conan from sources.
 
@@ -39,8 +39,9 @@ Install Conan:
     - In **Linux**, you may need **sudo** permissions to install Conan globally.
     - We strongly recommend using **virtualenvs** (virtualenvwrapper works great) for everything related to Python.
       (check https://virtualenvwrapper.readthedocs.io/en/stable/, or https://pypi.org/project/virtualenvwrapper-win/ in Windows)
+      With Python 3, the built-in module ``venv`` can also be used instead (check https://docs.python.org/3/library/venv.html).
       If not using a **virtualenv** it is possible that conan dependencies will conflict with previously existing dependencies,
-      specially if you are using Python for other purposes.
+      especially if you are using Python for other purposes.
     - In **Windows** and Python 2.7, you may need to use **32bit** python distribution (which is the Windows default), instead
       of 64 bit.
     - In **OSX**, especially the latest versions that may have **System Integrity Protection**, pip may fail. Try using virtualenvs, or
@@ -50,7 +51,7 @@ Install Conan:
       virtualenv in another location or upgrade your Python installation.
     - Some Linux distros, such as Linux Mint, require a restart (shell restart, or logout/system if not enough) after
       installation, so Conan is found in the path.
-    - Windows, Python 3 installation can fail installing the ``wrapt`` dependency because of a bug in **pip**. Information about this issue and
+    - In Windows, Python 3 installation can fail installing the ``wrapt`` dependency because of a bug in **pip**. Information about this issue and
       workarounds is available here: https://github.com/GrahamDumpleton/wrapt/issues/112.
     - Conan works with Python 2.7, but not all features are available when not using Python 3.x starting with version 1.6
 
@@ -125,8 +126,8 @@ The response should be similar to:
 .. code-block:: bash
 
     Consumer commands
-      install    Installs the requirements specified in a conanfile (.py or .txt).
-      config     Manages configuration. Edits the conan.conf or installs config files.
+      install    Installs the requirements specified in a recipe (conanfile.py or conanfile.txt).
+      config     Manages Conan configuration.
       get        Gets a file or list a directory of a given reference or package.
       info       Gets information about the dependency graph of a recipe.
       ...
@@ -193,7 +194,7 @@ All features of Conan until version 1.6 are fully supported in both Python 2 and
 that are only available in Python 3 or more easily available in Python 3 will be implemented and tested only in Python 3, and versions of
 Conan using Python 2 will not have access to that feature. This will be clearly described in code and documentation.
 
-If and when Conan 2.x is released (Not expected in 2018) the level of compatibility with Python 2 may be reduced further.
+If and when Conan 2.x is released, the level of compatibility with Python 2 may be reduced further.
 
 We encourage you to upgrade to Python 3 as soon as possible. However, if this is impossible for you or your team, we would like to know it.
 Please give feedback in the `Conan issue tracker`_ or write us to info@conan.io.

--- a/using_packages/conanfile_txt.rst
+++ b/using_packages/conanfile_txt.rst
@@ -28,8 +28,9 @@ headers and libraries for each package.
 If you execute a :command:`conan install Poco/1.9.0@pocoproject/stable` command in your shell, Conan will
 download the Poco package and its dependencies (*OpenSSL/1.0.2l@conan/stable* and
 *zlib/1.2.11@conan/stable*) to your local cache and print information about the folder where
-they are installed. While you can handle them manually, the recommended approach is to
-use a ``conanfile.txt``.
+they are installed. While you can install each of your dependencies individually like that,
+the recommended approach for handling dependencies is to use a ``conanfile.txt`` file.
+The structure of ``conanfile.txt`` is described below.
 
 Requires
 ........
@@ -75,7 +76,7 @@ Consider that a new release of the OpenSSL library has been released, and a new 
 available. In our example, we do not need to wait until `pocoproject`_ (the author) generates a new package of POCO that
 includes the new OpenSSL library.
 
-We can simply enter the new version in **[requires]** section:
+We can simply enter the new version in the **[requires]** section:
 
 .. code-block:: text
 
@@ -85,7 +86,7 @@ We can simply enter the new version in **[requires]** section:
 
 The second line will override the OpenSSL/1.0.2l required by POCO with the currently non-existent **OpenSSL/1.0.2p**.
 
-Another example in which we may want to try some new zlib alpha features, we could replace the zlib
+Another example in which we may want to try some new zlib alpha features: we could replace the zlib
 requirement with one from another user or channel.
 
 .. code-block:: text
@@ -122,7 +123,7 @@ Options
 .......
 
 We have already seen that there are some **settings** that can be specified during installation. For
-example, :command:`conan install . -s build_type=Debug`. These settings are typically a project-wide
+example, :command:`conan install .. -s build_type=Debug`. These settings are typically a project-wide
 configuration defined by the client machine, so they cannot have a default value in the recipe. For
 example, it doesn't make sense for a package recipe to declare "Visual Studio" as a default compiler
 because that is something defined by the end consumer, and unlikely to make sense if they are
@@ -148,7 +149,7 @@ and this is the linkage that should be used if consumers don't specify otherwise
         $ conan inspect Poco/1.9.0@pocoproject/stable -a=default_options
 
 For example, we can modify the previous example to use dynamic linkage instead of the default one, which was static, by editing the
-*conanfile.txt*:
+**[options]** section in ``conanfile.txt``:
 
 .. code-block:: text
 
@@ -180,13 +181,13 @@ command line:
     $ conan install .. -o *:shared=True
 
 Conan will install the binaries of the shared library packages, and the example will link with them. You can again inspect the different binaries installed.
-For example, :command:`conan search zlib/1.2.8@lasote/stable`.
+For example, :command:`conan search zlib/1.2.8@conan/stable`.
 
 Finally, launch the executable:
 
 .. code-block:: bash
 
-    $ ./bin/timer
+    $ ./bin/md5
 
 What happened? It fails because it can't find the shared libraries in the path. Remember that shared
 libraries are used at runtime, so the operating system, which is running the application, must be able to locate them.
@@ -197,7 +198,7 @@ example, in Linux, we could use the `objdump` tool and see the *Dynamic section*
 .. code-block:: bash
 
     $ cd bin
-    $ objdump -p timer
+    $ objdump -p md5
     ...
     Dynamic Section:
      NEEDED               libPocoUtil.so.31
@@ -229,11 +230,11 @@ There are some differences between shared libraries on Linux (\*.so), Windows (\
 (\*.dylib). The shared libraries must be located in a folder where they can be found, either by
 the linker, or by the OS runtime.
 
-You can add the libraries' folders to the path (dynamic linker LD_LIBRARY_PATH path
+You can add the libraries' folders to the path (LD_LIBRARY_PATH environment variable
 in Linux, DYLD_LIBRARY_PATH in OSX, or system PATH in Windows), or copy those shared libraries to
-some system folder where they can be found by the OS. But these operations are are typical operations deployments or
-final installation of apps; they are not desired during development, and Conan is intended for developers, so
-it avoids manipulations on the OS.
+some system folder where they can be found by the OS. But these operations are only related to the deployment or
+installation of apps; they are not relevant during development. Conan is intended for developers, so
+it avoids such manipulation of the OS environment.
 
 In Windows and OSX, the simplest approach is to copy the shared libraries to the executable
 folder, so they are found by the executable, without having to modify the path.
@@ -265,21 +266,21 @@ To demonstrate this, edit the ``conanfile.txt`` file and paste the following **[
     should be found in the **/lib** folder, however, this is just a convention, and different layouts are
     possible.
 
-Install the requirements (from the ``mytimer/build`` folder), and run the binary again:
+Install the requirements (from the ``build`` folder), and run the binary again:
 
 .. code-block:: bash
 
     $ conan install ..
-    $ ./bin/timer
+    $ ./bin/md5
 
-Now look at the ``mytimer/build/bin`` folder and verify that the required shared libraries are there.
+Now look at the ``build/bin`` folder and verify that the required shared libraries are there.
 
 As you can see, the **[imports]** section is a very generic way to import files from your
 requirements to your project. 
 
 This method can be used for packaging applications and copying the resulting executables to your bin
 folder, or for copying assets, images, sounds, test static files, etc. Conan is a generic solution
-for package management, not only (but focused in) for C/C++ or libraries.
+for package management, not only for (but focused on) C/C++ libraries.
 
 .. seealso::
 

--- a/using_packages/using_profiles.rst
+++ b/using_packages/using_profiles.rst
@@ -3,9 +3,9 @@
 Using profiles
 --------------
 
-So far, we have used the default settings stored in ``~/.conan/profiles/default`` and defined as command line arguments.
+So far, we have used the default settings stored in ``~/.conan/profiles/default`` and defined custom values for some of them as command line arguments.
 
-However, in large projects, configurations can get complex, settings can be very different, and we need an easy way to switch between different configurations with different settings, options etc,.
+However, in large projects, configurations can get complex, settings can be very different, and we need an easy way to switch between different configurations with different settings, options etc.
 An easy way to switch between configurations is by using profiles.
 
 A profile file contains a predefined set of ``settings``, ``options``, ``environment variables``, and ``build_requires`` specified in the following structure:
@@ -56,7 +56,7 @@ A profile file can be stored in the default profile folder, or anywhere else in 
 
     $ conan create . demo/testing -pr=clang_3.5
 
-Continuing with the example of Poco, instead of passing in a long list of command line arguments, we can define a handy profile that defines them all and pass that to the command line when installing the different project dependencies.
+Continuing with the example of Poco, instead of passing in a long list of command line arguments, we can define a handy profile that defines them all and pass that to the command line when installing the project dependencies.
 
 A profile to install dependencies as **shared** and in **debug** mode would look like this:
 
@@ -77,7 +77,7 @@ To install dependencies using the profile file, we would use:
 
 .. code-block:: bash
 
-    $ conan install . -pr=debug_shared
+    $ conan install .. -pr=debug_shared
 
 We could also create a new profile to use a different compiler version and store that in our project directory. For example:
 
@@ -95,14 +95,14 @@ To install dependencies using this new profile, we would use:
 
 .. code-block:: bash
 
-    $ conan install . -pr=./poco_clang_3.5
+    $ conan install .. -pr=../poco_clang_3.5
 
 You can specify multiple profiles in the command line. The applied configuration will be the composition
 of all the profiles applied in the order they are specified:
 
 .. code-block:: bash
 
-    $ conan install . -pr=./poco_clang_3.5 -pr=my_build_tool1 -pr=my_build_tool2
+    $ conan install .. -pr=../poco_clang_3.5 -pr=my_build_tool1 -pr=my_build_tool2
 
 .. seealso::
 


### PR DESCRIPTION
* Some small fixes of typos and grammar
* Added note about 'venv' for Python 3
* Linked example repository
* Fixed outdated content (conan output, md5 example etc.)
* Added mandatory path ("..") to full "conan install" invocation examples
  where missing
* Changed "." to ".." for "conan install" where present, because
  out-of-tree builds should be done.