### PR TITLE
Including in the example of travis-ci the caching

### DIFF
--- a/integrations/ci/travisci.rst
+++ b/integrations/ci/travisci.rst
@@ -30,6 +30,10 @@ To enable **Travis CI** support, you need to create a *.travis.yml* file and pas
     dist: xenial
     compiler:
       - gcc
+    cache:
+      pip: true
+      directories:
+        - $HOME/.conan
     install:
     # Install conan
       - pip install conan


### PR DESCRIPTION
Hello Everyone,
    
I know it is not necessary for building a project to have a cache of the dependencies in travis, but I would suggest to include it.

I am suggesting that mainly for 2 reasons:
- Usually the build speed is improved in subsequent builds.
- It reduces the load both in the conan center servers and possible in the servers that have source code for project (e.g. https://github.com/boostorg/boost/issues/299). CI probably is one of the reasons for these loads. If a library needs to be rebuild (because of different flags), this usually has to be done once and caching the builds is sufficient.
    
When I am going through the documentation and find an example, usually I just copy-paste the example and later adjust it to fit my purposes. Not to generalize too much, probably most programmers do the same :) By including in this basic example the cache, then we nudge the new users to follow the same path.
    
What do you think?
    
Kind regards,
Vasileios
