### PR TITLE
Set Travis Timeout to 20 min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ cache:
 install:
   - pip install -r requirements.txt
 script:
-  - python deploy_gh_pages.py
+  - travis_wait python deploy_gh_pages.py


### PR DESCRIPTION
The last deploy failed due Timeout. It's possible to update the output timeout:

https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

/cc @czoido @danimtb 