### PR TITLE
Convert all references to lowercase

### DIFF
--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -489,7 +489,7 @@ All the modes can be applied to all dependencies, or to individual ones:
 
   .. code-block:: text
 
-    MyLib/1.2.3@user/testing       => MyLib/1.Y.Z
+    my_lib/1.2.3@user/testing       => my_lib/1.Y.Z
     my_other_lib/2.3.4@user/testing  => my_other_lib/2.Y.Z
 
   In this mode, versions starting with ``0`` are considered unstable and mapped to the full version:

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -407,7 +407,7 @@ If it is necessary to change the default behavior, the applied versioning schema
         requires = "my_other_lib/2.0@lasote/stable"
 
         def package_id(self):
-            myotherlib = self.info.requires["MyOtherLib"]
+            myotherlib = self.info.requires["my_other_lib"]
 
             # Any change in the MyOtherLib version will change current Package ID
             myotherlib.version = myotherlib.full_version

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -561,7 +561,7 @@ All the modes can be applied to all dependencies, or to individual ones:
   .. code-block:: python
 
     def package_id(self):
-        self.info.requires["MyOtherLib"].full_package_mode()
+        self.info.requires["my_other_lib"].full_package_mode()
 
   Any change to the dependency, including its binary package-id, will in turn
   produce a new package-id for the consumer package.

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -777,7 +777,7 @@ Let's see some examples, corresponding to common scenarios:
           # or Package ID will affect our package ID
           self.info.requires["my_other_lib"].full_package_mode()
 
-          # Or any change in the MyOtherLib version, user or
+          # Or any change in the my_other_lib version, user or
           # channel will affect our package ID
           self.info.requires["my_other_lib"].full_recipe_mode()
 

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -470,7 +470,7 @@ All the modes can be applied to all dependencies, or to individual ones:
 
   .. code-block:: text
 
-    MyLib/1.2.3@user/testing       => MyLib/1.Y.Z
+    my_lib/1.2.3@user/testing       => my_lib/1.Y.Z
     my_other_lib/2.3.4@user/testing  =>
 
   So the direct dependencies are mapped to the major version only. Changing its channel, or using version

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -318,7 +318,7 @@ Dependency Issues
 Let's define a simple scenario whereby there are two packages: ``my_other_lib/2.0`` and ``my_lib/1.0`` which depends on
 ``my_other_lib/2.0``. Let's assume that their recipes and binaries have already been created and uploaded to a Conan remote.
 
-Now, a new release for ``my_other_lib/2.1`` is released with an improved recipe and new binaries. The ``my_lib/1.0`` is modified and is required to be upgraded to ``MyOtherLib/2.1``.
+Now, a new release for ``my_other_lib/2.1`` is released with an improved recipe and new binaries. The ``my_lib/1.0`` is modified and is required to be upgraded to ``my_other_lib/2.1``.
 
 .. note::
 

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -744,7 +744,7 @@ Library Types: Shared, Static, Header-only
 Let's see some examples, corresponding to common scenarios:
 
 - ``my_lib/1.0`` is a shared library that links with a static library ``my_other_lib/2.0`` package.
-  When a new ``MyOtherLib/2.1`` version is released: Do I need to create a new binary for
+  When a new ``my_other_lib/2.1`` version is released: Do I need to create a new binary for
   ``my_lib/1.0`` to link with it?
 
   Yes, always, as the implementation is embedded in the ``my_lib/1.0`` shared library. If we

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -773,7 +773,7 @@ Let's see some examples, corresponding to common scenarios:
   .. code-block:: python
 
       def package_id(self):
-          # Any change in the MyOtherLib version, user or channel
+          # Any change in the my_other_lib version, user or channel
           # or Package ID will affect our package ID
           self.info.requires["my_other_lib"].full_package_mode()
 

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -490,7 +490,7 @@ All the modes can be applied to all dependencies, or to individual ones:
   .. code-block:: text
 
     MyLib/1.2.3@user/testing       => MyLib/1.Y.Z
-    MyOtherLib/2.3.4@user/testing  => my_other_lib/2.Y.Z
+    my_other_lib/2.3.4@user/testing  => my_other_lib/2.Y.Z
 
   In this mode, versions starting with ``0`` are considered unstable and mapped to the full version:
 

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -474,7 +474,7 @@ All the modes can be applied to all dependencies, or to individual ones:
     my_other_lib/2.3.4@user/testing  =>
 
   So the direct dependencies are mapped to the major version only. Changing its channel, or using version
-  ``MyLib/1.4.5`` will still produce ``MyLib/1.Y.Z`` and thus the same package-id.
+  ``my_lib/1.4.5`` will still produce ``my_lib/1.Y.Z`` and thus the same package-id.
   The indirect, transitive dependency doesn't affect the package-id at all.
 
 - ``semver_mode()``: In this mode, only a major release version (starting from **1.0.0**) changes the package ID.

--- a/creating_packages/define_abi_compatibility.rst
+++ b/creating_packages/define_abi_compatibility.rst
@@ -12,7 +12,7 @@ different binary:
 .. code-block:: python
 
     class MyLibConanPackage(ConanFile):	
-        name = "MyLib"
+        name = "mylib"
         version = "1.0"
         settings = "os", "arch", "compiler", "build_type"
 
@@ -20,13 +20,13 @@ When this package is installed by a *conanfile.txt*, another package *conanfile.
 
 .. code-block:: bash
 
-    $ conan install MyLib/1.0@user/channel -s arch=x86_64 -s ...
+    $ conan install mylib/1.0@user/channel -s arch=x86_64 -s ...
 
 The process is:
 
 1. Conan gets the user input settings and options. Those settings and options can come from the command line, profiles or from the values
    cached in the latest :command:`conan install` execution.
-2. Conan retrieves the ``MyLib/1.0@user/channel`` recipe, reads the ``settings`` attribute, and assigns the necessary values.
+2. Conan retrieves the ``mylib/1.0@user/channel`` recipe, reads the ``settings`` attribute, and assigns the necessary values.
 3. With the current package values for ``settings`` (also ``options`` and ``requires``), it will compute a SHA1 hash that will serve as the binary
    package ID, e.g., ``c6d75a933080ca17eb7f076813e7fb21aaa740f2``.
 4. Conan will try to find the ``c6d75...`` binary package. If it exists, it will be retrieved. If it cannot be found, it will fail and indicate that it
@@ -36,7 +36,7 @@ If the package is installed again using different settings, for example, on a 32
 
 .. code-block:: bash
 
-    $ conan install MyLib/1.0@user/channel -s arch=x86 -s ...
+    $ conan install mylib/1.0@user/channel -s arch=x86 -s ...
 
 The process will be repeated with a different generated package ID, because the ``arch``
 setting will have a different value. The same applies to different compilers, compiler versions, build types. When generating multiple
@@ -95,7 +95,7 @@ For example, if you are sure your package ABI compatibility is fine for GCC vers
     from conans.model.version import Version
 
     class PkgConan(ConanFile):
-        name = "Pkg"
+        name = "pkg"
         version = "1.0"
         settings = "compiler", "build_type"
 
@@ -112,24 +112,24 @@ Let's try and check that it works properly when installing the package for GCC 4
 
 .. code-block:: bash
 
-    $ conan create . Pkg/1.0@myuser/mychannel -s compiler=gcc -s compiler.version=4.5 ...
+    $ conan create . pkg/1.0@myuser/mychannel -s compiler=gcc -s compiler.version=4.5 ...
 
     Requirements
-        Pkg/1.0@myuser/mychannel from local
+        pkg/1.0@myuser/mychannel from local
     Packages
-        Pkg/1.0@myuser/mychannel:af044f9619574eceb8e1cca737a64bdad88246ad
+        pkg/1.0@myuser/mychannel:af044f9619574eceb8e1cca737a64bdad88246ad
     ...
 
 We can see that the computed package ID is ``af04...46ad`` (not real). What happens if we specify GCC 4.6?
 
 .. code-block:: bash
 
-    $ conan install Pkg/1.0@myuser/mychannel -s compiler=gcc -s compiler.version=4.6 ...
+    $ conan install pkg/1.0@myuser/mychannel -s compiler=gcc -s compiler.version=4.6 ...
 
     Requirements
-        Pkg/1.0@myuser/mychannel from local
+        pkg/1.0@myuser/mychannel from local
     Packages
-        Pkg/1.0@myuser/mychannel:af044f9619574eceb8e1cca737a64bdad88246ad
+        pkg/1.0@myuser/mychannel:af044f9619574eceb8e1cca737a64bdad88246ad
 
 The required package has the same result again ``af04...46ad``. Now we can try using GCC 4.4 (< 4.5):
 
@@ -138,9 +138,9 @@ The required package has the same result again ``af04...46ad``. Now we can try u
     $ conan install Pkg/1.0@myuser/mychannel -s compiler=gcc -s compiler.version=4.4 ...
 
     Requirements
-        Pkg/1.0@myuser/mychannel from local
+        pkg/1.0@myuser/mychannel from local
     Packages
-        Pkg/1.0@myuser/mychannel:7d02dc01581029782b59dcc8c9783a73ab3c22dd
+        pkg/1.0@myuser/mychannel:7d02dc01581029782b59dcc8c9783a73ab3c22dd
 
 The computed package ID is different which means that we need a different binary package for GCC 4.4.
 
@@ -215,7 +215,6 @@ It is the responsibility of the developer to guarantee that such binaries are in
                 compatible_pkg.options.optimized = optimized
                 self.compatible_packages.append(compatible_pkg)
 
-
 This recipe defines that the binaries are compatible with binaries of itself built with a lower optimization value. It can
 have up to 3 different binaries, one for each different value of ``optimized`` option. The ``package_id()`` defines that a binary 
 built with ``optimized=1`` can be perfectly linked and will run even if someone defines ``optimized=2``, or ``optimized=3``
@@ -230,7 +229,6 @@ based on this compatibility model, it only applies to use-cases where the binari
 
     Compatible packages are a match for a binary in the dependency graph. When a compatible package is found, the :command:`--build=missing`
     build policy will **not** build from sources that package.
-
 
 Check the :ref:`Compatible Compilers<compatible_compilers>` section to see another example of how to take benefit of compatible packages.
 
@@ -312,36 +310,33 @@ In the above example, we will transform the package ID of the ``Visual Studio`` 
 be able to differentiate the packages built with ``intel`` with the ones built by ``Visual Studio`` because both will have the same package ID,
 and that is not always desirable.
 
-
-
-
 .. _problem_of_dependencies:
 
 Dependency Issues
 -----------------
 
-Let's define a simple scenario whereby there are two packages: ``MyOtherLib/2.0`` and ``MyLib/1.0`` which depends on
-``MyOtherLib/2.0``. Let's assume that their recipes and binaries have already been created and uploaded to a Conan remote.
+Let's define a simple scenario whereby there are two packages: ``my_other_lib/2.0`` and ``my_lib/1.0`` which depends on
+``my_other_lib/2.0``. Let's assume that their recipes and binaries have already been created and uploaded to a Conan remote.
 
-Now, a new release for ``MyOtherLib/2.1`` is released with an improved recipe and new binaries. The ``MyLib/1.0`` is modified and is required to be upgraded to ``MyOtherLib/2.1``.
+Now, a new release for ``my_other_lib/2.1`` is released with an improved recipe and new binaries. The ``my_lib/1.0`` is modified and is required to be upgraded to ``MyOtherLib/2.1``.
 
 .. note::
 
-    This scenario will be the same in the case that a consuming project of ``MyLib/1.0`` defines a dependency to ``MyOtherLib/2.1``, which
-    takes precedence over the existing project in ``MyLib/1.0``.
+    This scenario will be the same in the case that a consuming project of ``my_lib/1.0`` defines a dependency to ``my_other_lib/2.1``, which
+    takes precedence over the existing project in ``my_lib/1.0``.
 
-The question is: **Is it necessary to build new MyLib/1.0 binary packages?** or are the existing packages still valid?
+The question is: **Is it necessary to build new ``my_lib/1.0`` binary packages?** or are the existing packages still valid?
 
 The answer: **It depends**.
 
-Let's assume that both packages are compiled as static libraries and that the API exposed by ``MyOtherLib`` to ``MyLib/1.0`` through the
-public headers, has not changed at all. In this case, it is not required to build new binaries for ``MyLib/1.0`` because the final consumer will
-link against both ``Mylib/1.0`` and ``MyOtherLib/2.1``.
+Let's assume that both packages are compiled as static libraries and that the API exposed by ``my_other_lib`` to ``my_lib/1.0`` through the
+public headers, has not changed at all. In this case, it is not required to build new binaries for ``my_lib/1.0`` because the final consumer will
+link against both ``my_lib/1.0`` and ``my_other_lib/2.1``.
 
-On the other hand, it could happen that the API exposed by **MyOtherLib** in the public headers has changed, but without affecting the
-``MyLib/1.0`` binary for any reason (like changes consisting on new functions not used by **MyLib**). The same reasoning would apply if **MyOtherLib** was only the header.
+On the other hand, it could happen that the API exposed by **my_other_lib** in the public headers has changed, but without affecting the
+``my_lib/1.0`` binary for any reason (like changes consisting on new functions not used by **my_lib**). The same reasoning would apply if **MyOtherLib** was only the header.
 
-But what if a header file of ``MyOtherLib`` -named *myadd.h*- has changed from ``2.0`` to ``2.1``:
+But what if a header file of ``my_other_lib`` -named *myadd.h*- has changed from ``2.0`` to ``2.1``:
 
 .. code-block:: cpp
    :caption: *myadd.h* header file in version 2.0
@@ -353,11 +348,11 @@ But what if a header file of ``MyOtherLib`` -named *myadd.h*- has changed from `
 
     int addition (int a, int b) { return a + b; }
 
-And the ``addition()`` function is called from the compiled *.cpp* files of ``MyLib/1.0``?
+And the ``addition()`` function is called from the compiled *.cpp* files of ``my_lib/1.0``?
 
-Then, **a new binary for MyLib/1.0 is required to be built for the new dependency version**. Otherwise it will maintain the old, buggy
-``addition()`` version. Even in the case that ``MyLib/1.0`` doesn't have any change in its code lines neither in the recipe, the resulting
-binary rebuilding ``MyLib`` requires ``MyOtherLib/2.1`` and the package to be different.
+Then, **a new binary for my_lib/1.0 is required to be built for the new dependency version**. Otherwise it will maintain the old, buggy
+``addition()`` version. Even in the case that ``my_lib/1.0`` doesn't have any change in its code lines neither in the recipe, the resulting
+binary rebuilding ``my_lib`` requires ``my_other_lib/2.1`` and the package to be different.
 
 
 .. _package_id_mode:
@@ -366,11 +361,11 @@ Using package_id() for Package Dependencies
 -------------------------------------------
 
 The ``self.info`` object has also a ``requires`` object. It is a dictionary containing the necessary information for each requirement, all direct
-and transitive dependencies. For example, ``self.info.requires["MyOtherLib"]`` is a ``RequirementInfo`` object.
+and transitive dependencies. For example, ``self.info.requires["my_other_lib"]`` is a ``RequirementInfo`` object.
 
 - Each ``RequirementInfo`` has the following `read only` reference fields:
 
-    - ``full_name``: Full require's name, e.g., **MyOtherLib**
+    - ``full_name``: Full require's name, e.g., **my_other_lib**
     - ``full_version``: Full require's version, e.g., **1.2**
     - ``full_user``: Full require's user, e.g., **my_user**
     - ``full_channel``: Full require's channel, e.g., **stable**
@@ -378,7 +373,7 @@ and transitive dependencies. For example, ``self.info.requires["MyOtherLib"]`` i
 
 - The following fields are used in the ``package_id()`` evaluation:
 
-    - ``name``: By default same value as full_name, e.g., **MyOtherLib**.
+    - ``name``: By default same value as full_name, e.g., **my_other_lib**.
     - ``version``: By default the major version representation of the ``full_version``.
       E.g., **1.Y** for a **1.2** ``full_version`` field and **1.Y.Z** for a **1.2.3**
       ``full_version`` field.
@@ -406,10 +401,10 @@ If it is necessary to change the default behavior, the applied versioning schema
     from conans.model.version import Version
 
     class PkgConan(ConanFile):
-        name = "Mylib"
+        name = "my_lib"
         version = "1.0"
         settings = "os", "compiler", "build_type", "arch"
-        requires = "MyOtherLib/2.0@lasote/stable"
+        requires = "my_other_lib/2.0@lasote/stable"
 
         def package_id(self):
             myotherlib = self.info.requires["MyOtherLib"]
@@ -476,7 +471,7 @@ All the modes can be applied to all dependencies, or to individual ones:
   .. code-block:: text
 
     MyLib/1.2.3@user/testing       => MyLib/1.Y.Z
-    MyOtherLib/2.3.4@user/testing  =>
+    my_other_lib/2.3.4@user/testing  =>
 
   So the direct dependencies are mapped to the major version only. Changing its channel, or using version
   ``MyLib/1.4.5`` will still produce ``MyLib/1.Y.Z`` and thus the same package-id.
@@ -488,21 +483,21 @@ All the modes can be applied to all dependencies, or to individual ones:
   .. code-block:: python
 
     def package_id(self):
-      self.info.requires["MyOtherLib"].semver_mode()
+      self.info.requires["my_other_lib"].semver_mode()
 
   This results in:
 
   .. code-block:: text
 
     MyLib/1.2.3@user/testing       => MyLib/1.Y.Z
-    MyOtherLib/2.3.4@user/testing  => MyOtherLib/2.Y.Z
+    MyOtherLib/2.3.4@user/testing  => my_other_lib/2.Y.Z
 
   In this mode, versions starting with ``0`` are considered unstable and mapped to the full version:
 
   .. code-block:: text
 
-    MyLib/0.2.3@user/testing       => MyLib/0.2.3
-    MyOtherLib/0.3.4@user/testing  => MyOtherLib/0.3.4
+    my_lib/0.2.3@user/testing       => my_lib/0.2.3
+    my_other_lib/0.3.4@user/testing  => my_other_lib/0.3.4
 
 - ``major_mode()``: Any change in the major release version (starting from **0.0.0**) changes the package ID.
 
@@ -519,14 +514,14 @@ All the modes can be applied to all dependencies, or to individual ones:
   .. code-block:: python
 
       def package_id(self):
-          self.info.requires["MyOtherLib"].minor_mode()
+          self.info.requires["my_other_lib"].minor_mode()
 
 - ``patch_mode()``: Any changes to major, minor or patch (not build) versions of the required dependency change the package ID.
 
   .. code-block:: python
 
       def package_id(self):
-          self.info.requires["MyOtherLib"].patch_mode()
+          self.info.requires["my_other_lib"].patch_mode()
 
 - ``base_mode()``: Any changes to the base of the version (not build) of the required dependency changes the package ID. Note that in the
   case of semver notation this may produce the same result as ``patch_mode()``, but it is actually intended to dismiss the build part of the
@@ -535,38 +530,38 @@ All the modes can be applied to all dependencies, or to individual ones:
   .. code-block:: python
 
       def package_id(self):
-          self.info.requires["MyOtherLib"].base_mode()
+          self.info.requires["my_other_lib"].base_mode()
 
 - ``full_version_mode()``: Any changes to the version of the required dependency changes the package ID.
 
   .. code-block:: python
 
     def package_id(self):
-      self.info.requires["MyOtherLib"].full_version_mode()
+      self.info.requires["my_other_lib"].full_version_mode()
 
   .. code-block:: text
 
-    MyOtherLib/1.3.4-a4+b3@user/testing  => MyOtherLib/1.3.4-a4+b3   
+    my_other_lib/1.3.4-a4+b3@user/testing  => my_other_lib/1.3.4-a4+b3   
 
 - ``full_recipe_mode()``: Any change in the reference of the requirement (user & channel too) changes the package ID.
 
   .. code-block:: python
 
     def package_id(self):
-      self.info.requires["MyOtherLib"].full_recipe_mode()
+        self.info.requires["my_other_lib"].full_recipe_mode()
 
   This keeps the whole dependency reference, except the package-id of the dependency.
 
   .. code-block:: text
 
-    MyOtherLib/1.3.4-a4+b3@user/testing  => MyOtherLib/1.3.4-a4+b3@user/testing   
+    my_other_lib/1.3.4-a4+b3@user/testing  => my_other_lib/1.3.4-a4+b3@user/testing   
 
 - ``full_package_mode()``: Any change in the required version, user, channel or package ID changes the package ID.
 
   .. code-block:: python
 
     def package_id(self):
-      self.info.requires["MyOtherLib"].full_package_mode()
+        self.info.requires["MyOtherLib"].full_package_mode()
 
   Any change to the dependency, including its binary package-id, will in turn
   produce a new package-id for the consumer package.
@@ -721,26 +716,26 @@ a single dependency, which is a static library. Then, downstream
 consumers of the header only library that uses a package mode different from the default, should be also affected by the upstream
 transitivity dependency. Lets say that we have the following scenario:
 
-- ``App/1.0`` depends on ``PkgC/1.0`` and ``PkgA/1.0``
-- ``PkgC/1.0`` depends only on ``PkgB/1.0``
-- ``PkgB/1.0`` depends on ``PkgA/1.0``, and defines ``self.info.header_only()`` in its ``package_id()``
+- ``app/1.0`` depends on ``pkgc/1.0`` and ``pkga/1.0``
+- ``pkgc/1.0`` depends only on ``pkgb/1.0``
+- ``pkgb/1.0`` depends on ``pkga/1.0``, and defines ``self.info.header_only()`` in its ``package_id()``
 - We are using ``full_version_mode``
-- Now we create a new ``PkgA/2.0`` that has some changes in its header, that would require to rebuild ``PkgC/1.0`` against it.
-- ``App/1.0`` now depends on ``PkgC/1.0`` and ``PkgA/2.0``
+- Now we create a new ``pkga/2.0`` that has some changes in its header, that would require to rebuild ``pkgc/1.0`` against it.
+- ``app/1.0`` now depends on ```pkgc/1.0`` and ``pkga/2.0``
 
 .. image:: /images/conan-full_transitive_package_id.png
     :width: 100 %
     :align: center
 
-
-With the default behavior, the header only ``PkgB`` is isolating ``PkgC`` from the upstream changes effects. The package-id ``PIDC1`` we
-get for ``PkgC/1.0`` is exactly the same when depending on ``PkgA/1.0`` and ``PkgA/2.0``.
+With the default behavior, the header only ``pkgb`` is isolating ``pkgc`` from the upstream changes effects. The package-id ``PIDC1`` we
+get for ``pkgc/1.0`` is exactly the same when depending on ``pkga/1.0`` and ``pkga/2.0``.
 
 If we want to have the ``full_version_mode`` to be fully transitive, irrespective of the local package-id modes of the packages,
 we can configure it in the :ref:`conan_conf` section. To summarize, you can activate the ``general.full_transitive_package_id``
 configuration (``$ conan config set general.full_transitive_package_id=1``).
 
-If we do this, then ``PkgC/1.0`` will compute 2 different package-ids, one for ``PkgA/1.0`` (``PIDC1``) and the other to link with ``PkgA/2.0`` (``PIDC2``)
+If we do this, then ``pkgc/1.0`` will compute 2 different package-ids, one for ``pkga/1.0`` (``PIDC1``) and the other to link with
+``pkga/2.0`` (``PIDC2``).
 
 
 Library Types: Shared, Static, Header-only
@@ -748,47 +743,47 @@ Library Types: Shared, Static, Header-only
 
 Let's see some examples, corresponding to common scenarios:
 
-- ``MyLib/1.0`` is a shared library that links with a static library ``MyOtherLib/2.0`` package.
+- ``my_lib/1.0`` is a shared library that links with a static library ``my_other_lib/2.0`` package.
   When a new ``MyOtherLib/2.1`` version is released: Do I need to create a new binary for
-  ``MyLib/1.0`` to link with it?
+  ``my_lib/1.0`` to link with it?
 
-  Yes, always, as the implementation is embedded in the ``MyLib/1.0`` shared library. If we
+  Yes, always, as the implementation is embedded in the ``my_lib/1.0`` shared library. If we
   always want to rebuild our library, even if the channel changes (we assume a channel change could
   mean a source code change):
 
   .. code-block:: python
 
       def package_id(self):
-          # Any change in the MyOtherLib version, user or
+          # Any change in the my_other_lib version, user or
           # channel or Package ID will affect our package ID
-          self.info.requires["MyOtherLib"].full_package_mode()
+          self.info.requires["my_other_lib"].full_package_mode()
 
-- ``MyLib/1.0`` is a shared library, requiring another shared library ``MyOtherLib/2.0`` package.
-  When a new ``MyOtherLib/2.1`` version is released: Do I need to create a new binary for
-  ``MyLib/1.0`` to link with it?
+- ``my_lib/1.0`` is a shared library, requiring another shared library ``my_other_lib/2.0`` package.
+  When a new ``my_other_lib/2.1`` version is released: Do I need to create a new binary for
+  ``my_lib/1.0`` to link with it?
 
   It depends. If the public headers have not changed at all, it is not necessary. Actually it might
   be necessary to consider transitive dependencies that are shared among the public headers, how
   they are linked and if they cross the frontiers of the API, it might also lead to
   incompatibilities. If the public headers have changed, it would depend on what changes and how are
-  they used in ``MyLib/1.0``. Adding new methods to the public headers will have no impact, but
+  they used in ``my_lib/1.0``. Adding new methods to the public headers will have no impact, but
   changing the implementation of some functions that will be inlined when compiled from
-  ``MyLib/1.0`` will definitely require re-building. For this case, it could make sense to have this configuration:
+  ``my_lib/1.0`` will definitely require re-building. For this case, it could make sense to have this configuration:
 
   .. code-block:: python
 
       def package_id(self):
           # Any change in the MyOtherLib version, user or channel
           # or Package ID will affect our package ID
-          self.info.requires["MyOtherLib"].full_package_mode()
+          self.info.requires["my_other_lib"].full_package_mode()
 
           # Or any change in the MyOtherLib version, user or
           # channel will affect our package ID
-          self.info.requires["MyOtherLib"].full_recipe_mode()
+          self.info.requires["my_other_lib"].full_recipe_mode()
 
-- ``MyLib/1.0`` is a header-only library, linking with any kind (header, static, shared) of library
-  in ``MyOtherLib/2.0`` package. When a new ``MyOtherLib/2.1`` version is released: Do I need to
-  create a new binary for ``MyLib/1.0`` to link with it?
+- ``my_lib/1.0`` is a header-only library, linking with any kind (header, static, shared) of library
+  in ``my_other_lib/2.0`` package. When a new ``my_other_lib/2.1`` version is released: Do I need to
+  create a new binary for ``my_lib/1.0`` to link with it?
 
   Never. The package should always be the same as there are no settings, no options, and in any way a
   dependency can affect a binary, because there is no such binary. The default behavior should be
@@ -799,11 +794,11 @@ Let's see some examples, corresponding to common scenarios:
       def package_id(self):
           self.info.requires.clear()
 
-- ``MyLib/1.0`` is a static library linking to a header only library in ``MyOtherLib/2.0``
-  package. When a new ``MyOtherLib/2.1`` version is released: Do I need to create a new binary for
-  ``MyLib/1.0`` to link with it? It could happen that the ``MyOtherLib`` headers are strictly used
-  in some ``MyLib`` headers, which are not compiled, but transitively included. But in general,
-  it is more likely that ``MyOtherLib`` headers are used in ``MyLib`` implementation files, so every
+- ``my_lib/1.0`` is a static library linking to a header only library in ``my_other_lib/2.0``
+  package. When a new ``my_other_lib/2.1`` version is released: Do I need to create a new binary for
+  ``my_lib/1.0`` to link with it? It could happen that the ``my_other_lib`` headers are strictly used
+  in some ``my_lib`` headers, which are not compiled, but transitively included. But in general,
+  it is more likely that ``my_other_lib`` headers are used in ``MyLib`` implementation files, so every
   change in them should imply a new binary to be built. If we know that changes in the channel never
   imply a source code change, as set in our workflow/lifecycle, we could
   write:
@@ -811,5 +806,5 @@ Let's see some examples, corresponding to common scenarios:
   .. code-block:: python
 
       def package_id(self):
-          self.info.requires["MyOtherLib"].full_package()
-          self.info.requires["MyOtherLib"].channel = None # Channel doesn't change out package ID
+          self.info.requires["my_other_lib"].full_package()
+          self.info.requires["my_other_lib"].channel = None # Channel doesn't change out package ID

--- a/creating_packages/existing_binaries.rst
+++ b/creating_packages/existing_binaries.rst
@@ -25,14 +25,14 @@ A Conan recipe is still required, but is very simple and will only include the p
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1 --bare
+    $ conan new hello/0.1 --bare
 
 This will create and store the following package recipe in the local cache:
 
 .. code-block:: python
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
 
@@ -57,19 +57,19 @@ Based on the above, We can assume that our current directory contains a *lib* fo
 
 .. code-block:: bash
 
-    $ conan export-pkg . Hello/0.1@myuser/testing  -s os=Windows -s compiler=gcc -s compiler.version=4.9 ...
+    $ conan export-pkg . hello/0.1@myuser/testing  -s os=Windows -s compiler=gcc -s compiler.version=4.9 ...
 
 Having a *test_package* folder is still highly recommended for testing the package locally before
 upload. As we don't want to build the package from the sources, the flow would be:
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1 --bare --test
+    $ conan new hello/0.1 --bare --test
     # customize test_package project
     # customize package recipe if necessary
     $ cd my/path/to/binaries
-    $ conan export-pkg PATH/TO/conanfile.py Hello/0.1@myuser/testing  -s os=Windows -s compiler=gcc -s compiler.version=4.9 ...
-    $ conan test PATH/TO/test_package/conanfile.py Hello/0.1@myuser/testing -s os=Windows -s compiler=gcc -s ...
+    $ conan export-pkg PATH/TO/conanfile.py hello/0.1@myuser/testing  -s os=Windows -s compiler=gcc -s compiler.version=4.9 ...
+    $ conan test PATH/TO/test_package/conanfile.py hello/0.1@myuser/testing -s os=Windows -s compiler=gcc -s ...
 
 The last two steps can be repeated for any number of configurations.
 
@@ -83,7 +83,7 @@ Follow our sample recipe for this purpose:
 .. code-block:: python
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
 

--- a/creating_packages/getting_started.rst
+++ b/creating_packages/getting_started.rst
@@ -26,7 +26,7 @@ will create a working package recipe for us:
 .. code-block:: bash
 
     $ mkdir mypkg && cd mypkg
-    $ conan new Hello/0.1 -t
+    $ conan new hello/0.1 -t
 
 This will generate the following files:
 
@@ -50,11 +50,11 @@ Let's have a look at the root package recipe *conanfile.py*:
     from conans import ConanFile, CMake, tools
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         license = "<Put the package license here>"
         url = "<Package recipe repository url here, for issues about the package>"
-        description = "<Description of Hello here>"
+        description = "<Description of hello here>"
         settings = "os", "compiler", "build_type", "arch"
         options = {"shared": [True, False]}
         default_options = {"shared": False}
@@ -198,7 +198,7 @@ The *conanfile.py* described above has the following characteristics:
 .. note::
 
     An important difference with respect to standard package recipes is that you don't have
-    to declare a ``requires`` attribute to depend on the tested ``Hello/0.1@demo/testing`` package
+    to declare a ``requires`` attribute to depend on the tested ``hello/0.1@demo/testing`` package
     as the ``requires`` will automatically be injected by Conan during the run. However, if you choose to
     declare it explicitly, it will work, but you will have to remember to bump the version,
     and possibly also the user and channel if you decide to change them.
@@ -224,7 +224,7 @@ The :command:`conan create` command does the following:
 - Installs the package, forcing it to be built from the sources.
 - Moves to the *test_package* folder and creates a temporary *build* folder.
 - Executes the :command:`conan install ..`, to install the requirements of the
-  *test_package/conanfile.py*. Note that it will build "Hello" from the sources.
+  *test_package/conanfile.py*. Note that it will build "hello" from the sources.
 - Builds and launches the *example* consuming application, calling the *test_package/conanfile.py*
   ``build()`` and ``test()`` methods respectively.
 
@@ -233,9 +233,9 @@ Using Conan commands, the :command:`conan create` command would be equivalent to
 .. code-block:: bash
 
     $ conan export . demo/testing
-    $ conan install Hello/0.1@demo/testing --build=Hello
+    $ conan install hello/0.1@demo/testing --build=hello
     # package is created now, use test to test it
-    $ conan test test_package Hello/0.1@demo/testing
+    $ conan test test_package hello/0.1@demo/testing
 
 The :command:`conan create` command receives the same command line parameters as :command:`conan install` so
 you can pass to it the same settings, options, and command line switches. If you want to create and
@@ -244,7 +244,7 @@ test packages for different configurations, you could:
 .. code-block:: bash
 
     $ conan create . demo/testing -s build_type=Debug
-    $ conan create . demo/testing -o Hello:shared=True -s arch=x86
+    $ conan create . demo/testing -o hello:shared=True -s arch=x86
     $ conan create . demo/testing -pr my_gcc49_debug_profile
     ...
     $ conan create ...

--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -26,7 +26,7 @@ First, let's get the initial source code and create the basic package recipe:
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1 -t -s
+    $ conan new hello/0.1 -t -s
 
 A *src* folder will be created with the same "hello" source code as in the previous example. You
 can have a look at it and see that the code is straightforward.
@@ -38,11 +38,11 @@ Now let's have a look at *conanfile.py*:
     from conans import ConanFile, CMake
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         license = "<Put the package license here>"
         url = "<Package recipe repository url here, for issues about the package>"
-        description = "<Description of Hello here>"
+        description = "<Description of hello here>"
         settings = "os", "compiler", "build_type", "arch"
         options = {"shared": [True, False]}
         default_options = {"shared": False}
@@ -91,7 +91,7 @@ And simply create the package for user and channel **demo/testing** as described
 
     $ conan create . demo/testing
     ...
-    Hello/0.1@demo/testing test package: Running test()
+    hello/0.1@demo/testing test package: Running test()
     Hello world Release!
 
 .. _scm_feature:
@@ -196,9 +196,9 @@ be valid too:
 
    .. code-block:: bash
 
-     $ conan export . Hello/0.1@demo/testing
+     $ conan export . hello/0.1@demo/testing
 
-      Hello/0.1@demo/testing: WARN: There are uncommitted changes, skipping the replacement of 'scm.url'
+      hello/0.1@demo/testing: WARN: There are uncommitted changes, skipping the replacement of 'scm.url'
       and 'scm.revision' auto fields. Use --ignore-dirty to force it.
       The 'conan upload' command will prevent uploading recipes with 'auto' values in these fields.
 

--- a/creating_packages/understand_packaging.rst
+++ b/creating_packages/understand_packaging.rst
@@ -14,7 +14,7 @@ command line argument.
 .. code-block:: bash
 
     $ mkdir mypkg && cd mypkg
-    $ conan new Hello/0.1
+    $ conan new hello/0.1
 
 This will create just the *conanfile.py* recipe file. Now we can create our package:
 
@@ -27,10 +27,10 @@ This is equivalent to:
 .. code-block:: bash
 
     $ conan export . demo/testing
-    $ conan install Hello/0.1@demo/testing --build=Hello
+    $ conan install hello/0.1@demo/testing --build=hello
 
 Once the package is created, it can be consumed like any other package, by adding
-``Hello/0.1@demo/testing`` to a project *conanfile.txt* or *conanfile.py* requirements and running:
+``hello/0.1@demo/testing`` to a project *conanfile.txt* or *conanfile.py* requirements and running:
 
 .. code-block:: bash
 

--- a/developing_packages/package_dev_flow.rst
+++ b/developing_packages/package_dev_flow.rst
@@ -171,12 +171,12 @@ There are 2 modes of operation:
     $ conan export-pkg . user/channel --source-folder=tmp/source --build-folder=tmp/build --profile=myprofile
 
     Packaging to 6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
-    Hello/1.1@user/channel: Generating the package
-    Hello/1.1@user/channel: Package folder C:\Users\conan\.conan\data\Hello\1.1\user\channel\package\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
-    Hello/1.1@user/channel: Calling package()
-    Hello/1.1@user/channel package(): Copied 2 '.lib' files: greet.lib, hello.lib
-    Hello/1.1@user/channel package(): Copied 2 '.lib' files: greet.lib, hello.lib
-    Hello/1.1@user/channel: Package '6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7' created
+    hello/1.1@user/channel: Generating the package
+    hello/1.1@user/channel: Package folder C:\Users\conan\.conan\data\hello\1.1\user\channel\package\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
+    hello/1.1@user/channel: Calling package()
+    hello/1.1@user/channel package(): Copied 2 '.lib' files: greet.lib, hello.lib
+    hello/1.1@user/channel package(): Copied 2 '.lib' files: greet.lib, hello.lib
+    hello/1.1@user/channel: Package '6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7' created
 
 conan test
 ^^^^^^^^^^
@@ -185,19 +185,19 @@ The final step to test the package for consumers is the test command. This step 
 
 .. code-block:: bash
 
-    $ conan test test_package Hello/1.1@user/channel
+    $ conan test test_package hello/1.1@user/channel
 
-    Hello/1.1@user/channel (test package): Installing C:\Users\conan\repos\example_conan_flow\test_package\conanfile.py
+    hello/1.1@user/channel (test package): Installing C:\Users\conan\repos\example_conan_flow\test_package\conanfile.py
     Requirements
-        Hello/1.1@user/channel from local
+        hello/1.1@user/channel from local
     Packages
-        Hello/1.1@user/channel:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
+        hello/1.1@user/channel:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
 
-    Hello/1.1@user/channel: Already installed!
-    Hello/1.1@user/channel (test package): Generator cmake created conanbuildinfo.cmake
-    Hello/1.1@user/channel (test package): Generator txt created conanbuildinfo.txt
-    Hello/1.1@user/channel (test package): Generated conaninfo.txt
-    Hello/1.1@user/channel (test package): Running build()
+    hello/1.1@user/channel: Already installed!
+    hello/1.1@user/channel (test package): Generator cmake created conanbuildinfo.cmake
+    hello/1.1@user/channel (test package): Generator txt created conanbuildinfo.txt
+    hello/1.1@user/channel (test package): Generated conaninfo.txt
+    hello/1.1@user/channel (test package): Running build()
     ...
 
 There is often a need to repeatedly re-run the test to check the package is well generated for consumers.
@@ -213,11 +213,11 @@ As a summary, you could use the default folders and the flow would be as simple 
     $ conan build .
     $ conan package .
     # So far, this is local. Now put the local binaries in cache
-    $ conan export-pkg . Hello/1.1@user/testing -pr=default
+    $ conan export-pkg . hello/1.1@user/testing -pr=default
     # And test it, to check it is working in the local cache
-    $ conan test test_package Hello/1.1@user/testing
+    $ conan test test_package hello/1.1@user/testing
     ...
-    Hello/1.1@user/testing (test package): Running test()
+    hello/1.1@user/testing (test package): Running test()
     Hello World Release!
 
 conan create
@@ -243,26 +243,26 @@ If you see in the traces that the ``source()`` method has been properly executed
 
     $ conan create . user/channel --keep-source
 
-    Hello/1.1@user/channel: A new conanfile.py version was exported
-    Hello/1.1@user/channel: Folder: C:\Users\conan\.conan\data\Hello\1.1\user\channel\export
-    Hello/1.1@user/channel (test package): Installing C:\Users\conan\repos\example_conan_flow\test_package\conanfile.py
+    hello/1.1@user/channel: A new conanfile.py version was exported
+    hello/1.1@user/channel: Folder: C:\Users\conan\.conan\data\hello\1.1\user\channel\export
+    hello/1.1@user/channel (test package): Installing C:\Users\conan\repos\features\package_development_flow\test_package\conanfile.py
     Requirements
-        Hello/1.1@user/channel from local
+        hello/1.1@user/channel from local
     Packages
-        Hello/1.1@user/channel:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
+        hello/1.1@user/channel:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
 
-    Hello/1.1@user/channel: WARN: Forced build from source
-    Hello/1.1@user/channel: Building your package in C:\Users\conan\.conan\data\Hello\1.1\user\channel\build\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
-    Hello/1.1@user/channel: Configuring sources in C:\Users\conan\.conan\data\Hello\1.1\user\channel\source
+    hello/1.1@user/channel: WARN: Forced build from source
+    hello/1.1@user/channel: Building your package in C:\Users\conan\.conan\data\hello\1.1\user\channel\build\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7
+    hello/1.1@user/channel: Configuring sources in C:\Users\conan\.conan\data\hello\1.1\user\channel\source
     Cloning into 'hello'...
     remote: Counting objects: 17, done.
     remote: Total 17 (delta 0), reused 0 (delta 0), pack-reused 17
     Unpacking objects: 100% (17/17), done.
     Switched to a new branch 'static_shared'
     Branch 'static_shared' set up to track remote branch 'static_shared' from 'origin'.
-    Hello/1.1@user/channel: Copying sources to build folder
-    Hello/1.1@user/channel: Generator cmake created conanbuildinfo.cmake
-    Hello/1.1@user/channel: Calling build()
+    hello/1.1@user/channel: Copying sources to build folder
+    hello/1.1@user/channel: Generator cmake created conanbuildinfo.cmake
+    hello/1.1@user/channel: Calling build()
     ...
 
 If you see that the library is also built correctly, you can also skip the ``build()`` step with the ``--keep-build`` flag:

--- a/developing_packages/workspaces.rst
+++ b/developing_packages/workspaces.rst
@@ -121,8 +121,8 @@ depend on different versions of the same library, as in any other Conan command.
     root: ["helloA/0.1@lasote/stable", "helloB/0.1@lasote/stable"]
     # or
     root:
-        - helloA/0.1@lasote/stable
-        - helloB/0.1@lasote/stable
+        - helloa/0.1@lasote/stable
+        - hellob/0.1@lasote/stable
 
 
 Single configuration build environments

--- a/developing_packages/workspaces.rst
+++ b/developing_packages/workspaces.rst
@@ -118,7 +118,7 @@ depend on different versions of the same library, as in any other Conan command.
 
     root: chat/0.1@user/testing, say/0.1@user/testing
     # or
-    root: ["helloA/0.1@lasote/stable", "helloB/0.1@lasote/stable"]
+    root: ["helloa/0.1@lasote/stable", "hellob/0.1@lasote/stable"]
     # or
     root:
         - helloa/0.1@lasote/stable

--- a/developing_packages/workspaces.rst
+++ b/developing_packages/workspaces.rst
@@ -118,11 +118,11 @@ depend on different versions of the same library, as in any other Conan command.
 
     root: chat/0.1@user/testing, say/0.1@user/testing
     # or
-    root: ["HelloA/0.1@lasote/stable", "HelloB/0.1@lasote/stable"]
+    root: ["helloA/0.1@lasote/stable", "helloB/0.1@lasote/stable"]
     # or
     root:
-        - HelloA/0.1@lasote/stable
-        - HelloB/0.1@lasote/stable
+        - helloA/0.1@lasote/stable
+        - helloB/0.1@lasote/stable
 
 
 Single configuration build environments

--- a/devtools/build_requires.rst
+++ b/devtools/build_requires.rst
@@ -29,19 +29,19 @@ Build requirements can be declared in profiles, like:
    :caption: my_profile
 
     [build_requires]
-    Tool1/0.1@user/channel
-    Tool2/0.1@user/channel, Tool3/0.1@user/channel
-    *: Tool4/0.1@user/channel
-    MyPkg*: Tool5/0.1@user/channel
-    &: Tool6/0.1@user/channel
-    &!: Tool7/0.1@user/channel
+    tool1/0.1@user/channel
+    tool2/0.1@user/channel, tool3/0.1@user/channel
+    *: tool4/0.1@user/channel
+    my_pkg*: tool5/0.1@user/channel
+    &: tool6/0.1@user/channel
+    &!: tool7/0.1@user/channel
 
 Build requirements are specified by a ``pattern:``. If such pattern is not specified, it will be assumed to be ``*``, i.e. to apply to all
-packages. Packages can be declared in different lines or by a comma separated list. In this example, ``Tool1``, ``Tool2``, ``Tool3`` and
+packages. Packages can be declared in different lines or by a comma separated list. In this example, ``tool1``, ``tool2``, ``tool3`` and
 ``Tool4`` will be used for all packages in the dependency graph (while running :command:`conan install` or :command:`conan create`).
 
-If a pattern like ``MyPkg*`` is specified, the declared build requirements will only be applied to packages matching that pattern. ``Tool5``
-will not be applied to Zlib for example, but it will be applied to ``MyPkgZlib``.
+If a pattern like ``my_pkg*`` is specified, the declared build requirements will only be applied to packages matching that pattern. ``tool5``
+will not be applied to Zlib for example, but it will be applied to ``my_pkg_zlib``.
 
 The special case of a **consumer** conanfile (without name or version) it is impossible to match with a pattern, so it is handled with the
 special character ``&``:
@@ -57,13 +57,13 @@ Build requirements can also be specified in a package recipe, with the ``build_r
 .. code-block:: python
 
     class MyPkg(ConanFile):
-        build_requires = "ToolA/0.2@user/testing", "ToolB/0.2@user/testing"
+        build_requires = "tool_a/0.2@user/testing", "tool_b/0.2@user/testing"
 
         def build_requirements(self):
             # useful for example for conditional build_requires
             # This means, if we are running on a Windows machine, require ToolWin
             if platform.system() == "Windows":
-                self.build_requires("ToolWin/0.1@user/stable")
+                self.build_requires("tool_win/0.1@user/stable")
 
 The above ``ToolA`` and ``ToolB`` will always be retrieved and used for building this recipe, while the ``ToolWin`` one will only be used
 only in Windows.
@@ -170,11 +170,10 @@ If a Conan package is defined to wrap and reuse the *mypythontool.py* file:
 
 .. code-block:: python
 
-    import os
     from conans import ConanFile
 
     class Tool(ConanFile):
-        name = "PythonTool"
+        name = "python_tool"
         version = "0.1"
         exports_sources = "mypythontool.py"
 
@@ -189,7 +188,7 @@ Then if it is defined in a profile as a build require:
 .. code-block:: text
 
     [build_requires]
-    PythonTool/0.1@user/channel
+    python_tool/0.1@user/channel
 
 such package can be reused in other recipes like this:
 

--- a/devtools/build_requires.rst
+++ b/devtools/build_requires.rst
@@ -65,7 +65,7 @@ Build requirements can also be specified in a package recipe, with the ``build_r
             if platform.system() == "Windows":
                 self.build_requires("tool_win/0.1@user/stable")
 
-The above ``ToolA`` and ``ToolB`` will always be retrieved and used for building this recipe, while the ``ToolWin`` one will only be used
+The above ``tool_a`` and ``tool_b`` will always be retrieved and used for building this recipe, while the ``tool_win`` one will only be used
 only in Windows.
 
 If some build requirement defined inside ``build_requirements()`` has the same package name as the one defined in the ``build_requires``

--- a/devtools/running_packages.rst
+++ b/devtools/running_packages.rst
@@ -19,7 +19,7 @@ We can create a package that contains an executable, for example from the defaul
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1
+    $ conan new hello/0.1
 
 The source code used contains an executable called ``greet``, but it is not packaged by default. Let's modify the recipe
 ``package()`` method to also package the executable:
@@ -29,20 +29,18 @@ The source code used contains an executable called ``greet``, but it is not pack
     def package(self):
         self.copy("*greet*", src="bin", dst="bin", keep_path=False)
 
-
 Now we create the package as usual, but if we try to run the executable it won't be found:
 
 .. code-block:: bash
 
     $ conan create . user/testing
     ...
-    Hello/0.1@user/testing package(): Copied 1 '.h' files: hello.h
-    Hello/0.1@user/testing package(): Copied 1 '.exe' files: greet.exe
-    Hello/0.1@user/testing package(): Copied 1 '.lib' files: hello.lib
+    hello/0.1@user/testing package(): Copied 1 '.h' files: hello.h
+    hello/0.1@user/testing package(): Copied 1 '.exe' files: greet.exe
+    hello/0.1@user/testing package(): Copied 1 '.lib' files: hello.lib
 
     $ greet
     > ... not found...
-
 
 By default, Conan does not modify the environment, it will just create the package in the local cache, and that is not
 in the system PATH, so the ``greet`` executable is not found.
@@ -57,7 +55,7 @@ So if we install the package, specifying such ``virtualrunenv`` like:
 
 .. code-block:: bash
 
-    $ conan install Hello/0.1@user/testing -g virtualrunenv
+    $ conan install hello/0.1@user/testing -g virtualrunenv
 
 This will generate a few files that can be called to activate and deactivate the required environment variables
 
@@ -97,9 +95,9 @@ With that method in our package recipe, it will copy the executable when install
 
 .. code-block:: bash
 
-    $ conan install Hello/0.1@user/testing
+    $ conan install hello/0.1@user/testing
     ...
-    > Hello/0.1@user/testing deploy(): Copied 1 '.exe' files: greet.exe
+    > hello/0.1@user/testing deploy(): Copied 1 '.exe' files: greet.exe
     $ bin\greet.exe
     > Hello World Release!
 
@@ -225,7 +223,7 @@ For example, if we want to execute the :command:`greet` app while building the `
         name = "Consumer"
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
-        requires = "Hello/0.1@user/testing"
+        requires = "hello/0.1@user/testing"
 
         def build(self):
             self.run("greet", run_environment=True)
@@ -275,7 +273,7 @@ Runtime packages and re-packaging
 ----------------------------------
 
 It is possible to create packages that contain only runtime binaries, getting rid of all build-time dependencies.
-If we want to create a package from the above "Hello" one, but only containing the executable (remember that the above
+If we want to create a package from the above "hello" one, but only containing the executable (remember that the above
 package also contains a library, and the headers), we could do:
 
 .. code-block:: python
@@ -283,9 +281,9 @@ package also contains a library, and the headers), we could do:
     from conans import ConanFile
 
     class HellorunConan(ConanFile):
-        name = "HelloRun"
+        name = "hello_run"
         version = "0.1"
-        build_requires = "Hello/0.1@user/testing"
+        build_requires = "hello/0.1@user/testing"
         keep_imports = True
 
         def imports(self):
@@ -296,8 +294,8 @@ package also contains a library, and the headers), we could do:
 
 This recipe has the following characteristics:
 
-- It includes the ``Hello/0.1@user/testing`` package as ``build_requires``.
-  That means that it will be used to build this `HelloRun` package, but once the `HelloRun` package is built,
+- It includes the ``hello/0.1@user/testing`` package as ``build_requires``.
+  That means that it will be used to build this `hello_run` package, but once the `hello_run` package is built,
   it will not be necessary to retrieve it.
 - It is using ``imports()`` to copy from the dependencies, in this case, the executable
 - It is using the ``keep_imports`` attribute to define that imported artifacts during the ``build()`` step (which
@@ -309,15 +307,15 @@ To create and upload this package to a remote:
 .. code-block:: bash
 
     $ conan create . user/testing
-    $ conan upload HelloRun* --all -r=my-remote
+    $ conan upload hello_run* --all -r=my-remote
 
 Installing and running this package can be done using any of the methods presented above. For example:
 
 .. code-block:: bash
 
-    $ conan install HelloRun/0.1@user/testing -g virtualrunenv
+    $ conan install hello_run/0.1@user/testing -g virtualrunenv
     # You can specify the remote with -r=my-remote
-    # It will not install Hello/0.1@...
+    # It will not install hello/0.1@...
     $ activate_run.sh # $ source activate_run.sh in Unix/Linux
     $ greet
     > Hello World Release!

--- a/extending/python_requires.rst
+++ b/extending/python_requires.rst
@@ -167,14 +167,12 @@ Reusing files
 It is possible to access the files exported by a recipe that is used with ``python_requires``.
 We could have this recipe, together with a *myfile.txt* file containing the "Hello" text.
 
-
 .. code-block:: python
 
     from conans import ConanFile
 
     class PyReq(ConanFile):
         exports = "*"
-
 
 .. code-block:: bash
 

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -76,7 +76,7 @@ When you install or create a package, it is possible to see an error like this:
 
 .. code-block:: bash
 
-    ERROR: Hello/0.1@user/testing: 'settings.arch' value not defined
+    ERROR: hello/0.1@user/testing: 'settings.arch' value not defined
 
 This means that the recipe defined ``settings = "os", "arch", ...`` but a value for the ``arch`` setting was
 not provided either in a profile or in the command line. Make sure to specify a value for it in your profile,
@@ -90,7 +90,7 @@ If you are building a pure C library with gcc/clang, you might encounter an erro
 
 .. code-block:: bash
 
-    ERROR: Hello/0.1@user/testing: 'settings.compiler.libcxx' value not defined
+    ERROR: hello/0.1@user/testing: 'settings.compiler.libcxx' value not defined
 
 Indeed, for building a C library, it is not necessary to define a C++ standard library. And if you provide a value,
 you might end with multiple packages for exactly the same binary. What has to be done is to remove such subsetting

--- a/faq/using.rst
+++ b/faq/using.rst
@@ -30,9 +30,9 @@ package as the starting node of the dependency graph and upstream.
 
 The inverse model (from upstream to downstream) is not simple to obtain for Conan packages. This is because the dependency graph is not unique, it
 changes for every configuration. The graph can be different for different operating systems or just by changing some package options. So you
-cannot query which packages are dependent on ``MyLib/0.1@user/channel``, but which packages are dependent on
-``MyLib/0.1@user/channel:63da998e3642b50bee33`` binary package. Also, the response can contain many different binary packages for the same
-recipe, like ``MyDependent/0.1@user/channel:packageID1... ID2... MyDependent/0.1@user/channel:packageIDN``. That is the reason why
+cannot query which packages are dependent on ``my_lib/0.1@user/channel``, but which packages are dependent on
+``my_lib/0.1@user/channel:63da998e3642b50bee33`` binary package. Also, the response can contain many different binary packages for the same
+recipe, like ``my_dependent/0.1@user/channel:packageID1... ID2... my_dependent/0.1@user/channel:packageIDN``. That is the reason why
 :command:`conan info` and :command:`conan install` need a profile (default profile or one given with ``--profile```) or installation files
 ``conanbuildinfo.txt`` to look for settings and options.
 
@@ -61,7 +61,9 @@ your cache with :command:`conan get <ref> conanmanifest.txt`). The first value i
 into account to compute the hash. Checking and comparing the contents of the different *conanmanifest.txt* files in the different
 machines can give an idea of what is changing.
 
-If you want to make the solution self-contained, you can add a *.git/config* file in your project that sets the ``core.autocrlf`` property (for the whole repo), or if you need a per-file configuration, you could use the *.gitattributes* file to set the ``text eol=lf`` for every file you want.
+If you want to make the solution self-contained, you can add a *.git/config* file in your project that sets the ``core.autocrlf`` property
+(for the whole repo), or if you need a per-file configuration, you could use the *.gitattributes* file to set the ``text eol=lf`` for every
+file you want.
 
 .. _faq_recommendation_user_channel:
 
@@ -107,7 +109,7 @@ information is displayed in yellow with:
 
 .. code-block:: bash
 
-    $ conan search Pkg/0.1@user/channel --table=file.html
+    $ conan search pkg/0.1@user/channel --table=file.html
     # open file.html
     # It will show outdated binaries in yellow.
 

--- a/howtos/capture_version.rst
+++ b/howtos/capture_version.rst
@@ -35,7 +35,7 @@ the *conanfile.py* recipe resides, and use it to define the version of the Conan
             ...
 
 In this example, the package created with :command:`conan create` will be called 
-``Hello/branch_commit@user/channel``.
+``hello/branch_commit@user/channel``.
 
 How to capture package version from SCM: svn
 ============================================
@@ -48,7 +48,7 @@ the *conanfile.py* recipe resides, and use it to define the version of the Conan
     from conans import ConanFile, tools
 
     class HelloLibrary(ConanFile):
-        name = "Hello"
+        name = "hello"
         def set_version(self):
             scm = tools.SVN(folder=self.recipe_folder)
             revision = scm.get_revision()
@@ -64,7 +64,7 @@ the *conanfile.py* recipe resides, and use it to define the version of the Conan
             ...
 
 In this example, the package created with :command:`conan create` will be called 
-``Hello/generated_version@user/channel``. Note: this function should never raise, see the section
+``hello/generated_version@user/channel``. Note: this function should never raise, see the section
 about when the version is computed and saved above.
 
 How to capture package version from text or build files
@@ -81,7 +81,6 @@ As an example, let's assume we have the following library layout, and that we wa
        hello.cpp
        ...
 
-
 The *CMakeLists.txt* will have some variables to define the library version number. For simplicity, let's also assume
 that it includes a line such as the following:
 
@@ -91,9 +90,7 @@ that it includes a line such as the following:
     set(MY_LIBRARY_VERSION 1.2.3) # This is the version we want
     add_library(hello src/hello.cpp)
 
-
 You can extract the version dynamically using:
-
 
 .. code-block:: python
 
@@ -102,7 +99,7 @@ You can extract the version dynamically using:
     import re, os
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         def set_version(self):
             content = load(os.path.join(self.recipe_folder, "CMakeLists.txt"))
             version = re.search(b"set\(MY_LIBRARY_VERSION (.*)\)", content).group(1)

--- a/howtos/cmake_launch.rst
+++ b/howtos/cmake_launch.rst
@@ -42,4 +42,4 @@ If you want to use targets, you could do:
                     BASIC_SETUP CMAKE_TARGETS)
 
     add_executable(main main.cpp)
-    target_link_libraries(main CONAN_PKG::Hello)
+    target_link_libraries(main CONAN_PKG::hello)

--- a/howtos/collaborate_packages.rst
+++ b/howtos/collaborate_packages.rst
@@ -26,12 +26,12 @@ You can just directly run:
 
     $ conan create . demo/testing
 
-Once you have generated the desired binaries, you can store your pre-compiled binaries in your bintray repository or on your own Conan
+Once you have generated the desired binaries, you can store your pre-compiled binaries in your Bintray repository or on your own Conan
 server:
 
 .. code-block:: bash
 
-    $ conan upload Package/0.1@myuser/stable -r=myremote --all
+    $ conan upload package/0.1@myuser/stable -r=myremote --all
 
 Finally, if you made useful changes, you might want to create a pull request to the original repository of the package creator.
 

--- a/howtos/custom_generators.rst
+++ b/howtos/custom_generators.rst
@@ -89,7 +89,7 @@ This is a full working example. Note the ``PremakeDeps`` class as a helper. The 
 individual library separately, then also an aggregated information for all dependencies. This ``PremakeDeps`` wraps a single item of such
 information.
 
-Note the **name of the package** will be **PremakeGen/0.1@<user>/<channel>** as that is the name given to it, while the generator name is
+Note the **name of the package** will be **premakegen/0.1@<user>/<channel>** as that is the name given to it, while the generator name is
 **Premake** (the name of the class that inherits from ``Generator``). You can give the package any name you want, even the same as the
 generator's name if desired.
 
@@ -120,14 +120,14 @@ Now, let's create a folder for the application that will use Premake as build sy
     $ cd ..
     $ mkdir premake-project && cd premake-project
 
-Put the following files inside. Note the ``PremakeGen@0.1@myuser/testing`` package reference in your *conanfile.txt*.
+Put the following files inside. Note the ``premakegen@0.1@myuser/testing`` package reference in your *conanfile.txt*.
 
 .. code-block:: text
    :caption: *conanfile.txt*
 
     [requires]
     hello/0.1@myuser/testing
-    PremakeGen@0.1@myuser/testing
+    premakegen@0.1@myuser/testing
 
     [generators]
     Premake

--- a/howtos/makefiles.rst
+++ b/howtos/makefiles.rst
@@ -56,7 +56,7 @@ to match the current Conan settings (like ``-m32`` or ``-m64`` based on the Cona
     from conans import tools
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
         generators = "cmake"
@@ -127,7 +127,7 @@ And also a *conanfile.py* very similar to the previous one. In this case adding 
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
         exports_sources = "src/*"
-        requires = "Hello/0.1@user/testing"
+        requires = "hello/0.1@user/testing"
 
         def build(self):
             with tools.chdir("src"):
@@ -144,7 +144,7 @@ And also a *conanfile.py* very similar to the previous one. In this case adding 
 
 Note that in this case, the ``AutoToolsBuildEnvironment`` will automatically set values to ``CPPFLAGS``,
 ``LDFLAGS``, ``LIBS``, etc. existing in the *Makefile* with the correct include directories, library names,
-etc. to properly build and link with the ``hello`` library contained in the "Hello" package.
+etc. to properly build and link with the ``hello`` library contained in the "hello" package.
 
 As above, we can create the package with:
 
@@ -158,6 +158,6 @@ In this case, since the package has a ``deploy()`` method, we can use it:
 
 .. code-block:: bash
 
-    $ conan install Hello/0.1user/testing -s compiler=gcc -s compiler.version=4.9 -s compiler.libcxx=libstdc++
+    $ conan install hello/0.1user/testing -s compiler=gcc -s compiler.version=4.9 -s compiler.libcxx=libstdc++
     $ ./bin/app
     $ Hello World Release!

--- a/howtos/manage_shared_libraries/env_vars.rst
+++ b/howtos/manage_shared_libraries/env_vars.rst
@@ -86,7 +86,7 @@ execute directly ``tool_a`` using RunEnvironment build helper to set the environ
             ...
 
 Building an application using the shared library from ``tool_a``
----------------------------------------------------------------
+----------------------------------------------------------------
 
 As we are building a final application, we will probably want to distribute it together with the
 shared library from the ``tool_a``, so we can use the :ref:`Imports<imports_txt>` to import the required

--- a/howtos/manage_shared_libraries/env_vars.rst
+++ b/howtos/manage_shared_libraries/env_vars.rst
@@ -44,7 +44,7 @@ you will need to have the shared library available.
 
     class ToolA(ConanFile):
         ....
-        name = "toolA"
+        name = "tool_a"
         version = "1.0"
         options = {"shared": [True, False]}
         default_options = {"shared": False}
@@ -54,7 +54,7 @@ you will need to have the shared library available.
 
         def package(self):
             # Copy the executable
-            self.copy(pattern="toolA*", dst="bin", keep_path=False)
+            self.copy(pattern="tool_a*", dst="bin", keep_path=False)
 
             # Copy the libraries
             if self.options.shared:
@@ -67,8 +67,8 @@ you will need to have the shared library available.
 Using the tool from a different package
 ---------------------------------------
 
-If we are now creating a package that uses the ``ToolA`` executable to compress some data, we can
-execute directly ``toolA`` using RunEnvironment build helper to set the environment variables accordingly:
+If we are now creating a package that uses the ``tool_a`` executable to compress some data, we can
+execute directly ``tool_a`` using RunEnvironment build helper to set the environment variables accordingly:
 
 .. code-block:: python
 
@@ -76,33 +76,33 @@ execute directly ``toolA`` using RunEnvironment build helper to set the environm
     from conans import tools, ConanFile
 
     class PackageB(ConanFile):
-        name = "packageB"
+        name = "package_b"
         version = "1.0"
-        requires = "toolA/1.0@myuser/stable"
+        requires = "tool_a/1.0@myuser/stable"
 
         def build(self):
-            exe_name = "toolA.exe" if self.settings.os == "Windows" else "toolA"
+            exe_name = "tool_a.exe" if self.settings.os == "Windows" else "tool_a"
             self.run("%s --someparams" % exe_name, run_environment=True)
             ...
 
-Building an application using the shared library from ``toolA``
+Building an application using the shared library from ``tool_a``
 ---------------------------------------------------------------
 
 As we are building a final application, we will probably want to distribute it together with the
-shared library from the ``toolA``, so we can use the :ref:`Imports<imports_txt>` to import the required
+shared library from the ``tool_a``, so we can use the :ref:`Imports<imports_txt>` to import the required
 shared libraries to our user space.
 
 .. code-block:: python
    :caption: *conanfile.txt*
 
     [requires]
-    toolA/1.0@myuser/stable
+    tool_a/1.0@myuser/stable
 
     [generators]
     cmake
 
     [options]
-    toolA:shared=True
+    tool_a:shared=True
 
     [imports]
     bin, *.dll -> ./bin # Copies all dll files from packages bin folder to my "bin" folder
@@ -127,7 +127,7 @@ In Linux you still need to set the ``LD_LIBRARY_PATH``, or in OSX, the ``DYLD_LI
 
 .. code-block:: bash
 
-   $ cd bin && LD_LIBRARY_PATH=$(pwd) && ./mytool
+    $ cd bin && LD_LIBRARY_PATH=$(pwd) && ./mytool
 
 Using shared libraries from dependencies
 ----------------------------------------
@@ -161,10 +161,10 @@ Using ``virtualrunenv`` generator
    :caption: *conanfile.txt*
 
     [requires]
-    toolA/1.0@myuser/stable
+    tool_a/1.0@myuser/stable
 
     [options]
-    toolA:shared=True
+    tool_a:shared=True
 
     [generators]
     virtualrunenv
@@ -175,6 +175,6 @@ In the terminal window:
 
     $ conan install .
     $ source activate_run
-    $ toolA --someparams
+    $ toola --someparams
     # Only For Mac OS users to avoid restrictions:
     $ DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH toolA --someparams

--- a/howtos/manage_shared_libraries/env_vars.rst
+++ b/howtos/manage_shared_libraries/env_vars.rst
@@ -175,6 +175,6 @@ In the terminal window:
 
     $ conan install .
     $ source activate_run
-    $ toola --someparams
+    $ tool_a --someparams
     # Only For Mac OS users to avoid restrictions:
     $ DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH toolA --someparams

--- a/howtos/other_languages_package_manager/python.rst
+++ b/howtos/other_languages_package_manager/python.rst
@@ -114,7 +114,7 @@ avoid this and use the same binary for different setups, modifying this behavior
 .. code-block:: bash
 
     $ conan export . memsharded/testing
-    $ conan install PocoPy/0.1@memsharded/testing -s arch=x86 -g virtualenv
+    $ conan install pocopy/0.1@memsharded/testing -s arch=x86 -g virtualenv
     $ activate
     $ python
     >>> import poco
@@ -132,7 +132,7 @@ The output of the :command:`conan install` command also shows us the dependencie
     Requirements
         openssl/1.0.2t from conan.io
         poco/1.9.4 from conan.io
-        PocoPy/0.1@memsharded/testing from local
+        pocopy/0.1@memsharded/testing from local
         pybind11/2.3.0@conan/stable from conan.io
         zlib/1.2.11 from conan.io
 

--- a/howtos/python_code_reuse.rst
+++ b/howtos/python_code_reuse.rst
@@ -50,7 +50,7 @@ It is not necessary to compile code, so the package recipe ``conanfile.py`` is q
     from conans import ConanFile
 
     class HelloPythonConan(ConanFile):
-        name = "HelloPy"
+        name = "hello_py"
         version = "0.1"
         exports = '*'
         build_policy = "missing"
@@ -88,7 +88,7 @@ Now the package is ready for consumption. In another folder, we can create a *co
 .. code-block:: text
 
     [requires]
-    HelloPy/0.1@memsharded/testing
+    hello_py/0.1@memsharded/testing
 
 
 And install it with the following command:
@@ -99,7 +99,7 @@ And install it with the following command:
     $ conan install . -g virtualenv
 
 Creating the above ``conanfile.txt`` might be unnecessary for this simple example, as you can directly run
-:command:`conan install HelloPy/0.1@memsharded/testing -g virtualenv`, however, using the file is the canonical way.
+:command:`conan install hello_py/0.1@memsharded/testing -g virtualenv`, however, using the file is the canonical way.
 
 The specified ``virtualenv`` generator will create an ``activate`` script (in Windows *activate.bat*), that basically contains the
 environment, in this case, the ``PYTHONPATH``. Once we activate it, we are able to find the package in the path and use it:
@@ -130,13 +130,11 @@ As the Conan recipes are Python code itself, it is easy to reuse Python packages
     from conans import ConanFile
 
     class HelloPythonReuseConan(ConanFile):
-        requires = "HelloPy/0.1@memsharded/testing"
+        requires = "hello_py/0.1@memsharded/testing"
 
         def build(self):
             from hello import hello
             hello()
-
-
 
 The ``requires`` section is just referencing the previously created package. The functionality of that package can be used in several
 methods of the recipe: ``source()``, ``build()``, ``package()`` and ``package_info()``, i.e. all of the methods used for creating the

--- a/howtos/visual_studio_packages.rst
+++ b/howtos/visual_studio_packages.rst
@@ -37,7 +37,6 @@ Then build and run the app with Ctrl+F5. (Debug -> Start Without Debugging)
 
 Because the ``hello.cpp`` file contains an ``#ifdef _DEBUG`` to switch between debug and release message.
 
-
 In the repository, there is already a ``conanfile.py`` recipe:
 
 .. code-block:: python
@@ -45,7 +44,7 @@ In the repository, there is already a ``conanfile.py`` recipe:
     from conans import ConanFile, MSBuild
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         license = "MIT"
         url = "https://github.com/memsharded/hello_vs"
@@ -70,8 +69,8 @@ information from the requirements, as include directories, library names, defini
 to allow our project to locate the declared dependencies.
 
 The recipe contains also a ``test_package`` folder with a simple example consuming application.
-In this example, the consuming application is using cmake to build, but it could also use Visual Studio too.
-We have left the cmake one because it is the default generated with :command:`conan new`, and also to show that packages
+In this example, the consuming application is using CMake to build, but it could also use Visual Studio too.
+We have left the CMake one because it is the default generated with :command:`conan new`, and also to show that packages
 created from Visual Studio projects can also be consumed with other build systems like CMake.
 
 Once we want to create a package, it is advised to close VS IDE, clean the temporary build files from VS to avoid problems,
@@ -96,7 +95,6 @@ This process can be repeated to create and test packages for different configura
    $ conan create . memsharded/testing -s compiler="Visual Studio" -s compiler.runtime=MDd -s build_type=Debug
    $ conan create . memsharded/testing -s compiler="Visual Studio" -s compiler.runtime=MDd -s build_type=Debug -s arch=x86
 
-
 .. note::
 
     It is not mandatory to specify the ``compiler.runtime`` setting. If it is not explicitly defined, Conan will
@@ -107,7 +105,7 @@ You can list the different created binary packages:
 
 .. code-block:: bash
 
-    $ conan search Hello/0.1@memsharded/testing
+    $ conan search hello/0.1@memsharded/testing
 
 Uploading binaries
 ------------------
@@ -117,8 +115,8 @@ If you created them with the original username "memsharded", as from the git clo
 to put them on your own username. Of course, you can also directly use your user name in :command:`conan create`.
 
 Another alternative is to configure the permissions in the remote, to allow uploading packages with
-different usernames. By default artifactory will do it but Conan server won't:
-permissions must be given in ``[write_permissions]`` section of ``server.conf``.
+different usernames. By default, Artifactory will do it but Conan server won't: Permissions must be given in the ``[write_permissions]``
+section of *server.conf* file.
 
 
 Reusing packages
@@ -181,7 +179,7 @@ The recipe is almost identical to the above one, just with two minor differences
 
 .. code-block:: python
 
-    requires = "Hello/0.1@memsharded/testing"
+    requires = "hello/0.1@memsharded/testing"
     ...
     generators = "visual_studio"
 

--- a/howtos/vs2017_cmake.rst
+++ b/howtos/vs2017_cmake.rst
@@ -7,12 +7,12 @@ Visual Studio 2017 comes with a CMake integration that allows one to just open a
 and Visual will use it to define the project build.
 
 Conan can also be used in this setup to install dependencies. Let`s say that we are going to build an application that depends
-on an existing Conan package called ``Hello/0.1@user/testing``. For the purpose of this example, you can quickly create this package by typing
+on an existing Conan package called ``hello/0.1@user/testing``. For the purpose of this example, you can quickly create this package by typing
 in your terminal:
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1 -s
+    $ conan new hello/0.1 -s
     $ conan create . user/testing # Default conan profile is Release
     $ conan create . user/testing -s build_type=Debug
 
@@ -33,7 +33,7 @@ The project we want to develop will be a simple application with these 3 files i
     :caption: **conanfile.txt**
 
     [requires]
-    Hello/0.1@user/testing
+    hello/0.1@user/testing
 
     [generators]
     cmake
@@ -120,11 +120,11 @@ configuration, that will match the Visual Studio one. This script can be used to
     add_executable(example example.cpp)
     target_link_libraries(example ${CONAN_LIBS})
 
-This code will manage to download the **cmake-conan** CMake script, and use it automatically, calling a ``conan install`` automatically.
+This code will manage to download the **cmake-conan** CMake script, and use it automatically, calling a :command:`conan install` automatically.
 
 There could be an issue, though, for the ``Release`` configuration. Internally, the Visual Studio 2017 defines the ``configurationType`` As
 ``RelWithDebInfo`` for ``Release`` builds. But Conan default settings (in the Conan *settings.yml* file), only have ``Debug`` and ``Release``
-defined. It is possible to modify the *settings.yml* file, and add those extra build types. Then you should create the ``Hello`` package 
+defined. It is possible to modify the *settings.yml* file, and add those extra build types. Then you should create the ``hello`` package 
 for those settings. And most existing packages, specially in central repositories, are built only for Debug and Release modes.
 
 An easier approach is to change the CMake configuration in Visual: go to the Menu -> CMake -> Change CMake Configuration. That should open

--- a/integrations/build_system/cmake/find_packages.rst
+++ b/integrations/build_system/cmake/find_packages.rst
@@ -9,7 +9,6 @@ The CMake **find_library** function will be able to locate the libraries in the 
 
 So, you can use **find_package** normally:
 
-
 .. code-block:: cmake
 
     project(MyHello)
@@ -28,15 +27,8 @@ So, you can use **find_package** normally:
         message(FATAL_ERROR "Zlib not found")
     endif()
 
-
 In addition to automatic **find_package** support, **CMAKE_MODULE_PATH** variable is set with the requirements root package paths.
 You can override the default behavior of any find_package() by creating a ``findXXX.cmake`` file in your package.
-
-
-
-
-
-
 
 Creating a custom FindXXX.cmake file
 ------------------------------------
@@ -56,37 +48,33 @@ If it's not provided, you can create a basic one. Take a look at this example wi
 
 .. code-block:: cmake
 
-   find_path(ZLIB_INCLUDE_DIR NAMES zlib.h PATHS ${CONAN_INCLUDE_DIRS_ZLIB})
-   find_library(ZLIB_LIBRARY NAMES ${CONAN_LIBS_ZLIB} PATHS ${CONAN_LIB_DIRS_ZLIB})
+    find_path(ZLIB_INCLUDE_DIR NAMES zlib.h PATHS ${CONAN_INCLUDE_DIRS_ZLIB})
+    find_library(ZLIB_LIBRARY NAMES ${CONAN_LIBS_ZLIB} PATHS ${CONAN_LIB_DIRS_ZLIB})
 
-   set(ZLIB_FOUND TRUE)
-   set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
-   set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
-   mark_as_advanced(ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
-
+    set(ZLIB_FOUND TRUE)
+    set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+    set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
+    mark_as_advanced(ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
 
 In the first line we find the path where the headers should be found. We suggest the CONAN_INCLUDE_DIRS_XXX.
 Then repeat for the library names with CONAN_LIBS_XXX and the paths where the libs are CONAN_LIB_DIRS_XXX.
 
 2. In your conanfile.py file add the ``FindXXX.cmake`` to the ``exports_sources`` field:
 
-
 .. code-block:: python
 
    class HelloConan(ConanFile):
-       name = "Hello"
+       name = "hello"
        version = "0.1"
        ...
        exports_sources = ["FindXXX.cmake"]
 
 3. In the package method, copy the ``FindXXX.cmake`` file to the root:
 
-
-
 .. code-block:: python
 
    class HelloConan(ConanFile):
-       name = "Hello"
+       name = "hello"
        version = "0.1"
        ...
        exports_sources = ["FindXXX.cmake"]
@@ -95,7 +83,6 @@ Then repeat for the library names with CONAN_LIBS_XXX and the paths where the li
        def package(self):
            ...
            self.copy("FindXXX.cmake", ".", ".")
-
 
 
 .. _`conan's boost package`: https://github.com/conan-community/conan-boost.git

--- a/integrations/build_system/pkg_config_pc_files.rst
+++ b/integrations/build_system/pkg_config_pc_files.rst
@@ -180,7 +180,7 @@ So it can be a good solution in case you are building **library A** with a build
 
     class ConanFileToolsTest(ConanFile):
         generators = "pkg_config"
-        requires = "LIB_A/0.1@conan/stable"
+        requires = "lib_a/0.1@conan/stable"
         settings = "os", "compiler", "build_type"
 
         def build(self):
@@ -198,7 +198,7 @@ So it can be a good solution in case you are building **library A** with a build
 
     class ConanFileToolsTest(ConanFile):
         generators = "pkg_config"
-        requires = "LIB_A/0.1@conan/stable"
+        requires = "lib_a/0.1@conan/stable"
         settings = "os", "compiler", "build_type"
 
         def build(self):

--- a/integrations/build_system/qmake.rst
+++ b/integrations/build_system/qmake.rst
@@ -51,15 +51,15 @@ This example project will depend on a multi-configuration (Debug/Release) "Hello
     $ git clone https://github.com/memsharded/hello_multi_config
     $ cd hello_multi_config
     $ conan create . memsharded/testing
-    Hello/0.1@memsharded/testing export: Copied 1 '.txt' file: CMakeLists.txt
-    Hello/0.1@memsharded/testing export: Copied 1 '.cpp' file: hello.cpp
-    Hello/0.1@memsharded/testing export: Copied 1 '.h' file: hello.h
-    Hello/0.1@memsharded/testing: A new conanfile.py version was exported
+    hello/0.1@memsharded/testing export: Copied 1 '.txt' file: CMakeLists.txt
+    hello/0.1@memsharded/testing export: Copied 1 '.cpp' file: hello.cpp
+    hello/0.1@memsharded/testing export: Copied 1 '.h' file: hello.h
+    hello/0.1@memsharded/testing: A new conanfile.py version was exported
 
 This hello package is created with CMake, but that doesn't matter for this example, as it can be consumed from a qmake project with the
 configuration showed before.
 
-Now let's get the qmake project and install its `Hello/0.1@memsharded/testing` dependency:
+Now let's get the qmake project and install its `hello/0.1@memsharded/testing` dependency:
 
 .. code-block:: bash
 
@@ -68,11 +68,11 @@ Now let's get the qmake project and install its `Hello/0.1@memsharded/testing` d
     $ conan install .
     PROJECT: Installing C:\Users\memsharded\qmake_example\conanfile.txt
     Requirements
-        Hello/0.1@memsharded/testing from local cache - Cache
+        hello/0.1@memsharded/testing from local cache - Cache
     Packages
-        Hello/0.1@memsharded/testing:15af85373a5688417675aa1e5065700263bf257e - Cache
+        hello/0.1@memsharded/testing:15af85373a5688417675aa1e5065700263bf257e - Cache
 
-    Hello/0.1@memsharded/testing: Already installed!
+    hello/0.1@memsharded/testing: Already installed!
     PROJECT: Generator qmake created conanbuildinfo.pri
     PROJECT: Generator txt created conanbuildinfo.txt
     PROJECT: Generated conaninfo.txt

--- a/integrations/build_system/scons.rst
+++ b/integrations/build_system/scons.rst
@@ -10,7 +10,7 @@ generator. The package recipe ``build()`` method could be similar to:
 
     class PkgConan(ConanFile):
         settings = 'os', 'compiler', 'build_type', 'arch'
-        requires = 'Hello/1.0@user/stable'
+        requires = 'hello/1.0@user/stable'
         generators = "scons"
         ...
 

--- a/integrations/ci/appveyor.rst
+++ b/integrations/ci/appveyor.rst
@@ -76,14 +76,14 @@ example we are assuming that you are using GitHub and also uploading your final 
 #. Activate the repo in your Appveyor account, so it is built when we push changes to it.
 #. Under *Appveyor Settings->Environment*, add the ``CONAN_PASSWORD`` environment variable with the Bintray API Key, and encrypt it.  If your Bintray user is different from the package user, you can define your Bintray username too, defining the environment variable ``CONAN_LOGIN_USERNAME``
 #. Clone the repo: ``$ git clone <your_repo/hello> && cd hello``
-#. Create the package: :command:`conan new Hello/0.1@<user>/testing -t -s -ciw -cis -ciu=UPLOAD_URL` where **user** is your Bintray username
+#. Create the package: :command:`conan new hello/0.1@<user>/testing -t -s -ciw -cis -ciu=UPLOAD_URL` where **user** is your Bintray username
 #. You can inspect the created files: both *appveyor.yml* and the *build.py* script, that is used by **conan-package-tools** utility to
    split different builds with different configurations in different appveyor jobs.
 #. You can test locally, before pushing, with :command:`conan create`
 #. Add the changes, commit and push: :command:`git add . && git commit -m "first commit" && git push`
 #. Go to Appveyor and see the build, with the different jobs.
 #. When it finish, go to your Bintray repository, you should see there the uploaded packages for different configurations
-#. Check locally, searching in Bintray: :command:`conan search Hello/0.1@<user>/testing -r=mybintray`
+#. Check locally, searching in Bintray: :command:`conan search hello/0.1@<user>/testing -r=mybintray`
 
 If something fails, please report an issue in the ``conan-package-tools`` github repository: https://github.com/conan-io/conan-package-tools
 

--- a/integrations/ci/circleci.rst
+++ b/integrations/ci/circleci.rst
@@ -72,13 +72,13 @@ You could follow these steps:
 #. Create a Conan repository in Bintray under your user or organization, and get its URL ("Set me up"). We will call it ``UPLOAD_URL``
 #. Under your project page, *Settings -> Pipelines -> Add a variable*, add the ``CONAN_PASSWORD`` environment variable with the Bintray API Key. If your Bintray user is different from the package user, you can also define your Bintray username, defining the environment variable ``CONAN_LOGIN_USERNAME``
 #. Clone the repo: ``$ git clone <your_repo/hello> && cd hello``
-#. Create the package: ``$ conan new Hello/0.1@<user>/testing -t -s -ciccg -ciccc -cicco -cis -ciu=UPLOAD_URL`` where ``user`` is your Bintray username
+#. Create the package: ``$ conan new hello/0.1@<user>/testing -t -s -ciccg -ciccc -cicco -cis -ciu=UPLOAD_URL`` where ``user`` is your Bintray username
 #. You can inspect the created files: both ``.circleci/config.yml`` and the ``build.py`` script, that is used by ``conan-package-tools`` utility to split different builds with different configurations in different GitLab CI jobs.
 #. You can test locally, before pushing, with ``$ conan create``
 #. Add the changes, commit and push: ``$ git add . && git commit -m "first commit" && git push``
 #. Go to Pipelines page and see the pipeline, with the different jobs.
 #. When it has finished, go to your Bintray repository, you should see there the uploaded packages for different configurations
-#. Check locally, searching in Bintray: ``$ conan search Hello/0.1@<user>/testing -r=mybintray``
+#. Check locally, searching in Bintray: ``$ conan search hello/0.1@<user>/testing -r=mybintray``
 
 If something fails, please report an issue in the ``conan-package-tools`` github repository: https://github.com/conan-io/conan-package-tools
 

--- a/integrations/ci/gitlab.rst
+++ b/integrations/ci/gitlab.rst
@@ -69,14 +69,14 @@ You could follow these steps:
 #. Create a Conan repository in Bintray under your user or organization, and get its URL ("Set me up"). We will call it ``UPLOAD_URL``
 #. Under your project page, *Settings -> Pipelines -> Add a variable*, add the ``CONAN_PASSWORD`` environment variable with the Bintray API Key. If your Bintray user is different from the package user, you can also define your Bintray username, defining the environment variable ``CONAN_LOGIN_USERNAME``
 #. Clone the repo: :command:`git clone <your_repo/hello> && cd hello`.
-#. Create the package: :command:`conan new Hello/0.1@<user>/testing -t -s -ciglg -ciglc -cis -ciu=UPLOAD_URL` where **user** is your Bintray username.
+#. Create the package: :command:`conan new hello/0.1@<user>/testing -t -s -ciglg -ciglc -cis -ciu=UPLOAD_URL` where **user** is your Bintray username.
 #. You can inspect the created files: both *.gitlab-ci.yml* and the *build.py* script, that is used by **conan-package-tools** utility to
    split different builds with different configurations in different GitLab CI jobs.
 #. You can test locally, before pushing, with :command:`conan create` or by GitLab Runner.
 #. Add the changes, commit and push: :command:`git add . && git commit -m "first commit" && git push`.
 #. Go to Pipelines page and see the pipeline, with the different jobs.
 #. When it has finished, go to your Bintray repository, you should see there the uploaded packages for different configurations.
-#. Check locally, searching in Bintray: :command:`conan search Hello/0.1@<user>/testing -r=mybintray`.
+#. Check locally, searching in Bintray: :command:`conan search hello/0.1@<user>/testing -r=mybintray`.
 
 If something fails, please report an issue in the **conan-package-tools** github repository: https://github.com/conan-io/conan-package-tools
 

--- a/integrations/ci/travisci.rst
+++ b/integrations/ci/travisci.rst
@@ -67,14 +67,14 @@ You could follow these steps:
    If your Bintray user is different from the package user, you can also define your Bintray username, defining the environment variable
    ``CONAN_LOGIN_USERNAME``.
 #. Clone the repo: :command:`git clone <your_repo/hello> && cd hello`.
-#. Create the package: :command:`conan new Hello/0.1@<user>/testing -t -s -cilg -cis -ciu=UPLOAD_URL` where **user** is your Bintray username.
+#. Create the package: :command:`conan new hello/0.1@<user>/testing -t -s -cilg -cis -ciu=UPLOAD_URL` where **user** is your Bintray username.
 #. You can inspect the created files: both *.travis.yml*, *.travis/run.sh*, and ``.travis/install.sh`` and the *build.py* script, that is
    used by **conan-package-tools** utility to split different builds with different configurations in different Travis CI jobs.
 #. You can test locally, before pushing, with :command:`conan test`.
 #. Add the changes, commit and push: :command:`git add . && git commit -m "first commit" && git push`.
 #. Go to Travis and see the build, with the different jobs.
 #. When it has finished, go to your Bintray repository, you should see there the uploaded packages for different configurations.
-#. Check locally, searching in Bintray: :command:`conan search Hello/0.1@<user>/testing -r=mybintray`.
+#. Check locally, searching in Bintray: :command:`conan search hello/0.1@<user>/testing -r=mybintray`.
 
 If something fails, please report an issue in the ``conan-package-tools`` GitHub repository: https://github.com/conan-io/conan-package-tools
 

--- a/reference/build_helpers/cmake.rst
+++ b/reference/build_helpers/cmake.rst
@@ -375,7 +375,7 @@ will contain absolute paths to the installed package folder, for example it will
 
 .. code-block:: text
 
-    SET(Foo_INSTALL_DIR /home/developer/.conan/data/Foo/1.0.0/...)
+    SET(Foo_INSTALL_DIR /home/developer/.conan/data/foo/1.0.0/...)
 
 This will cause cmake's ``find_package()`` method to fail when someone else installs the package via Conan. This function will replace such
 paths to:
@@ -390,7 +390,7 @@ For dependent packages method replaces lines with references to dependencies ins
 
 .. code-block:: text
 
-    SET_TARGET_PROPERTIES(foo PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "/home/developer/.conan/data/Bar/1.0.0/user/channel/id/include")
+    SET_TARGET_PROPERTIES(foo PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "/home/developer/.conan/data/bar/1.0.0/user/channel/id/include")
 
 to following lines:
 

--- a/reference/build_helpers/meson.rst
+++ b/reference/build_helpers/meson.rst
@@ -15,7 +15,7 @@ files of our requirements, then ``Meson()`` build helper will locate them automa
 
     class ConanFileToolsTest(ConanFile):
         generators = "pkg_config"
-        requires = "LIB_A/0.1@conan/stable"
+        requires = "lib_a/0.1@conan/stable"
         settings = "os", "compiler", "build_type"
 
         def build(self):
@@ -157,7 +157,7 @@ library locally (in your user folder, not in the local cache), could be:
     from conans import ConanFile, Meson
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
         generators = "pkg_config"

--- a/reference/commands/consumer/info.rst
+++ b/reference/commands/consumer/info.rst
@@ -89,7 +89,7 @@ your local cache.
     $ conan info .
     $ conan info myproject_folder
     $ conan info myproject_folder/conanfile.py
-    $ conan info Hello/1.0@user/channel
+    $ conan info hello/1.0@user/channel
 
 The output will look like:
 
@@ -104,9 +104,9 @@ The output will look like:
      Updates: Version not checked
      Creation date: 2017-10-31 14:45:34
      Required by:
-        Hello/1.0@user/channel
+        hello/1.0@user/channel
 
-    Hello/1.0@user/channel
+    hello/1.0@user/channel
      ID: 5ab84d6acfe1f23c4fa5ab84d6acfe1f23c4fa8
      BuildID: None
      Remote: None
@@ -116,7 +116,7 @@ The output will look like:
      Required by:
         Project
      Requires:
-        Hello0/0.1@user/channel
+        hello0/0.1@user/channel
 
 :command:`conan info` builds the complete dependency graph, like :command:`conan install` does. The main
 difference is that it doesn't try to install or build the binaries, but the package recipes

--- a/reference/commands/consumer/search.rst
+++ b/reference/commands/consumer/search.rst
@@ -95,14 +95,14 @@ setting, Conan won't find the packages. e.g:
 
 .. code-block:: bash
 
-    $ conan search MyRecipe/1.0@lasote/stable -q os=Windows
+    $ conan search my_recipe/1.0@lasote/stable -q os=Windows
 
-The query above won't find the ``MyRecipe`` binary packages (because the recipe doesn't declare
+The query above won't find the ``my_recipe`` binary packages (because the recipe doesn't declare
 "os" as a setting) unless you specify the ``None`` value:
 
 .. code-block:: bash
 
-    $ conan search MyRecipe/1.0@lasote/stable -q os=None
+    $ conan search my_recipe/1.0@lasote/stable -q os=None
 
 You can generate a table for all binaries from a given recipe with the ``--table`` option:
 

--- a/reference/commands/creator/create.rst
+++ b/reference/commands/creator/create.rst
@@ -119,10 +119,10 @@ The ``reference`` field can be:
 .. code-block:: bash
 
     $ conan export . demo/testing
-    $ conan install Hello/0.1@demo/testing --build=Hello
+    $ conan install hello/0.1@demo/testing --build=hello
     # package is created now, use test to test it
     $ cd test_package
-    $ conan test . Hello/0.1@demo/testing
+    $ conan test . hello/0.1@demo/testing
 
 
 .. tip::

--- a/reference/commands/creator/export-pkg.rst
+++ b/reference/commands/creator/export-pkg.rst
@@ -131,8 +131,8 @@ There are different scenarios where this command could look like useful:
 
   .. code-block:: bash
 
-      $ conan new Hello/0.1 --bare  # It creates a minimum recipe example
-      $ conan export-pkg . Hello/0.1@user/stable -s os=Windows -s arch=x86 -s build_type=Release --package-folder=Release_x86
+      $ conan new hello/0.1 --bare  # It creates a minimum recipe example
+      $ conan export-pkg . hello/0.1@user/stable -s os=Windows -s arch=x86 -s build_type=Release --package-folder=Release_x86
 
   This last command will copy all the contents from the ``package-folder`` and
   create the package associated with the settings provided through the command
@@ -166,4 +166,4 @@ There are different scenarios where this command could look like useful:
 
   .. code-block:: bash
 
-      $ conan export-pkg . Hello/0.1@user/stable -pr=myprofile --source-folder=sources --build-folder=build
+      $ conan export-pkg . hello/0.1@user/stable -pr=myprofile --source-folder=sources --build-folder=build

--- a/reference/commands/creator/test.rst
+++ b/reference/commands/creator/test.rst
@@ -77,12 +77,12 @@ This command is util for testing existing packages, that have been previously bu
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1 -s -t
+    $ conan new hello/0.1 -s -t
     $ mv test_package test_package2
     $ conan create . user/testing
     # doesn't automatically run test, it has been renamed
     # now run test
-    $ conan test test_package2 Hello/0.1@user/testing
+    $ conan test test_package2 hello/0.1@user/testing
 
 The test package folder, could be elsewhere, or could be even applied to different versions of the
 package.

--- a/reference/commands/development/package.rst
+++ b/reference/commands/development/package.rst
@@ -62,7 +62,7 @@ This example shows how ``package()`` works in a package which can be edited and 
 
 .. code-block:: bash
 
-    $ conan new Hello/0.1 -s
+    $ conan new hello/0.1 -s
     $ conan install . --install-folder=build_x86 -s arch=x86
     $ conan build . --build-folder=build_x86
     $ conan package . --build-folder=build_x86 --package-folder=package_x86
@@ -78,7 +78,7 @@ This example shows how ``package()`` works in a package which can be edited and 
 
     .. code-block:: bash
 
-        $ conan new Hello/0.1 -s
+        $ conan new hello/0.1 -s
         $ conan install . --install-folder=build_x86 -s arch=x86
         $ conan build . --build-folder=build_x86
-        $ conan export-pkg . Hello/0.1@user/stable --build-folder=build_x86 -s arch=x86
+        $ conan export-pkg . hello/0.1@user/stable --build-folder=build_x86 -s arch=x86

--- a/reference/commands/misc/alias.rst
+++ b/reference/commands/misc/alias.rst
@@ -29,19 +29,19 @@ The command:
 
 .. code-block:: bash
 
-    $ conan alias Hello/0.X@user/testing Hello/0.1@user/testing
+    $ conan alias hello/0.X@user/testing hello/0.1@user/testing
 
-Creates and exports a package recipe for ``Hello/0.X@user/testing`` with the following content:
+Creates and exports a package recipe for ``hello/0.X@user/testing`` with the following content:
 
 .. code-block:: python
 
     from conans import ConanFile
 
     class AliasConanfile(ConanFile):
-        alias = "Hello/0.1@user/testing"
+        alias = "hello/0.1@user/testing"
 
 Such package recipe acts as a "proxy" for the aliased reference. Users depending on
-``Hello/0.X@user/testing`` will actually use version ``Hello/0.1@user/testing``. The alias package
+``hello/0.X@user/testing`` will actually use version ``hello/0.1@user/testing``. The alias package
 reference will not appear in the dependency graph at all. It is useful to define symbolic names, or
 behaviors like "always depend on the latest minor", but defined upstream instead of being defined
 downstream with ``version-ranges``.

--- a/reference/commands/output/info.rst
+++ b/reference/commands/output/info.rst
@@ -34,17 +34,16 @@ each nested one can be built in parallel.
     {  
         "groups":[  
             [  
-                "LibA/0.1@lasote/stable",
-                "LibE/0.1@lasote/stable",
-                "LibF/0.1@lasote/stable"
+                "liba/0.1@lasote/stable",
+                "libe/0.1@lasote/stable",
+                "libf/0.1@lasote/stable"
             ],
             [  
-                "LibB/0.1@lasote/stable",
-                "LibC/0.1@lasote/stable"
+                "libb/0.1@lasote/stable",
+                "libc/0.1@lasote/stable"
             ]
         ]
     }
-
 
 Nodes to build
 ==============
@@ -57,11 +56,11 @@ references.
    :caption: nodes_to_build.json
 
     [  
-        "H0/0.1@lu/st",
-        "H1a/0.1@lu/st",
-        "H1c/0.1@lu/st",
-        "H2a/0.1@lu/st",
-        "H2c/0.1@lu/st"
+        "h0/0.1@lu/st",
+        "h1a/0.1@lu/st",
+        "h1c/0.1@lu/st",
+        "h2a/0.1@lu/st",
+        "h2c/0.1@lu/st"
     ]
 
 
@@ -75,44 +74,44 @@ contain a list with the information for each of the nodes.
 .. code-block:: json
    :caption: info.json
 
-    [  
-        {  
-            "reference":"LibA/0.1@lasote/stable",
+    [
+        {
+            "reference":"liba/0.1@lasote/stable",
             "is_ref":true,
-            "display_name":"LibA/0.1@lasote/stable",
+            "display_name":"liba/0.1@lasote/stable",
             "id":"8da7d879f40d12efabc9a1f26ab12f1b6cafb6ad",
             "build_id":null,
             "url":"myurl",
-            "license":[  
+            "license":[
                 "MIT"
             ],
             "recipe":"No remote",
             "binary":"Missing",
             "creation_date":"2019-01-29 17:22:41",
             "required_by":[  
-                "LibC/0.1@lasote/stable",
-                "LibB/0.1@lasote/stable"
+                "libc/0.1@lasote/stable",
+                "libb/0.1@lasote/stable"
             ]
         },
-        {  
-            "reference":"LibB/0.1@lasote/stable",
+        {
+            "reference":"libb/0.1@lasote/stable",
             "is_ref":true,
-            "display_name":"LibB/0.1@lasote/stable",
+            "display_name":"libb/0.1@lasote/stable",
             "id":"c4ec2bf350e2a02405029ab366535e26372a4f63",
             "build_id":null,
             "url":"myurl",
-            "license":[  
+            "license":[
                 "MIT"
             ],
             "recipe":"No remote",
             "binary":"Missing",
             "creation_date":"2019-01-29 17:22:41",
-            "required_by":[  
-                "conanfile.py (LibD/0.1@None/None)"
+            "required_by":[
+                "conanfile.py (libd/0.1@None/None)"
             ],
-            "requires":[  
-                "LibA/0.1@lasote/stable",
-                "LibE/0.1@lasote/stable"
+            "requires":[
+                "liba/0.1@lasote/stable",
+                "libe/0.1@lasote/stable"
             ]
         },
         { "...": "..."}

--- a/reference/commands/output/search.rst
+++ b/reference/commands/output/search.rst
@@ -287,7 +287,7 @@ The output JSON contains a two first level keys:
                                       "os":"Windows"
                                   },
                                   "requires":[
-                                      "OpenSSL/1.0.2n@conan/stable:606fdb601e335c2001bdf31d478826b644747077",
+                                      "openssl/1.0.2n@conan/stable:606fdb601e335c2001bdf31d478826b644747077",
                                       "zlib/1.2.11@conan/stable:6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7"
                                   ],
                                   "outdated":true
@@ -309,7 +309,7 @@ The output JSON contains a two first level keys:
                                       "os":"Windows"
                                   },
                                   "requires":[
-                                      "OpenSSL/1.0.2n@conan/stable:f761d91cef7988eafb88c6b6179f4cf261609f26",
+                                      "openssl/1.0.2n@conan/stable:f761d91cef7988eafb88c6b6179f4cf261609f26",
                                       "zlib/1.2.11@conan/stable:6dc82da13f94df549e60f9c1ce4c5d11285a4dff"
                                   ],
                                   "outdated":true

--- a/reference/commands/output/upload.rst
+++ b/reference/commands/output/upload.rst
@@ -42,7 +42,7 @@ The output JSON contains a two first level keys:
         "uploaded":[
             {
                 "recipe":{
-                    "id":"Hello/0.1@conan/testing",
+                    "id":"hello/0.1@conan/testing",
                     "remote_name":"conan-center",
                     "remote_url":"https://conan.bintray.com",
                     "time":"2018-04-30T11:18:19.204728"
@@ -76,7 +76,7 @@ The output JSON contains a two first level keys:
             },
             {
                 "recipe":{
-                    "id":"Hello0/1.2.1@conan/testing",
+                    "id":"hello0/1.2.1@conan/testing",
                     "remote_name":"conan-center",
                     "remote_url":"https://conan.bintray.com",
                     "time":"2018-04-30T11:18:32.688651"
@@ -92,7 +92,7 @@ The output JSON contains a two first level keys:
             },
             {
                 "recipe":{
-                    "id":"HelloApp/0.1@conan/testing",
+                    "id":"hello_app/0.1@conan/testing",
                     "remote_name":"conan-center",
                     "remote_url":"https://conan.bintray.com",
                     "time":"2018-04-30T11:18:36.901333"
@@ -108,7 +108,7 @@ The output JSON contains a two first level keys:
             },
             {
                 "recipe":{
-                    "id":"HelloPythonConan/0.1@conan/testing",
+                    "id":"hello_python_conan/0.1@conan/testing",
                     "remote_name":"conan-center",
                     "remote_url":"https://conan.bintray.com",
                     "time":"2018-04-30T11:18:41.181543"
@@ -124,7 +124,7 @@ The output JSON contains a two first level keys:
             },
             {
                 "recipe":{
-                    "id":"HelloPythonReuseConan/0.1@conan/testing",
+                    "id":"hello_python_reuse_conan/0.1@conan/testing",
                     "remote_name":"conan-center",
                     "remote_url":"https://conan.bintray.com",
                     "time":"2018-04-30T11:18:45.614096"

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -38,7 +38,7 @@ short description of the package.
 .. code-block:: python
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         description = """This is a Hello World library.
                         A fully featured, portable, C++ library to say Hello World in the stdout,
@@ -71,7 +71,7 @@ repository, please indicate it in the ``url`` attribute, so that it can be easil
 .. code-block:: python
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         url = "https://github.com/conan-io/hello.git"
 
@@ -92,7 +92,7 @@ the :command:`conan info` command and possibly other search and report tools.
 .. code-block:: python
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         license = "MIT"
 
@@ -118,7 +118,7 @@ define who is the creator/maintainer of the package
 .. code-block:: python
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         author = "John J. Smith (john.smith@company.com)"
 
@@ -158,32 +158,30 @@ The value of these fields can be accessed from within a ``conanfile.py``:
     from conans import ConanFile
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
 
         def requirements(self):
             self.requires("common-lib/version")
             if self.user and self.channel:
                 # If the recipe is using them, I want to consume my fork.
-                self.requires("Say/0.1@%s/%s" % (self.user, self.channel))
+                self.requires("say/0.1@%s/%s" % (self.user, self.channel))
             else:
                 # otherwise, I'll consume the community one
-                self.requires("Say/0.1")
+                self.requires("say/0.1")
 
 
 Only packages that have already been exported (packages in the local cache or in a remote server)
 can have a user/channel assigned. For package recipes working in the user space, there is no
-current user/channel by default, although they can be defined at ``conan install`` time with:
+current user/channel by default, although they can be defined at :command:`conan install` time with:
 
 .. code-block:: bash
 
     $ conan install <path to conanfile.py> user/channel
 
-
 .. seealso::
 
     FAQ: :ref:`faq_recommendation_user_channel`
-
 
 .. warning::
 
@@ -205,7 +203,7 @@ you need to declare the environment variables ``CONAN_USERNAME`` and ``CONAN_CHA
     from conans import ConanFile
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         default_user = "myuser"
 
@@ -214,7 +212,7 @@ you need to declare the environment variables ``CONAN_USERNAME`` and ``CONAN_CHA
             return "mydefaultchannel"
 
         def requirements(self):
-            self.requires("Pkg/0.1@%s/%s" % (self.user, self.channel))
+            self.requires("pkg/0.1@%s/%s" % (self.user, self.channel))
 
 
 .. _settings_property:
@@ -250,7 +248,7 @@ We can indicate that in the conanfile:
    from conans import ConanFile
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         # We can just omit the settings attribute too
         settings = None
@@ -297,10 +295,10 @@ It is possible to check the settings to implement conditional logic, with attrib
             # Other different commands
 
 Those comparisons do content checking, for example if you do a typo like ``self.settings.os == "Windos"``,
-conan will fail and tell you that is not a valid ``settings.os`` value, and the possible range of values.
+Conan will fail and tell you that is not a valid ``settings.os`` value, and the possible range of values.
 
 Likewise, if you try to access some setting that doesn't exist, like ``self.settings.compiler.libcxx``
-for the ``Visual Studio`` setting, conan will fail telling that ``libcxx`` does not exist for that compiler.
+for the ``Visual Studio`` setting, Conan will fail telling that ``libcxx`` does not exist for that compiler.
 
 If you want to do a safe check of settings values, you could use the ``get_safe()`` method:
 
@@ -313,8 +311,6 @@ If you want to do a safe check of settings values, you could use the ``get_safe(
         compiler_version = self.settings.get_safe("compiler.version")
 
 The ``get_safe()`` method will return ``None`` if that setting or subsetting doesn't exist.
-
-
 
 .. _conanfile_options:
 
@@ -374,12 +370,12 @@ legacy reasons.
 .. tip::
 
     - You can inspect available package options reading the package recipe, which can be
-      done with the command :command:`conan inspect MyPkg/0.1@user/channel`.
+      done with the command :command:`conan inspect mypkg/0.1@user/channel`.
     - Options ``"shared": [True, False]`` and ``"fPIC": [True, False]`` are automatically managed in :ref:`cmake_reference` and
       :ref:`autotools_reference` build helpers.
 
 As we mentioned before, values for options in a recipe can be defined using different ways, let's
-go over all of them for the example recipe ``MyPkg`` defined above:
+go over all of them for the example recipe ``mypkg`` defined above:
 
 - Using the attribute ``default_options`` in the recipe itself.
 - In the ``default_options`` of a recipe that requires this one: the values defined here
@@ -388,18 +384,18 @@ go over all of them for the example recipe ``MyPkg`` defined above:
   .. code-block:: python
 
       class OtherPkg(ConanFile):
-          requires = "MyPkg/0.1@user/channel"
-          default_options = {"MyPkg:shared": False}
+          requires = "mypkg/0.1@user/channel"
+          default_options = {"mypkg:shared": False}
 
   Of course, this will work in the same way working with a *conanfile.txt*:
 
   .. code-block:: text
 
       [requires]
-      MyPkg/0.1@user/channel
+      mypkg/0.1@user/channel
 
       [options]
-      MyPkg:shared=False
+      mypkg:shared=False
 
 - It is also possible to define default values for the options of a recipe using
   :ref:`profiles<profiles>`. They will apply whenever that recipe is used:
@@ -438,7 +434,7 @@ consistent implementation take into account these considerations:
 
     - ``default_options = {"shared": True, "option": None}``
     - ``default_options = {"shared": "True", "option": "None"}``
-    - ``MyPkg:shared=True``, ``MyPkg:option=None`` on profiles, command line or *conanfile.txt*
+    - ``mypkg:shared=True``, ``mypkg:option=None`` on profiles, command line or *conanfile.txt*
 
 - **Implicit conversion to boolean is case insensitive**, so the
   expression ``bool(self.options.option)``:
@@ -471,21 +467,21 @@ However, you can also specify default option values of the required dependencies
 .. code-block:: python
 
     class OtherPkg(ConanFile):
-        requires = "Pkg/0.1@user/channel"
-        default_options = {"Pkg:pkg_option": "value"}
+        requires = "pkg/0.1@user/channel"
+        default_options = {"pkg:pkg_option": "value"}
 
 And it also works with default option values of conditional required dependencies:
 
 .. code-block:: python
 
     class OtherPkg(ConanFile):
-        default_options = {"Pkg:pkg_option": "value"}
+        default_options = {"pkg:pkg_option": "value"}
 
         def requirements(self):
             if self.settings.os != "Windows":
-                self.requires("Pkg/0.1@user/channel")
+                self.requires("pkg/0.1@user/channel")
 
-For this example running in Windows, the `default_options` for the `Pkg/0.1@user/channel` will be ignored, they will only be used on every
+For this example running in Windows, the `default_options` for the `pkg/0.1@user/channel` will be ignored, they will only be used on every
 other OS.
 
 You can also set the options conditionally to a final value with ``config_options()`` instead of using ``default_options``:
@@ -526,21 +522,21 @@ Specify package dependencies as a list or tuple of other packages:
 .. code-block:: python
 
     class MyLibConan(ConanFile):
-        requires = "Hello/1.0@user/stable", "OtherLib/2.1@otheruser/testing"
+        requires = "hello/1.0@user/stable", "OtherLib/2.1@otheruser/testing"
 
 You can specify further information about the package requirements:
 
 .. code-block:: python
 
     class MyLibConan(ConanFile):
-        requires = [("Hello/0.1@user/testing"),
-                    ("Say/0.2@dummy/stable", "override"),
-                    ("Bye/2.1@coder/beta", "private")]
+        requires = [("hello/0.1@user/testing"),
+                    ("say/0.2@dummy/stable", "override"),
+                    ("bye/2.1@coder/beta", "private")]
 
 .. code-block:: python
 
     class MyLibConan(ConanFile):
-        requires = (("Hello/1.0@user/stable", "private"), )
+        requires = (("hello/1.0@user/stable", "private"), )
 
 
 Requirements can be complemented by 2 different parameters:
@@ -558,17 +554,16 @@ the compression is enabled or not. Now, if you want to force the usage of Zlib(v
 ..  code-block:: python
 
     class HelloConan(ConanFile):
-        requires = ("A/1.0@user/stable", ("Zlib/3.0@other/beta", "override"))
+        requires = ("ab/1.0@user/stable", ("zlib/3.0@other/beta", "override"))
 
-This **will not introduce a new dependency**, it will just change Zlib v2 to v3 if A actually
-requires it. Otherwise Zlib will not be a dependency of your package.
+This **will not introduce a new dependency**, it will just change ``zlib/2.0`` to ``zlib/3.0`` if ``ab`` actually
+requires it. Otherwise zlib will not be a dependency of your package.
 
 .. note::
 
     To prevent accidental override of transitive dependencies, check the config variable
     :ref:`general.error_on_override<conan_conf>` or the environment variable
     :ref:`CONAN_ERROR_ON_OVERRIDE<env_vars_conan_error_on_override>`.
-
 
 .. _version_ranges_reference:
 
@@ -580,7 +575,7 @@ The syntax is using brackets:
 ..  code-block:: python
 
     class HelloConan(ConanFile):
-        requires = "Pkg/[>1.0 <1.8]@user/stable"
+        requires = "pkg/[>1.0 <1.8]@user/stable"
 
 Expressions are those defined and implemented by [python node-semver](https://pypi.org/project/node-semver/). Accepted expressions would be:
 
@@ -590,7 +585,6 @@ Expressions are those defined and implemented by [python node-semver](https://py
     2.8          # equivalent to =2.8
     ~=3.0        # compatible, according to semver
     >1.1 || 0.8  # conditions can be OR'ed
-
 
 .. container:: out_reference_box
 
@@ -606,7 +600,7 @@ They can be specified as a comma separated tuple in the package recipe:
 .. code-block:: python
 
     class MyPkg(ConanFile):
-        build_requires = "ToolA/0.2@user/testing", "ToolB/0.2@user/testing"
+        build_requires = "tool_a/0.2@user/testing", "tool_b/0.2@user/testing"
 
 Read more: :ref:`Build requirements <build_requires>`
 
@@ -671,11 +665,10 @@ Exclude patterns are also possible, with the ``!`` prefix:
 
     exports_sources = "include*", "src*", "!src/build/*"
 
-
 generators
 ----------
 
-Generators specify which is the output of the ``install`` command in your project folder. By default, a *conanbuildinfo.txt* file is
+Generators specify which is the output of the :command:`install` command in your project folder. By default, a *conanbuildinfo.txt* file is
 generated, but you can specify different generators and even use more than one.
 
 .. code-block:: python
@@ -736,7 +729,7 @@ the cache and can be only modified for the local flow with :command:`conan build
 build_policy
 ------------
 
-With the ``build_policy`` attribute the package creator can change the default conan's build behavior.
+With the ``build_policy`` attribute the package creator can change the default Conan's build behavior.
 The allowed ``build_policy`` values are:
 
 - ``missing``: If no binary package is found, Conan will build it without the need to invoke :command:`conan install --build missing` option.
@@ -877,7 +870,7 @@ This object should be filled in ``package_info()`` method.
 +----------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.cflags             | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                             |
 +----------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cppflags           | [DEPRECATED: use cxxflags instead]                                                                      |
+| self.cpp_info.cppflags           | [DEPRECATED: Use cxxflags instead]                                                                      |
 +----------------------------------+---------------------------------------------------------------------------------------------------------+
 | self.cpp_info.cxxflags           | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
 +----------------------------------+---------------------------------------------------------------------------------------------------------+
@@ -981,8 +974,6 @@ The ``self.env_info`` object can be filled with the environment variables to be 
 
     Read :ref:`package_info() method docs <method_package_info>` for more info.
 
-
-
 .. _deps_env_info_attributes_reference:
 
 deps_env_info
@@ -1010,8 +1001,6 @@ you want to access to the variable declared by some specific requirement you can
 
             # Access to the environment variables globally
             os.environ["SOMEVAR"]
-
-
 
 user_info
 ---------

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -18,7 +18,7 @@ control. But if the source code is available in a repository, you can directly g
     from conans import ConanFile
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
         settings = "os", "compiler", "build_type", "arch"
 
@@ -555,7 +555,7 @@ This method is useful for defining conditional build requirements, for example:
 
         def build_requirements(self):
             if self.settings.os == "Windows":
-                self.build_requires("ToolWin/0.1@user/stable")
+                self.build_requires("tool_win/0.1@user/stable")
 
 .. seealso::
 
@@ -566,10 +566,10 @@ This method is useful for defining conditional build requirements, for example:
 system_requirements()
 ---------------------
 
-It is possible to install system-wide packages from conan. Just add a ``system_requirements()`` method to your conanfile and specify what
+It is possible to install system-wide packages from Conan. Just add a ``system_requirements()`` method to your conanfile and specify what
 you need there.
 
-For a special use case you can use also ``conans.tools.os_info`` object to detect the operating system, version and distribution (linux):
+For a special use case you can use also ``conans.tools.os_info`` object to detect the operating system, version and distribution (Linux):
 
 - ``os_info.is_linux``: True if Linux.
 - ``os_info.is_windows``: True if Windows.
@@ -1051,10 +1051,10 @@ The ``deploy()`` method is designed to work on a package that is installed direc
 
 .. code-block:: bash
 
-    $ conan install Pkg/0.1@user/channel
+    $ conan install pkg/0.1@user/channel
     > ...
-    > Pkg/0.1@user/testing deploy(): Copied 1 '.dll' files: mylib.dll
-    > Pkg/0.1@user/testing deploy(): Copied 1 '.exe' files: myexe.exe
+    > pkg/0.1@user/testing deploy(): Copied 1 '.dll' files: mylib.dll
+    > pkg/0.1@user/testing deploy(): Copied 1 '.exe' files: myexe.exe
 
-All other packages and dependencies, even transitive dependencies of "Pkg/0.1@user/testing" will not be deployed, it is the responsibility
+All other packages and dependencies, even transitive dependencies of "pkg/0.1@user/testing" will not be deployed, it is the responsibility
 of the installed package to deploy what it needs from its dependencies.

--- a/reference/config_files/registry.txt.rst
+++ b/reference/config_files/registry.txt.rst
@@ -21,7 +21,7 @@ packages in your cache associated with the remote they were retrieved from.
     conan-center https://conan.bintray.com True
     local http://localhost:9300 True
 
-    Hello/0.1@demo/testing local
+    hello/0.1@demo/testing local
 
 The first section of the file is listing ``remote-name``: ``remote-url`` ``verify_ssl``. Adding, removing or changing
 those lines, will add, remove or change the respective remote. If ``verify_ssl`` is enabled, Conan will verify the SSL certificates for that

--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -439,7 +439,7 @@ See example of build method in ``conanfile.py`` to enable/disable running tests 
     from conans import ConanFile, CMake, tools
 
     class HelloConan(ConanFile):
-        name = "Hello"
+        name = "hello"
         version = "0.1"
 
         def build(self):

--- a/reference/generators/json.rst
+++ b/reference/generators/json.rst
@@ -18,7 +18,7 @@ every dependency and the installed settings and options:
         "MY_ENV_VAR": "foo"
       },
       "deps_user_info": {
-        "Hello": {
+        "hello": {
           "my_var": "my_value"
         }
       },
@@ -84,8 +84,8 @@ it is holding a dictionary with the data related to each configuration:
     "...": "...",
     "dependencies": [
         {
-            "name": "Hello",
-            "rootpath": "/private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmpkp9l_dovconans/path with spaces/.conan/data/Hello/0.1/lasote/testing/package/46f53f156846659bf39ad6675fa0ee8156e859fe",
+            "name": "hello",
+            "rootpath": "/private/var/folders/yq/14hmvxm96xd7gfgl37_tnrbh0000gn/T/tmpkp9l_dovconans/path with spaces/.conan/data/hello/0.1/lasote/testing/package/46f53f156846659bf39ad6675fa0ee8156e859fe",
             "...": "...",
             "configs": {
                 "debug": {

--- a/reference/generators/scons.rst
+++ b/reference/generators/scons.rst
@@ -21,7 +21,7 @@ The generated ``SConscript_conan`` will generate several dictionaries, like:
         "LINKFLAGS"   : [],
     },
 
-    "Hello" : {
+    "hello" : {
         "CPPPATH"     : ['/path/to/include'],
         "LIBPATH"     : ['/path/to/lib'],
         "BINPATH"     : ['/path/to/bin'],
@@ -33,7 +33,7 @@ The generated ``SConscript_conan`` will generate several dictionaries, like:
         "LINKFLAGS"   : [],
     },
 
-The ``conan`` dictionary will contain the aggregated values for all dependencies, while the individual ``"Hello"`` dictionaries, one per
+The ``conan`` dictionary will contain the aggregated values for all dependencies, while the individual ``"hello"`` dictionaries, one per
 package, will contain just the values for that specific dependency.
 
 These dictionaries can be directly loaded into the environment like:

--- a/reference/generators/visualstudio.rst
+++ b/reference/generators/visualstudio.rst
@@ -67,7 +67,7 @@ different property sheet will be generated for each configuration. The process c
 
 There are ``ConanVariables`` containing the information of the dependencies. Those variables are used later in the file, like in the ``<Link>`` task.
 
-Note that for single-configuration packages, which is the most typical, conan install Debug/Release, 32/64bits, packages separately. So a different property sheet will be generated for each configuration. The process could be:
+Note that for single-configuration packages, which is the most typical, :command:`conan install` Debug/Release, 32/64bits, packages separately. So a different property sheet will be generated for each configuration. The process could be:
 
 Given for example a ``conanfile.txt`` like:
 
@@ -75,12 +75,12 @@ Given for example a ``conanfile.txt`` like:
    :caption: *conanfile.txt*
 
     [requires]
-    Pkg/0.1@user/channel
+    pkg/0.1@user/channel
 
     [generators]
     visual_studio
 
-And assuming that binary packages exist for ``Pkg/0.1@user/channel``, we could do:
+And assuming that binary packages exist for ``pkg/0.1@user/channel``, we could do:
 
 .. code-block:: bash
 

--- a/reference/generators/visualstudiolegacy.rst
+++ b/reference/generators/visualstudiolegacy.rst
@@ -48,12 +48,12 @@ Given for example a recipe like:
    :caption: *conanfile.txt*
 
     [requires]
-    Pkg/0.1@user/channel
+    pkg/0.1@user/channel
 
     [generators]
     visual_studio_legacy
 
-And assuming that binary packages exist for ``Pkg/0.1@user/channel``, we could do:
+And assuming that binary packages exist for ``pkg/0.1@user/channel``, we could do:
 
 .. code-block:: bash
 

--- a/reference/profiles.rst
+++ b/reference/profiles.rst
@@ -18,9 +18,9 @@ requirements** in a file. They have this structure:
     env_var=value
 
     [build_requires]
-    Tool1/0.1@user/channel
-    Tool2/0.1@user/channel, Tool3/0.1@user/channel
-    *: Tool4/0.1@user/channel
+    tool1/0.1@user/channel
+    tool2/0.1@user/channel, tool3/0.1@user/channel
+    *: tool4/0.1@user/channel
 
 Profile can be created with ``new`` option in :command:`conan profile`. And then edit it later.
 

--- a/uploading_packages/uploading_to_remotes.rst
+++ b/uploading_packages/uploading_to_remotes.rst
@@ -25,11 +25,10 @@ our ``my_local_server`` remote, but you could use any other.
 
 .. code-block:: bash
 
-    $ conan upload Hello/0.1@demo/testing --all -r=my_local_server
+    $ conan upload hello/0.1@demo/testing --all -r=my_local_server
 
 You might be prompted for a username and password. The default Conan server remote has a
 **demo/demo** account we can use for testing.
-
 
 The ``--all`` option will upload the package recipe plus all the binary packages. Omitting the
 ``--all`` option will upload the package recipe *only*. For fine-grained control over which binary
@@ -46,7 +45,7 @@ machine, as it could be running on another server in your LAN:
 
 .. code-block:: bash
 
-    $ conan search Hello/0.1@demo/testing -r=my_local_server
+    $ conan search hello/0.1@demo/testing -r=my_local_server
 
 .. note::
 
@@ -59,7 +58,7 @@ have just uploaded them, they are identical to the local ones.
 
 .. code-block:: bash
 
-    $ conan remove "Hello*"
+    $ conan remove "hello*"
     $ conan search
 
 Since we have our test setup from the previous section, we can just use it for our test. Go to your

--- a/using_packages/using_profiles.rst
+++ b/using_packages/using_profiles.rst
@@ -22,9 +22,9 @@ A profile file contains a predefined set of ``settings``, ``options``, ``environ
     env_var=value
 
     [build_requires]
-    Tool1/0.1@user/channel
-    Tool2/0.1@user/channel, Tool3/0.1@user/channel
-    *: Tool4/0.1@user/channel
+    tool1/0.1@user/channel
+    tool2/0.1@user/channel, tool3/0.1@user/channel
+    *: tool4/0.1@user/channel
 
 Options allow the use of wildcards letting you apply the same option value to many packages. For example:
 

--- a/versioning/introduction.rst
+++ b/versioning/introduction.rst
@@ -43,8 +43,8 @@ When a :command:`conan install` is executed, it will check in the local cache fi
 not in the remotes what ``pkg`` versions are available and will select the latest one
 that satisfies the defined range.
 
-By default, it is less deterministic, one ``conan install`` can resolve to ``pkg/1.1`` and
-then ``pkg/1.2`` is published, and a new ``conan install`` (by users, or CI), will automatically
+By default, it is less deterministic, one :command:`conan install` can resolve to ``pkg/1.1`` and
+then ``pkg/1.2`` is published, and a new :command:`conan install` (by users, or CI), will automatically
 pick the newer 1.2 version, with different results. On the other hand it doesn't require
 changes to consumer recipes to upgrade to use new versions of dependencies.
 
@@ -112,8 +112,8 @@ is fired again, a new package revision can be created. The package revision
 is the hash of the contents of the package (headers, libraries...), so unless
 deterministic builds are achieved, new package revisions will be generated.
 
-In general revisions are not intended to be defined explictly in conanfiles,
-altough they can for specific purposes like debugging.
+In general revisions are not intended to be defined explicitly in conanfiles,
+although they can for specific purposes like debugging.
 
 Read more about :ref:`package_revisions`
 
@@ -125,27 +125,28 @@ When two different branches of the same dependency graph require the same packag
 this is known as "diamonds" in the graph. If the two branches of a diamond require
 the same package but different versions, this is known as a conflict (a version conflict).
 
-Lets say that we are building an executable in **PkgD/1.0**, that depends on **PkgB/1.0** and **PkgC/1.0**,
-which contain static libraries. In turn, **PkgB/1.0** depends on **PkgA/1.0** and finally **PkgC/1.0** depends on
-**PkgA/2.0**, which is also another static library.
+Lets say that we are building an executable in **pkgd/1.0**, that depends on **pkgb/1.0** and **pkgc/1.0**,
+which contain static libraries. In turn, **pkgb/1.0** depends on **pkga/1.0** and finally **pkgc/1.0** depends on
+**pkga/2.0**, which is also another static library.
 
-The executable in **PkgD/1.0**, cannot link with 2 different versions of the same static library in **PkgC**, and the dependency resolution algorithm raises an error to let the
+The executable in **pkgd/1.0**, cannot link with 2 different versions of the same static library in **pkgc**, and the dependency resolution algorithm raises an error to let the
 user decide which one.
 
 .. image:: ../images/conan-graph_conflicts.png
 
-The same situation happens if the different packages require different configurations of the same upstream package, even if the same version is used. In the example above, both **PkgB** and **PkgC** can be requiring the same version **PkgA/1.0**, but one of them will try to use it as a static library and the other one will try to use it as shared library.
+The same situation happens if the different packages require different configurations of the same upstream package, even if the same version is used. In the example above, both **PkgB** and **PkgC** can be requiring the same version **pkga/1.0**, but one of them will try to use it as a static library and the other one will try to use it as shared library.
 The dependency resolution algorithm will also raise an error.
 
 Dependencies overriding
 -----------------------
-The downstream consumer packages always have higher priority, so the versions they request, will be overriden upstream as the dependency graph is built, re-defining the possible requires that the packages could have. For example, **PkgB/1.0** could define in its recipe a dependency to **PkgA/1.0**. But if a downstream consumer defines a requirement to **PkgA/2.0**, then that version will be used in the upstream graph:
+
+The downstream consumer packages always have higher priority, so the versions they request, will be overridden upstream as the dependency graph is built, re-defining the possible requires that the packages could have. For example, **pkgb/1.0** could define in its recipe a dependency to **pkga/1.0**. But if a downstream consumer defines a requirement to **pkga/2.0**, then that version will be used in the upstream graph:
 
 .. image:: ../images/conan-graph_override.png
 
-This is what enables the users to have control. Even when a package recipe upstream defines an older version, the downstream consumers can force to use an updated version. Note that this is not a diamond structure in the graph, so it is not a conflict by default. This behavior can be also restricted defining the :ref:`env_vars_conan_error_on_override` environment variable to raise an error when these overrides happen, and then the user can go and explicitly modify the upstream **PkgB/1.0** recipe to match the version of PkgA and avoid the override.
+This is what enables the users to have control. Even when a package recipe upstream defines an older version, the downstream consumers can force to use an updated version. Note that this is not a diamond structure in the graph, so it is not a conflict by default. This behavior can be also restricted defining the :ref:`env_vars_conan_error_on_override` environment variable to raise an error when these overrides happen, and then the user can go and explicitly modify the upstream **pkgb/1.0** recipe to match the version of PkgA and avoid the override.
 
-In some scenarios, the downstream consumer **PkgD/1.0** might not want to force a dependency on PkgA. There are several possibilities, for example that PkgA is a conditional requirement that only happens in some operating systems. If PkgD defines a normal requirement to PkgA, then, it will be introducing that edge in the graph, forcing PkgA to be used always, in all operating systems. For this purpose the ``override`` qualifier can be defined in requirement, see :ref:`method_requirements`.
+In some scenarios, the downstream consumer **pkgd/1.0** might not want to force a dependency on ``pkga``. There are several possibilities, for example that PkgA is a conditional requirement that only happens in some operating systems. If ``pkgd`` defines a normal requirement to ``pkga``, then, it will be introducing that edge in the graph, forcing pkga to be used always, in all operating systems. For this purpose the ``override`` qualifier can be defined in requirement, see :ref:`method_requirements`.
 
 
 Versioning and binary compatibility
@@ -154,5 +155,5 @@ Versioning and binary compatibility
 It is important to note and this point that versioning approaches and strategies should also be
 consistent with the binary management.
 
-By default conan assumes *semver* compatibility, so it will not require to build a new binary for a package when its dependencies change their minor or patch versions. This might not be enough for C or C++ libraries which versioning scheme doesn't strictly follow semver. It is strongly suggested to read more about this in :ref:`define_abi_compatibility`
+By default, Conan assumes *semver* compatibility, so it will not require to build a new binary for a package when its dependencies change their minor or patch versions. This might not be enough for C or C++ libraries which versioning scheme doesn't strictly follow semver. It is strongly suggested to read more about this in :ref:`define_abi_compatibility`
 

--- a/versioning/lockfiles.rst
+++ b/versioning/lockfiles.rst
@@ -7,7 +7,6 @@ Lockfiles
 
     This is an **experimental** feature subject to breaking changes in future releases.
 
-
 Lockfiles are files that store the information of a dependency graph, including the
 exact versions, revisions, options, and configuration of that dependency graph. As 
 they depend on the configuration, and the dependency graph can change with every 
@@ -17,15 +16,15 @@ Lockfiles are useful for achieving deterministic builds, even if the dependency
 definitions in conanfile recipes are not fully deterministic, for example when using
 version ranges or using package revisions.
 
-Let's say we have 3 package recipes PkgC, PkgB, and PkgA, that define this dependency graph:
+Let's say we have 3 package recipes ``pkgc``, ``pkgb``, and ``pkga``, that define this dependency graph:
 
 .. image:: ../images/conan-graph_not_deterministic.png
 
 The first time, when a :command:`conan install .` is executed, the requirement defined
-in PkgB is resolved to **PkgA/1.0**, because that was the latest at that time that
-satisfied the version range ``PkgA/[*]``. After such install, the user can build and 
-run an application in the source code of PkgC. But some time later, another colleague
-tries to do exactly the same, and suddenly it is pulling a newer version of PkgA that
+in ``pkgb`` is resolved to **pkga/1.0**, because that was the latest at that time that
+satisfied the version range ``pkga/[*]``. After such install, the user can build and 
+run an application in the source code of ``pkgc``. But some time later, another colleague
+tries to do exactly the same, and suddenly it is pulling a newer version of ``pkga`` that
 was recently published, getting different results (maybe even not working). Builds with
 version ranges are not reproducible by default.
 
@@ -44,7 +43,7 @@ used later:
 
 The second time that :command:`conan install . --lockfile` is called, with the lockfile argument
 it will load the previously generated *conan.lock* file, that contains the information that
-**PkgA/1.0** is used, and will apply it again to the dependency resolution, resolving exactly
+``pkga/1.0`` is used, and will apply it again to the dependency resolution, resolving exactly
 the same dependency graph:
 
 .. image:: ../images/conan-graph_locked.png
@@ -76,7 +75,6 @@ following if we wanted to work with different configurations (e.g. Debug/Release
     $ conan install .. --lockfile # uses the existing conan.lock (debug)
     $ cd ../release
     $ conan install .. --lockfile # uses the existing conan.lock (release)
-
 
 Commands
 --------
@@ -123,9 +121,7 @@ There are 2 main entry points for lockfile information in conan commands:
         in the graph have to be built. It only returns those packages that really need to be built,
         following the :command:`--build` arguments and the ``package_id()`` rules.
 
-
 For more information see :ref:`commands`
-
 
 How to use lockfiles in CI
 --------------------------
@@ -141,13 +137,12 @@ How to use lockfiles in CI
         $ cd features/lockfiles/ci
         $ python build.py 
 
-
 One of the applications of lockfiles is to be able to propagate changes in one package
 belonging to a dependency graph downstream its affected consumers.
 
-Lets say that we have the following project in which packages PkgA, PkgB, PkgC, PkgZ and App
+Lets say that we have the following project in which packages ``pkga``, ``pkgb``, ``pkgc``, ``pkgz`` and ``app``
 have already been created and only one version of each, the version 0.1 exists. All packages
-are using version ranges with a range like ``PkgZ/[>0.0]``, so basically they will resolve to
+are using version ranges with a range like ``pkgz/[>0.0]``, so basically they will resolve to
 any new version of their dependencies that it is published.
 
 Also, the ``full_version_mode`` will be defined for dependencies. This means that if the version
@@ -168,7 +163,7 @@ The process starts generating a *conan.lock* lockfile in the *release* subfolder
 
 .. code-block:: bash
 
-    $ conan graph lock App/0.1@user/testing --lockfile=release
+    $ conan graph lock app/0.1@user/testing --lockfile=release
 
 This lockfile will contain the resolved dependencies in the graph, as we only have one version
 0.1 for all the packages, all of them will be locked to that 0.1 version.
@@ -178,20 +173,20 @@ This lockfile will contain the resolved dependencies in the graph, as we only ha
 
 
 Once the lockfile has been generated, it doesn't matter if new, unrelated versions of other
-packages, like **PkgZ/0.2** is created with ``cd PkgZ && conan create . PkgZ/0.2@user/testing``
+packages, like **pkgz/0.2** is created with ``cd pkgz && conan create . pkgz/0.2@user/testing``
 
-Now we can safely create the new version of **PkgA/0.2**, that will resolve to use **PkgZ/0.1**
+Now we can safely create the new version of **pkga/0.2**, that will resolve to use **pkgz/0.1**
 instead of the latest 0.2, if we use the lockfile:
 
 .. code-block:: bash
 
-    cd PkgA && conan create . PkgA/0.2@user/testing --lockfile=../release
-    # lockfile in release/conan.lock is modified to contain PkgA/0.2
+    cd pkga && conan create . pkga/0.2@user/testing --lockfile=../release
+    # lockfile in release/conan.lock is modified to contain pkga/0.2
 
-Note that the lockfile is modified, to contain the new **PkgA/0.2** version.
+Note that the lockfile is modified, to contain the new **pkga/0.2** version.
 
-The next step is to know which dependants need to be built because they are affected by the new
-**PkgA/0.2** version:
+The next step is to know which dependents need to be built because they are affected by the new
+**pkga/0.2** version:
 
 .. code-block:: bash
 
@@ -201,7 +196,7 @@ The next step is to know which dependants need to be built because they are affe
 This command will return a list of lists, in order, of those packages to be built. It will be
 stored in a *bo.json* json file too. Note that the ``--build=missing`` follows the same rules
 as :command:`create` and :command:`install` commands. The result of evaluating the graph with
-the **PkgA/0.2** version, due to the ``full_version_mode`` policy is that new binaries for
+the **pkga/0.2** version, due to the ``full_version_mode`` policy is that new binaries for
 PkgB, PkgC and App are necessary, and they do not exist yet. If we don't provide the ``--build=missing``
 it will return an empty list (but it will fail later, because binary packages are not available).
 
@@ -281,8 +276,6 @@ With package revisions it is also possible to achieve the same flow without bump
 - It is necessary to define the ``recipe_revision_mode`` or the ``package_revision_mode`` if we want to guarantee that the binaries correctly model the dependencies changes.
 
 For implementing this flow, it might be necessary to share the different ``conan.lock`` lockfiles among different machines, to pass them to build servers. A git repo could be used, but also an Artifactory generic repository could be very convenient for this purpose.
-
-
 
 .. note::
 


### PR DESCRIPTION
In order to avoid problems with case-sensitive OSs, we can start using only lowercase references in our documentation and examples in order to void them.

Still, we are not enforcing lowercase usage in Conan, but this could be a good de-facto practice in our documentation to start teaching the users,