### PR TITLE
Fix virtualenv activate/deactivate filename

### DIFF
--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -63,10 +63,10 @@ This will generate a few files that can be called to activate and deactivate the
 
 .. code-block:: bash
 
-    $ activate_run.sh # $ source activate_run.sh in Unix/Linux
+    $ activate.sh # $ source activate.sh in Unix/Linux
     $ greet
     > Hello World!
-    $ deactivate_run.sh # $ source deactivate_run.sh in Unix/Linux
+    $ deactivate.sh # $ source deactivate.sh in Unix/Linux
 
 Imports
 -------
@@ -315,10 +315,10 @@ Installing and running this package can be done using any of the methods present
     $ conan install HelloRun/0.1@user/testing -g virtualrunenv
     # You can specify the remote with -r=my-remote
     # It will not install Hello/0.1@...
-    $ activate_run.sh # $ source activate_run.sh in Unix/Linux
+    $ activate.sh # $ source activate.sh in Unix/Linux
     $ greet
     > Hello World!
-    $ deactivate_run.sh # $ source deactivate_run.sh in Unix/Linux
+    $ deactivate.sh # $ source deactivate.sh in Unix/Linux
 
 .. _deployment_challenges:
 

--- a/howtos/manage_shared_libraries/env_vars.rst
+++ b/howtos/manage_shared_libraries/env_vars.rst
@@ -174,7 +174,7 @@ In the terminal window:
 .. code-block:: bash
 
     $ conan install .
-    $ source activate_run
+    $ source activate
     $ toolA --someparams
     # Only For Mac OS users to avoid restrictions:
     $ DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH toolA --someparams

--- a/mastering/virtualenv.rst
+++ b/mastering/virtualenv.rst
@@ -113,7 +113,7 @@ Use the generator ``virtualrunenv`` to activate an environment that will:
 - Append to ``PATH`` environment variable every ``bin`` folder of your requirements.
 - Append to ``LD_LIBRARY_PATH`` and ``DYLD_LIBRARY_PATH`` environment variables each ``lib`` folder of  your requirements.
 
-The generator will create ``activate_run`` and ``deactivate_run`` files. This generator is especially useful:
+The generator will create ``activate`` and ``deactivate`` files. This generator is especially useful:
 
 - If you are requiring packages with shared libraries and you are running some executable that needs those libraries.
 - If you have a requirement with some tool (executable) and you need it in the path.

--- a/reference/generators/virtualrunenv.rst
+++ b/reference/generators/virtualrunenv.rst
@@ -11,8 +11,8 @@ virtualrunenv
 Created files
 -------------
 
-- activate_run.{sh|bat}
-- deactivate_run.{sh|bat}
+- activate.{sh|bat}
+- deactivate.{sh|bat}
 
 Usage
 -----
@@ -21,13 +21,13 @@ Linux/macOS:
 
 .. code-block:: bash
 
-    > source activate_run.sh
+    > source activate.sh
 
 Windows:
 
 .. code-block:: bash
 
-    > activate_run.bat
+    > activate.bat
 
 Variables declared
 ------------------


### PR DESCRIPTION
I found a mistake in the documentation. The virtualenv generator files are "activate.sh", "deactivate.sh", "activate.bat" and "deactivate.bat"