### PR TITLE
remove * from the first search example

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -44,7 +44,7 @@ An MD5 Encrypter using the Poco Libraries
 
     .. code-block:: bash
 
-        $ conan search Poco* --remote=conan-center
+        $ conan search Poco --remote=conan-center
         Existing package recipes:
 
         Poco/1.7.8p3@pocoproject/stable


### PR DESCRIPTION
both
`conan search 'Poco*' --remote=conan-center`
and 
`conan search Poco --remote=conan-center` 
would work here, but the latter is more straight-forward and the page explains the Search command further later on