### PR TITLE
Add GLOBAL for targets

### DIFF
--- a/integrations/build_system/cmake/cmake_generator.rst
+++ b/integrations/build_system/cmake/cmake_generator.rst
@@ -58,7 +58,8 @@ For **modern cmake (>=3.1.2)**, you can use the following approach:
     target_link_libraries(timer CONAN_PKG::poco)
 
 Using ``TARGETS`` as argument, ``conan_basic_setup()`` will internally call the macro ``conan_define_targets()``
-which defines cmake ``INTERFACE IMPORTED`` targets, one per package. These targets, named ``CONAN_PKG::PackageName`` can be used to link against, instead of using global cmake setup.
+which defines cmake ``INTERFACE IMPORTED GLOBAL`` targets, one per package. These targets, named ``CONAN_PKG::PackageName`` 
+can be used to link against, instead of using global cmake setup.
 
 .. seealso::
 

--- a/reference/generators/cmake.rst
+++ b/reference/generators/cmake.rst
@@ -167,12 +167,13 @@ Helper to link all libraries to a specified target.
 
 These targets are:
 
-- A ``CONAN_PKG::<PKG-NAME>`` target per package in the dependency graph. This is an ``IMPORTED INTERFACE`` target. ``IMPORTED`` because it is
+- A ``CONAN_PKG::<PKG-NAME>`` target per package in the dependency graph. This is an ``IMPORTED INTERFACE GLOBAL`` target. ``IMPORTED`` because it is
   external, a pre-compiled library. ``INTERFACE``, because it doesn't necessarily match a library, it could be a header-only library, or the
-  package could even contain several libraries. It contains all the properties (include paths, compile flags, etc.) that are defined in the
+  package could even contain several libraries. It is also ``GLOBAL`` so that ``ALIAS`` of these targets can be defined in the consumer.
+  It contains all the properties (include paths, compile flags, etc.) that are defined in the
   ``package_info()`` method of the recipe.
 
-- Inside each package a ``CONAN_LIB::<PKG-NAME>_<LIB-NAME>`` target will be generated for each library. Its type is ``IMPORTED UNKNOWN`` and its
+- Inside each package a ``CONAN_LIB::<PKG-NAME>_<LIB-NAME>`` target will be generated for each library. Its type is ``IMPORTED UNKNOWN GLOBAL`` and its
   main purpose is to provide a correct link order. Their only properties are the location and the dependencies.
 
 - A ``CONAN_PKG`` depends on every ``CONAN_LIB`` that belongs to it, and to its direct public dependencies (e.g. other ``CONAN_PKG`` targets

--- a/reference/generators/cmakemulti.rst
+++ b/reference/generators/cmakemulti.rst
@@ -61,10 +61,11 @@ Helper to link all libraries to a specified target.
 
 These targets are:
 
-- A ``CONAN_PKG::<PKG-NAME>`` target per package in the dependency graph. This is an ``IMPORTED INTERFACE`` target. ``IMPORTED`` because it is
-  external, a pre-compiled library. ``INTERFACE``, because it doesn't necessarily match a library, it could be a header-only library, or the
-  package could even contain several libraries. It contains all the properties (include paths, compile flags, etc.) that are defined in the
-  ``package_info()`` method of the recipe.
+- A ``CONAN_PKG::<PKG-NAME>`` target per package in the dependency graph. This is an ``IMPORTED INTERFACE GLOBAL`` target. ``IMPORTED`` 
+  because it is external, a pre-compiled library. ``INTERFACE``, because it doesn't necessarily match a library, it could be a header-only 
+  library, or the package could even contain several libraries. It is also ``GLOBAL`` so that ``ALIAS`` of these targets can be defined 
+  in the consumer. It contains all the properties (include paths, compile flags, etc.) that are defined in the ``package_info()`` method 
+  of the recipe.
 
 - Inside each package a ``CONAN_LIB::<PKG-NAME>_<LIB-NAME>`` target will be generated for each library. Its type is ``IMPORTED UNKNOWN`` and its
   main purpose is to provide a correct link order. Their only properties are the location and the dependencies.


### PR DESCRIPTION
For Conan 1.22 we'll set the generated targets as `GLOBAL` so that they can be added as `ALIAS`: https://github.com/conan-io/conan/pull/6438
