### PR TITLE
Add clang 9

### DIFF
--- a/reference/config_files/settings.yml.rst
+++ b/reference/config_files/settings.yml.rst
@@ -75,7 +75,7 @@ are possible. These are the **default** values, but it is possible to customize 
         clang:
             version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                       "5.0", "6.0", "7.0",
-                      "8"]
+                      "8", "9"]
             libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         apple-clang:


### PR DESCRIPTION
Add clang version 9 to default list of compilers now that llvm 9 is officially released