### PR TITLE
Add 404 page for gh-pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=https://docs.conan.io/en/latest/404">
+        <script type="text/javascript">
+            window.location.href = "https://docs.conan.io/en/latest/404"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow this <a href='https://docs.conan.io/en/latest'>link to https://docs.conan.io/en/latest</a>.
+    </body>
+</html>


### PR DESCRIPTION
After trying some experiments, I just realized the redirection problem is related to Github pages, not sphinx.

The github documentation says to add a 404.html file for a custom "Not Found Page": https://help.github.com/en/enterprise/2.13/user/articles/creating-a-custom-404-page-for-your-github-pages-site

Thus, this new 404.html in this PR will redirect to https://docs.conan.io/en/latest/404, which is our custom page.

/cc @memsharded 