### PR TITLE
Mentioned needing to specify remotes in search

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -58,6 +58,8 @@ An MD5 Encrypter using the Poco Libraries
         Poco/1.9.1@pocoproject/stable
         Poco/1.9.2@pocoproject/stable
 
+    Conan remotes must be specified in search. It will otherwise only search local cache.
+
 3. We got some interesting references for Poco. Let's inspect the metadata of the 1.9.0 version:
 
     .. code-block:: bash


### PR DESCRIPTION
I noticed you can't access remotes by default with conan search and added a note about it to that section in getting started. #[6093](https://github.com/conan-io/conan/issues/6093) I will take a look at updating the docs on the search command in the hopes that putting the words default and remote will let google find it.