### PR TITLE
Documents cpp_info.names["generator_name"] feature

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -898,7 +898,7 @@ This object should be filled in ``package_info()`` method.
 +----------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.names["generator"] | | Alternative name for the package used by an specific generator to create files or variables.          |
 |                                  | | If set for a generator it will overrite the information provided by self.cpp_info.name.               |
-|                                  | | Like the cpp_info.name, is supported by `cmake`, `cmake_multi`, `cmake_find_package`,                 |
+|                                  | | Like the cpp_info.name, this is only supported by `cmake`, `cmake_multi`, `cmake_find_package`,       |
 |                                  | | `cmake_find_package_multi`, `cmake_paths` and `pkg_config` generators.                                |
 +----------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.system_libs        | Ordered list with the system library names. Defaulted to ``[]`` (empty)                                 |

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -858,49 +858,54 @@ library paths... There are some default values that will be applied automaticall
 
 This object should be filled in ``package_info()`` method.
 
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| NAME                           | DESCRIPTION                                                                                             |
-+================================+=========================================================================================================+
-| self.cpp_info.includedirs      | Ordered list with include paths. Defaulted to ``["include"]``                                           |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.libdirs          | Ordered list with lib paths. Defaulted to ``["lib"]``                                                   |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.resdirs          | Ordered list of resource (data) paths. Defaulted to ``["res"]``                                         |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.bindirs          | Ordered list with paths to binaries (executables, dynamic libraries,...). Defaulted to ``["bin"]``      |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.builddirs        | | Ordered list with build scripts directory paths. Defaulted to ``[""]`` (Package folder directory)     |
-|                                | | CMake generators will search in these dirs for files like *findXXX.cmake*                             |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.libs             | Ordered list with the library names, Defaulted to ``[]`` (empty)                                        |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.defines          | Preprocessor definitions. Defaulted to ``[]`` (empty)                                                   |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cflags           | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                             |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cppflags         | [DEPRECATED: use cxxflags instead]                                                                      |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cxxflags         | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.sharedlinkflags  | Ordered list with linker flags (shared libs). Defaulted to ``[]`` (empty)                               |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.exelinkflags     | Ordered list with linker flags (executables). Defaulted to ``[]`` (empty)                               |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.frameworks       | Ordered list with the framework names (OSX), Defaulted to ``[]`` (empty)                                |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.frameworkdirs    | Ordered list with frameworks search paths (OSX). Defaulted to ``["Frameworks"]``                        |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.rootpath         | Filled with the root directory of the package, see ``deps_cpp_info``                                    |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.name             | | Alternative name for the package used by generators to create files or variables.                     |
-|                                | | Defaulted to the package name. Supported by `cmake`, `cmake_multi`, `cmake_find_package`,             |
-|                                | | `cmake_find_package_multi` and `pkg_config` generators.                                               |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.system_libs      | Ordered list with the system library names. Defaulted to ``[]`` (empty)                                 |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.build_modules    | | List of relative paths to build system related utility module files created by the package. Used by   |
-|                                | | CMake generators to export *.cmake* files with functions for consumers. Defaulted to ``[]`` (empty)   |
-+--------------------------------+---------------------------------------------------------------------------------------------------------+
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| NAME                             | DESCRIPTION                                                                                             |
++==================================+=========================================================================================================+
+| self.cpp_info.includedirs        | Ordered list with include paths. Defaulted to ``["include"]``                                           |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.libdirs            | Ordered list with lib paths. Defaulted to ``["lib"]``                                                   |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.resdirs            | Ordered list of resource (data) paths. Defaulted to ``["res"]``                                         |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.bindirs            | Ordered list with paths to binaries (executables, dynamic libraries,...). Defaulted to ``["bin"]``      |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.builddirs          | | Ordered list with build scripts directory paths. Defaulted to ``[""]`` (Package folder directory)     |
+|                                  | | CMake generators will search in these dirs for files like *findXXX.cmake*                             |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.libs               | Ordered list with the library names, Defaulted to ``[]`` (empty)                                        |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.defines            | Preprocessor definitions. Defaulted to ``[]`` (empty)                                                   |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cflags             | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                             |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cppflags           | [DEPRECATED: use cxxflags instead]                                                                      |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cxxflags           | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.sharedlinkflags    | Ordered list with linker flags (shared libs). Defaulted to ``[]`` (empty)                               |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.exelinkflags       | Ordered list with linker flags (executables). Defaulted to ``[]`` (empty)                               |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.frameworks         | Ordered list with the framework names (OSX), Defaulted to ``[]`` (empty)                                |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.frameworkdirs      | Ordered list with frameworks search paths (OSX). Defaulted to ``["Frameworks"]``                        |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.rootpath           | Filled with the root directory of the package, see ``deps_cpp_info``                                    |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.name               | | Alternative name for the package used by generators to create files or variables.                     |
+|                                  | | Defaulted to the package name. Supported by `cmake`, `cmake_multi`, `cmake_find_package`,             |
+|                                  | | `cmake_find_package_multi`, `cmake_paths` and `pkg_config` generators.                                |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.names["generator"] | | Alternative name for the package used by an specific generator to create files or variables.          |
+|                                  | | If set for a generator it will overrite the information provided by self.cpp_info.name.               |
+|                                  | | Like the cpp_info.name, is supported by `cmake`, `cmake_multi`, `cmake_find_package`,                 |
+|                                  | | `cmake_find_package_multi`, `cmake_paths` and `pkg_config` generators.                                |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.system_libs        | Ordered list with the system library names. Defaulted to ``[]`` (empty)                                 |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
+| self.cpp_info.build_modules      | | List of relative paths to build system related utility module files created by the package. Used by   |
+|                                  | | CMake generators to export *.cmake* files with functions for consumers. Defaulted to ``[]`` (empty)   |
++----------------------------------+---------------------------------------------------------------------------------------------------------+
 
 The paths of the directories in the directory variables indicated above are relative to the
 :ref:`self.package_folder<folders_attributes_reference>` directory.

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -202,6 +202,7 @@ The ``cpp_info`` attribute has the following properties you can assign/append to
 .. code-block:: python
 
     self.cpp_info.name = "<PKG_NAME>"
+    self.cpp_info.names["generator_name"] = "<PKG_NAME>"
     self.cpp_info.includedirs = ['include']  # Ordered list of include paths
     self.cpp_info.libs = []  # The libs to link against
     self.cpp_info.libdirs = ['lib']  # Directories where libraries can be found

--- a/reference/generators/cmake.rst
+++ b/reference/generators/cmake.rst
@@ -18,7 +18,8 @@ Variables in *conanbuildinfo.cmake*
 - **Package declared variables**:
 
   For each requirement *conanbuildinfo.cmake* file declares the following variables. Where ``<PKG-NAME>`` is the placeholder for the name of
-  the require in uppercase (``ZLIB`` for ``zlib/1.2.8@lasote/stable``) or the one declared in ``cpp_info.name``:
+  the require in uppercase (``ZLIB`` for ``zlib/1.2.8@lasote/stable``) or the one declared in ``cpp_info.name`` or in 
+  ``cpp_info.names["cmake"]`` if specified:
 
   +---------------------------------------+----------------------------------------------------------------------+
   | NAME                                  | VALUE                                                                |

--- a/reference/generators/cmake_find_package.rst
+++ b/reference/generators/cmake_find_package.rst
@@ -18,7 +18,8 @@ a ``Findzlib.cmake`` file will be generated.
 Variables in Find<PKG-NAME>.cmake
 ---------------------------------
 
-Being ``<PKG-NAME>`` the package name used in the reference (by default) or the one declared in ``cpp_info.name``:
+Being ``<PKG-NAME>`` the package name used in the reference (by default) or the one declared in ``cpp_info.name`` or in 
+``cpp_info.names["cmake_find_package"]`` if specified:
 
 +------------------------------------+-----------------------------------------------------------------------------------------------------+
 | NAME                               | VALUE                                                                                               |

--- a/reference/generators/cmake_find_package_multi.rst
+++ b/reference/generators/cmake_find_package_multi.rst
@@ -17,7 +17,8 @@ Generated files
 ---------------
 
 For each conan package in your graph, it will generate 2 files and 1 more per different ``build_type``.
-Being ``<PKG-NAME>`` the package name used in the reference (by default) or the one declared in ``cpp_info.name``:
+Being ``<PKG-NAME>`` the package name used in the reference (by default) or the one declared in ``cpp_info.name`` or in 
+``cpp_info.names["cmake_find_package_multi"]`` if specified:
 
 +----------------------------------------+--------------------------------------------------------------------------------------+
 | NAME                                   | CONTENTS                                                                             |

--- a/reference/generators/cmake_paths.rst
+++ b/reference/generators/cmake_paths.rst
@@ -27,4 +27,4 @@ Variables in *conan_paths.cmake*
 +-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Where ``<PKG-NAME>`` is the placeholder for the name of the require in uppercase (``ZLIB`` for ``zlib/1.2.8@lasote/stable``) or the one
-declared in ``cpp_info.name``.
+declared in ``cpp_info.name`` or in ``cpp_info.names["cmake_paths"]`` if specified.

--- a/reference/generators/pkg_config.rst
+++ b/reference/generators/pkg_config.rst
@@ -4,7 +4,8 @@
 pkg_config
 ==========
 
-Generates N files named ``<PKG-NAME>.pc`` (where ``<PKG-NAME`` is the name declared by dependencies in ``cpp_info.name``), containing a
+Generates N files named ``<PKG-NAME>.pc`` (where ``<PKG-NAME`` is the name declared by dependencies in 
+``cpp_info.name`` or in ``cpp_info.names["pkg_config"]`` if specified), containing a
 valid pkg-config file syntax. The ``prefix`` variable is automatically adjusted to the ``package_folder``.
 
 Go to :ref:`Integrations/pkg-config and pc files/Use the pkg_config generator<pkg_config_generator_example>`


### PR DESCRIPTION
Document changes introduced by https://github.com/conan-io/conan/pull/6033
Now a different name can be specified for each generator that supports the `cpp_info.name` property.