### PR TITLE
Add DnfTool to the SystemPackageTool docs

### DIFF
--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -553,8 +553,9 @@ For a special use case you can use also ``conans.tools.os_info`` object to detec
 - ``os_info.uname(options=None)``: Runs the "uname" command and returns the output. You can pass arguments with the `options` parameter.
 - ``os_info.detect_windows_subsystem()``: Returns "MSYS", "MSYS2", "CYGWIN" or "WSL" if any of these Windows subsystems are detected.
 
-You can also use ``SystemPackageTool`` class, that will automatically invoke the right system package tool: **apt**, **yum**, **pkg**,
-**pkgutil**, **brew** and **pacman** depending on the system we are running.
+You can also use ``SystemPackageTool`` class, that will automatically invoke the right system package
+tool: **apt**, **yum**, **dnf**, **pkg**, **pkgutil**, **brew** and **pacman** depending on the
+system we are running.
 
 ..  code-block:: python
 
@@ -599,8 +600,8 @@ SystemPackageTool
 
     def SystemPackageTool(runner=None, os_info=None, tool=None, recommends=False, output=None, conanfile=None)
 
-Available tool classes: **AptTool**, **YumTool**, **BrewTool**, **PkgTool**, **PkgUtilTool**, **ChocolateyTool**,
-**PacManTool**.
+Available tool classes: **AptTool**, **YumTool**, **DnfTool**, **BrewTool**, **PkgTool**,
+**PkgUtilTool**, **ChocolateyTool**, **PacManTool**.
 
 Methods:
     - **add_repository(repository, repo_key=None)**: Add ``repository`` address in your current repo list.

--- a/reference/config_files/conan.conf.rst
+++ b/reference/config_files/conan.conf.rst
@@ -70,7 +70,7 @@ The typical location of the **conan.conf** file is the directory ``~/.conan/``:
     path = ./data
 
     [proxies]
-    # Empty section will try to use system proxies.
+    # Empty (or missing) section will try to use system proxies.
     # As documented in https://requests.kennethreitz.org/en/latest/user/advanced/#proxies - but see below
     # for proxies to specific hosts
     # http = http://user:pass@10.10.1.10:3128/
@@ -240,13 +240,13 @@ Proxies
 
     ``no_proxy`` is deprecated in favor of ``no_proxy_match`` since Conan 1.16.
 
-If you leave the ``[proxies]`` section blank, conan will copy the system configured
-proxies, but if you configured some exclusion rule it won't work:
+If you leave the ``[proxies]`` section blank or delete the section, conan will copy the system
+configured proxies, but if you configured some exclusion rule it won't work:
 
 .. code-block:: text
 
     [proxies]
-    # Empty section will try to use system proxies.
+    # Empty (or missing) section will try to use system proxies.
 
 You can specify http and https proxies as follows. Use the `no_proxy_match` keyword to specify a list
 of URLs or patterns that will skip the proxy:

--- a/reference/config_files/conan.conf.rst
+++ b/reference/config_files/conan.conf.rst
@@ -70,8 +70,9 @@ The typical location of the **conan.conf** file is the directory ``~/.conan/``:
     path = ./data
 
     [proxies]
-    # Empty (or missing) section will try to use system proxies.
-    # As documented in https://requests.kennethreitz.org/en/latest/user/advanced/#proxies - but see below
+    # Empty section will try to use system proxies.
+    # If don't want proxy at all, remove section [proxies]
+    # As documented in http://docs.python-requests.org/en/latest/user/advanced/#proxies - but see below
     # for proxies to specific hosts
     # http = http://user:pass@10.10.1.10:3128/
     # http = http://10.10.1.10:3128
@@ -240,13 +241,17 @@ Proxies
 
     ``no_proxy`` is deprecated in favor of ``no_proxy_match`` since Conan 1.16.
 
-If you leave the ``[proxies]`` section blank or delete the section, conan will copy the system
-configured proxies, but if you configured some exclusion rule it won't work:
+If you are not using proxies at all, or you want to use the proxies specified by the operating system,
+just remove the ``[proxies]`` section completely. You can run :command:`conan config rm proxies`.
+
+If you leave the ``[proxies]`` section blank, conan will copy the system configured
+proxies, but if you configured some exclusion rule it won't work:
 
 .. code-block:: text
 
     [proxies]
-    # Empty (or missing) section will try to use system proxies.
+    # Empty section will try to use system proxies.
+    # If you don't want Conan to mess with proxies at all, remove section [proxies]
 
 You can specify http and https proxies as follows. Use the `no_proxy_match` keyword to specify a list
 of URLs or patterns that will skip the proxy:
@@ -254,7 +259,7 @@ of URLs or patterns that will skip the proxy:
 .. code-block:: text
 
     [proxies]
-    # As documented in https://requests.kennethreitz.org/en/latest/user/advanced/#proxies
+    # As documented in http://docs.python-requests.org/en/latest/user/advanced/#proxies
     http: http://user:pass@10.10.1.10:3128/
     http: http://10.10.1.10:3128
     https: http://10.10.1.10:1080

--- a/reference/config_files/conan.conf.rst
+++ b/reference/config_files/conan.conf.rst
@@ -71,8 +71,7 @@ The typical location of the **conan.conf** file is the directory ``~/.conan/``:
 
     [proxies]
     # Empty section will try to use system proxies.
-    # If don't want proxy at all, remove section [proxies]
-    # As documented in http://docs.python-requests.org/en/latest/user/advanced/#proxies - but see below
+    # As documented in https://requests.kennethreitz.org/en/latest/user/advanced/#proxies - but see below
     # for proxies to specific hosts
     # http = http://user:pass@10.10.1.10:3128/
     # http = http://10.10.1.10:3128
@@ -241,9 +240,6 @@ Proxies
 
     ``no_proxy`` is deprecated in favor of ``no_proxy_match`` since Conan 1.16.
 
-If you are not using proxies at all, or you want to use the proxies specified by the operating system,
-just remove the ``[proxies]`` section completely. You can run :command:`conan config rm proxies`.
-
 If you leave the ``[proxies]`` section blank, conan will copy the system configured
 proxies, but if you configured some exclusion rule it won't work:
 
@@ -251,7 +247,6 @@ proxies, but if you configured some exclusion rule it won't work:
 
     [proxies]
     # Empty section will try to use system proxies.
-    # If you don't want Conan to mess with proxies at all, remove section [proxies]
 
 You can specify http and https proxies as follows. Use the `no_proxy_match` keyword to specify a list
 of URLs or patterns that will skip the proxy:
@@ -259,7 +254,7 @@ of URLs or patterns that will skip the proxy:
 .. code-block:: text
 
     [proxies]
-    # As documented in http://docs.python-requests.org/en/latest/user/advanced/#proxies
+    # As documented in https://requests.kennethreitz.org/en/latest/user/advanced/#proxies
     http: http://user:pass@10.10.1.10:3128/
     http: http://10.10.1.10:3128
     https: http://10.10.1.10:1080


### PR DESCRIPTION
As commented on https://github.com/conan-io/conan/pull/5791 for Fedora starting with Fedora 31 yum will be removed. This PR adds documentation for the DnfTool