### PR TITLE
Remove redundant "by default" from virtualenv section

### DIFF
--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -43,7 +43,7 @@ Now we create the package as usual, but if we try to run the executable it won't
     > ... not found...
 
 
-By default, Conan does not modify by default the environment, it will just create the package in the local cache, and that is not
+By default, Conan does not modify the environment, it will just create the package in the local cache, and that is not
 in the system PATH, so the ``greet`` executable is not found.
 
 The ``virtualrunenv`` generator generates files that add the package's default binary locations to the necessary paths:


### PR DESCRIPTION
The paragraph describing virtualenvs contained the following sentence: "By default, Conan does not modify by default the environment (...)". The second redundant "by default" was removed.