### PR TITLE
Change create command build policy documentation

### DIFF
--- a/reference/commands/creator/create.rst
+++ b/reference/commands/creator/create.rst
@@ -81,7 +81,7 @@ to know more about 'test_folder' project.
                             others. Allows multiple --build parameters. 'pattern'
                             is a fnmatch file pattern of a package reference.
                             Default behavior: If you don't specify anything, it
-                            will be similar to '--build=reference', but package
+                            will be similar to '--build=package name', but package
                             recipes can override it with their 'build_policy'
                             attribute in the conanfile.py.
       -e ENV, --env ENV     Environment variables that will be set during the

--- a/reference/commands/creator/create.rst
+++ b/reference/commands/creator/create.rst
@@ -81,7 +81,7 @@ to know more about 'test_folder' project.
                             others. Allows multiple --build parameters. 'pattern'
                             is a fnmatch file pattern of a package reference.
                             Default behavior: If you don't specify anything, it
-                            will be similar to '--build=never', but package
+                            will be similar to '--build=reference', but package
                             recipes can override it with their 'build_policy'
                             attribute in the conanfile.py.
       -e ENV, --env ENV     Environment variables that will be set during the


### PR DESCRIPTION
As explained in https://github.com/conan-io/conan/pull/6131 the --build policy help message was the same for the commands create, test, install and workspace but the behavior for the create command by default was not to behave as `--build=never` but as `--build=package name` which could be misleading.