### PR TITLE
Update Conan cache folder description

### DIFF
--- a/mastering/custom_cache.rst
+++ b/mastering/custom_cache.rst
@@ -36,7 +36,7 @@ Windows users:
 .. code-block:: bash
 
    $ SET CONAN_USER_HOME=c:\data
-   $ conan install . # call conan normally, config & data will be in c:\data
+   $ conan install . # call conan normally, config & data will be in c:\data\.conan
 
 
 Linux/macOS users:
@@ -44,7 +44,7 @@ Linux/macOS users:
 .. code-block:: bash
 
    $ export CONAN_USER_HOME=/tmp/conan
-   $ conan install . # call conan normally, config & data will be in /tmp/conan
+   $ conan install . # call conan normally, config & data will be in /tmp/conan/.conan
 
 You can now:
 

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -542,8 +542,9 @@ CONAN_USER_HOME
 
 **Defaulted to**: Not defined
 
-Allows defining a custom Conan cache directory. Can be useful for concurrent builds under different
-users in CI, to retrieve and store per-project specific dependencies (useful for deployment, for example).
+Allows defining a custom base directory for Conan cache directory. Can be useful for concurrent builds under different
+users in CI, to retrieve and store per-project specific dependencies (useful for deployment, for example). Conan will
+generate the folder ``.conan`` under the custom base path.
 
 .. seealso::
 


### PR DESCRIPTION
Based on follow commands:

```
$ conan --version
Conan version 1.21.1
$ export CONAN_USER_HOME=/tmp/foo
$ conan profile new default --detect
Found gcc 9.2
Found clang 9.0
gcc>=5, using the major as version

Profile created with detected settings: /tmp/foo/.conan/profiles/default
```

As you can see, `CONAN_USER_HOME` determines the base folder for conan cache folder, not the conan cache itself.

I didn't check on Windows, but I presume the result will be the same.


Related on issue https://github.com/conan-io/conan/issues/6407