### PR TITLE
Add some experimental warnings to the xbuild feature

### DIFF
--- a/devtools/build_requires.rst
+++ b/devtools/build_requires.rst
@@ -81,6 +81,12 @@ profile, it will overwrite the build requirements defined in package recipes tha
 Build and Host contexts
 -----------------------
 
+.. warning::
+
+    This section refers to the **experimental feature** that is activated when using ``--profile:build`` and ``--profile:host``
+    in the command-line. It is currently under development, features can be added or removed in the following versions.
+
+
 Conan v1.24 differentiates between the ``build`` context and the ``host`` context in the dependency graph (read more about
 the meaning of ``host`` and ``build`` platforms in the :ref:`cross building <cross_building>` section) **when the user
 supplies two profiles** to the command line using the ``--profile:build`` and ``--profile:host`` arguments:

--- a/devtools/create_installer_packages.rst
+++ b/devtools/create_installer_packages.rst
@@ -82,6 +82,12 @@ This two simple declarations are enough to reuse this tool in the scenarios we a
 Using the tool packages in other recipes
 ----------------------------------------
 
+.. warning::
+
+    This section refers to the **experimental feature** that is activated when using ``--profile:build`` and ``--profile:host``
+    in the command-line. It is currently under development, features can be added or removed in the following versions.
+
+
 These kind of tools are not usually part of the application graph itself, they are needed only to build the library, so
 you should usually declare them as :ref:`build requirements <build_requires>`, in the recipe itself or in a profile.
 

--- a/reference/profiles.rst
+++ b/reference/profiles.rst
@@ -234,6 +234,11 @@ variables will be available:
 Build profiles and host profiles
 --------------------------------
 
+.. warning::
+
+    This is an **experimental feature** subject to breaking changes in future releases.
+
+
 All the commands that take a profile as an argument, from Conan v1.24 are starting to accept two profiles with
 command line arguments ``-pr:h``/``--profile:host`` and ``-pr:b``/``--profile:build``. If both profiles are
 provided, Conan will build a graph with some packages associated with the ``host`` platform and some build

--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -130,6 +130,12 @@ You can find working examples at the :ref:`bottom of this section <cross_buildin
 Using build requires
 ++++++++++++++++++++
 
+.. warning::
+
+    This section refers to the **experimental feature** that is activated when using ``--profile:build`` and ``--profile:host``
+    in the command-line. It is currently under development, features can be added or removed in the following versions.
+
+
 Instead of manually downloading the toolchain and creating a profile, you can create a Conan package
 with it. Starting with Conan v1.24 and the command line arguments ``--profile:host`` and ``--profile:build``
 this should be a regular recipe, for older versions some more work is needed.


### PR DESCRIPTION
The feature is working great, we are not planning to remove or change anything about it, but we need to warn people that new functionalities are features/fixes and not bugs that we can solve right away. We need to evaluate the requirements before adding new functionality.