### PR TITLE
Correct binary build path in doc

### DIFF
--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -26,7 +26,7 @@ The source code used contains an executable called ``greet``, but it is not pack
 .. code-block:: python
 
     def package(self):
-        self.copy("*greet*", src="hello/bin", dst="bin", keep_path=False)
+        self.copy("*greet*", src="bin", dst="bin", keep_path=False)
 
 
 Now we create the package as usual, but if we try to run the executable it won't be found:


### PR DESCRIPTION
The hello world project doesn't store the binary "greet" (or "greet.exe") in the build directory hello/bin. I think it stores it directly in the directory bin.
So in order for the recipe to work this change has to be made. After it, the console shows 
     Hello/0.1@user/testing package(): Packaged 1 file: greet
but before the fix that line it's not shown.