### PR TITLE
Update cross_building.rst

### DIFF
--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -302,6 +302,8 @@ RPI one:
 
 .. code-block:: text
 
+    include(default)
+
     standalone_toolchain=/myfolder/arm_21_toolchain # Adjust this path
     target_host=arm-linux-androideabi
     cc_compiler=clang
@@ -338,6 +340,8 @@ match the gcc toolchain compiler:
 
 
 .. code-block:: text
+
+    include(default)
 
     standalone_toolchain=/myfolder/arm_21_toolchain
     target_host=arm-linux-androideabi


### PR DESCRIPTION
Formula that have some generators that run on the host (e.g. protoc) require `arch_build` and `os_build` to be set in the profile. Thus, include the default profile that sets them.