### PR TITLE
Warning for conan-docker-tools images

### DIFF
--- a/howtos/run_conan_in_docker.rst
+++ b/howtos/run_conan_in_docker.rst
@@ -112,11 +112,17 @@ Cross-building and uploading a package along with all its missing dependencies f
     $ conan upload "*" -r myremoteARMV7 --all
 
 
-
 .. _available_docker_images:
 
 Available Docker images
 -----------------------
+
+We provide a set of images with the most common compilers installed that can be used to generate Conan packages for different profiles.
+
+.. warning::
+
+    The images listed below are intended for generating opensource library packages and we cannot guarantee any kind of stability.
+    We strongly recommend using your own generated images for production environments taking the dockerfiles as a reference.
 
 **GCC** images
 
@@ -182,4 +188,4 @@ Available Docker images
 +--------------------------------------------------------------------------------------+------------------+
 
 
-The Dockerfiles for all these images can be found `here <https://github.com/conan-io/conan-docker-tools>`_.
+The Dockerfiles for all these images can be found in the `conan-docker-tools repository<https://github.com/conan-io/conan-docker-tools>`_.

--- a/howtos/run_conan_in_docker.rst
+++ b/howtos/run_conan_in_docker.rst
@@ -118,11 +118,12 @@ Available Docker images
 -----------------------
 
 We provide a set of images with the most common compilers installed that can be used to generate Conan packages for different profiles.
+Their dockerfiles can be found in the `Conan Docker Tools <https://github.com/conan-io/conan-docker-tools>`_ repository.
 
 .. warning::
 
     The images listed below are intended for generating opensource library packages and we cannot guarantee any kind of stability.
-    We strongly recommend using your own generated images for production environments taking the dockerfiles as a reference.
+    We strongly recommend using your own generated images for production environments taking these dockerfiles as a reference.
 
 **GCC** images
 
@@ -186,6 +187,3 @@ We provide a set of images with the most common compilers installed that can be 
 +--------------------------------------------------------------------------------------+------------------+
 | `conanio/clang50 (Clang 5) <https://hub.docker.com/r/conanio/clang50/>`_             | x86_64           |
 +--------------------------------------------------------------------------------------+------------------+
-
-
-The Dockerfiles for all these images can be found in the `conan-docker-tools repository<https://github.com/conan-io/conan-docker-tools>`_.

--- a/howtos/run_conan_in_docker.rst
+++ b/howtos/run_conan_in_docker.rst
@@ -122,7 +122,7 @@ Their dockerfiles can be found in the `Conan Docker Tools <https://github.com/co
 
 .. warning::
 
-    The images listed below are intended for generating opensource library packages and we cannot guarantee any kind of stability.
+    The images listed below are intended for generating open-source library packages and we cannot guarantee any kind of stability.
     We strongly recommend using your own generated images for production environments taking these dockerfiles as a reference.
 
 **GCC** images

--- a/integrations/cross_platform/android.rst
+++ b/integrations/cross_platform/android.rst
@@ -69,9 +69,10 @@ By adjusting ``arch`` setting, you may cross-compile for ``x86`` and ``x86_64`` 
 Using Docker images
 ===================
 
-If you're using `docker <https://www.docker.com/>`_ for builds, you may consider using docker images from the `conan docker tools <https://github.com/conan-io/conan-docker-tools>`_ project.
+If you're using `Docker <https://www.docker.com/>`_ for builds, you may consider using docker images from the
+`Conan Docker Tools <https://github.com/conan-io/conan-docker-tools>`_ repository.
 
-Currently, conan docker tools provide the following Android images:
+Currently, Conan Docker Tools provide the following Android images:
 
 - conanio/android-clang8
 - conanio/android-clang8-x86


### PR DESCRIPTION
We are using and maintaining the images in Conan Docker Tools for open source usage and we'd like to clearly state that in the documentation and warn people to not use them in production or do it at their own risk.

Please provide feedback about the text and I will open a PR later to the readme on the conan-docker-tools repo.