### PR TITLE
[FIX DEVELOP] Fix jinja URL

### DIFF
--- a/developing_packages/editable_packages.rst
+++ b/developing_packages/editable_packages.rst
@@ -145,7 +145,7 @@ can add logic to the files:
        src/{{ item }}/resouces/{% if item != "cmp3" %}{{ settings.arch }}{% endif %}
        {% endfor %}
 
-You can have a look at the `Jinja2 documentation <http://jinja.pocoo.org/>`_ to know more
+You can have a look at the `Jinja2 documentation <https://palletsprojects.com/p/jinja/>`_ to know more
 about its powerful syntax.
 
 


### PR DESCRIPTION
The domain for jinja documentation changed a probably there was some downtime of the domain.
Now it is redirected (that's why the CI in master branch is green), but better add the new link