### PR TITLE
Document order of execution of 'set_name' and 'set_name' regarding CLI

### DIFF
--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -394,13 +394,16 @@ Dynamically define ``name`` and ``version`` attributes in the recipe with these 
 defines the package name reading it from a *name.txt* file and the version from the branch and commit of the
 recipe's repository.
 
+These functions are executed after assigning the values of the ``name`` and ``version`` from the command line.
+
 ..  code-block:: python
 
     from conans import ConanFile, tools
 
     class HelloConan(ConanFile):
         def set_name(self):
-            self.name = tools.load("name.txt")
+            # Read the value from 'name.txt' if it is not provided in the command line
+            self.name = self.name or tools.load("name.txt")
 
         def set_version(self):
             git = tools.Git()

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -394,7 +394,8 @@ Dynamically define ``name`` and ``version`` attributes in the recipe with these 
 defines the package name reading it from a *name.txt* file and the version from the branch and commit of the
 recipe's repository.
 
-These functions are executed after assigning the values of the ``name`` and ``version`` from the command line.
+These functions are executed after assigning the values of the ``name`` and ``version`` if they are provided 
+from the command line.
 
 ..  code-block:: python
 


### PR DESCRIPTION
PR https://github.com/conan-io/conan/pull/6940 changes the order of execution of `set_name/version` and the assignment of these values from the command line. Some users rely on this behavior, we should document it.

If merged, we should update the comment for `Docs` in the PR.