### PR TITLE
Fixing typo for cmake_find_package generator example

### DIFF
--- a/integrations/build_system/cmake/cmake_find_package_generator.rst
+++ b/integrations/build_system/cmake/cmake_find_package_generator.rst
@@ -20,7 +20,7 @@ In a conanfile.py
    :caption: conanfile.py
    :emphasize-lines: 7
 
-   from conans import ConanFile, tools
+   from conans import ConanFile, CMake, tools
 
 
    class LibConan(ConanFile):


### PR DESCRIPTION
There is a typo in the example code where the `build()` method contains a `CMake` object instantiation without the module being imported appropriately in the beginning of the example.