### PR TITLE
Some changes related to hooks documentation

### DIFF
--- a/extending/hooks.rst
+++ b/extending/hooks.rst
@@ -13,8 +13,13 @@ points.
 Hook structure
 --------------
 
-Hooks are Python files containing **pre** and **post** functions that will be executed before and after a particular task performed by the
-Conan client. Those tasks could be Conan commands, recipe interactions such as exporting or packaging, or interactions with the remotes.
+A hook is a Python function that will be executed at certain points of Conan workflow
+to customize the client behavior without modifying the client sources or the recipe ones.
+In the :ref:`hooks reference <hooks_reference>` you can find the full list of hook functions
+and exhaustive documentation about their arguments.
+
+Hooks can implement any functionality: it could be Conan commands, recipe interactions
+such as exporting or packaging, or interactions with the remotes.
 
 Here is an example of a simple hook:
 
@@ -57,20 +62,13 @@ This hook checks the recipe content prior to it being exported and prior to down
 ``pre_export()`` function checks the attributes of the ``conanfile`` object to see if there is an URL, a license and a description and if missing, 
 warns the user with a message through the ``output``. This is done **before** the recipe is exported to the local cache.
 
-The ``pre_source()`` function checks if the recipe contains a ``source()`` method (this time it is using the conanfile content instead of
+The ``pre_source()`` function checks if the recipe contains a ``source()`` method (this time it is using the *conanfile.py* content instead of
 the ``conanfile`` object) and in that case it checks if the download of the sources are likely coming from immutable places (a compressed
 file or a determined :command:`git checkout`). This is done **before** the **source()** method of the recipe is called.
 
 Any kind of Python script can be executed. You can create global functions and call them from different hook functions, import from a
 relative module and warn, error or even raise to abort the Conan client execution.
 
-Each function receives some parameters but not all of them are available for all functions as this may change depending on
-the context of the commands being executed, such as the recipe being in the local cache or not.
-
-.. important::
-
-    A detailed description of the functions allowed and its parameters as well as their execution can be found in it dedicated reference
-    section: :ref:`hooks_reference`.
 
 Other useful task where a hook may come handy are the upload and download actions. There are **pre** and **post** functions for every
 download/upload as a whole and for fine download tasks such as recipe and package downloads/uploads.
@@ -101,7 +99,7 @@ signature every time they are downloaded.
 Importing from a module
 -----------------------
 
-The hook interface should always be placed inside a Python file with the name of the hook and stored in the *hooks* folder. However,
+The hook interface should always be placed inside a Python file with the name of the hook and stored in the *~/.conan/hooks* folder. However,
 you can use functionalities from imported modules if you have them installed in your system or if they are installed with Conan:
 
 .. code-block:: python
@@ -132,15 +130,15 @@ Inside the *custom.py* from my *custom_module* there is:
     def my_printer(output):
         output.info("my_printer(): CUSTOM MODULE")
 
-And it can be used in hook importing the module:
+And it can be used in the hook importing the module, just like regular Python:
 
 .. code-block:: python
 
     from custom_module.custom import my_printer
 
-
     def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         my_printer(output)
+
 
 Storage, activation and sharing
 -------------------------------
@@ -168,11 +166,11 @@ They can be easily activated and deactivated from the command line using the :co
 
     $ conan config rm hooks.my_custom_hook/hook  # Deactivates 'my_custom_hook'
 
-There is also an environment variable ``CONAN_HOOKS`` to list the active hooks. Hooks listed in *conan.conf* will be loaded into
-this variable and values in the environment variable will be used to load the hooks.
+There is also an environment variable :ref:`env_vars_conan_hooks` that you can use to declare which hooks should be
+activated.
 
 Hooks are considered part of the Conan client configuration and can be shared as usual with the :ref:`conan_config_install` command.
-However, they can also be managed in isolated git repositories cloned into the *hooks* folder:
+However, they can also be managed in isolated Git repositories cloned into the *~/.conan/hooks* folder:
 
 .. code-block:: bash
 
@@ -185,22 +183,14 @@ This way you can easily change from one version to another.
 Official Hooks
 --------------
 
-There is a simple *attribute_checker* hook ready to be used in Conan. You can take it as a starting point to create your own ones.
+There are some officially maintained hooks in its own repository in `GitHub <https://github.com/conan-io/hooks>`_,
+including the ``attribute_checker`` that has been packaged with Conan sources for several versions (although it is
+distributed with Conan still, it is no longer maintained and we may remove it in the future, so we encourage you to install
+the one in the hooks repository and activate it).
 
-attribute_checker
-+++++++++++++++++
+Using the hooks in the official repository is as easy as installing them and activating the ones of interest:
 
-This hook is shipped together with the Conan client and it warns the user when recipes do not contain some metadata attributes.
+.. code-block:: text
 
-.. code-block:: python
-   :caption: *attribute_checker.py*
-
-    def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
-        # Check basic meta-data
-        for field in ["url", "license", "description"]:
-            field_value = getattr(conanfile, field, None)
-            if not field_value:
-                output.warn("Conanfile doesn't have '%s'. It is recommended to add it as attribute"
-                            % field)
-
-This hook comes activated by default.
+    conan config install https://github.com/conan-io/hooks.git -sf hooks -tf hooks
+    conan config set hooks.attribute_checker

--- a/howtos/sanitizers.rst
+++ b/howtos/sanitizers.rst
@@ -142,8 +142,15 @@ the variable.
 Using conan Hooks to set compiler environment variables
 #######################################################
 
-If you are not interested in modelling the settings in the Conan package you can use a Hook to modify
-the environment variable and apply the sanitizer flags to the build. It could be something like:
+.. important::
+
+    Take into account that the package ID doesn't encode information about the environment,
+    so different binaries due to different `CXX_FLAGS` would be considered by Conan as the same package.
+
+
+If you are not interested in modelling the settings in the Conan package you can use a
+:ref:`Hook <hooks_reference>` to modify the environment variable and apply the sanitizer
+flags to the build. It could be something like:
 
 .. code-block:: python
     :caption: *sanitizer_hook.py*
@@ -168,6 +175,3 @@ And then calling those functions from a *pre_build* and a *post_build* hook:
 
     def post_build(output, conanfile, **kwargs):
         reset_sanitize_address_flag()
-
-Note that here the package id will be the same for the binaries built with the hook activated and the
-ones that were built without it as we are not modelling the sanitizer setting.

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -328,6 +328,8 @@ For example, for a remote named "conan-center":
 
     See the :ref:`conan_user` command documentation for more information about login to remotes
 
+.. _env_vars_conan_hooks:
+
 CONAN_HOOKS
 -----------
 

--- a/reference/hooks.rst
+++ b/reference/hooks.rst
@@ -1,17 +1,18 @@
 .. _hooks_reference:
 
-Hooks [EXPERIMENTAL]
-======================
+Hooks
+=====
 
 .. warning::
 
     This is an **experimental** feature subject to breaking changes in future releases.
 
 The Conan hooks are Python functions that are intended to extend the Conan functionalities and let users customize the client behavior at
-determined execution points.
+determined execution points. Check the :ref:`hooks section in extending Conan <hooks>` to see
+some examples of how to use them and already available ones providing useful functionality.
 
 Hook interface
-----------------
+--------------
 
 Here you can see a complete example of all the hook functions available and the different parameters for each of them depending on the
 context:


### PR DESCRIPTION
Fix https://github.com/conan-io/docs/issues/1418

My main objective here was to differentiate the contents of the _Extending_ and the _Reference_ sections in the first paragraph of each page (I'm not sure if I've been able to do it). There are also some minor changes