### PR TITLE
List python-patch-ng as a dependency on Arch Linux

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -87,7 +87,7 @@ Alternatively, build and install Conan manually using ``makepkg`` and ``pacman``
 Conan build files can be downloaded from AUR: https://aur.archlinux.org/packages/conan/.
 Make sure to first install the three Conan dependencies which are also found in AUR:
 
-- python-patch 
+- python-patch-ng 
 - python-node-semver
 - python-pluginbase
 


### PR DESCRIPTION
Conan 1.20 depends on patch-ng instead of patch. patch-ng is now packaged for Arch Linux as python-patch-ng.