### PR TITLE
Fix exception in capture package version example

### DIFF
--- a/howtos/capture_version.rst
+++ b/howtos/capture_version.rst
@@ -102,5 +102,5 @@ You can extract the version dynamically using:
         name = "hello"
         def set_version(self):
             content = load(os.path.join(self.recipe_folder, "CMakeLists.txt"))
-            version = re.search(b"set\(MY_LIBRARY_VERSION (.*)\)", content).group(1)
+            version = re.search(r"set\(MY_LIBRARY_VERSION (.*)\)", content).group(1)
             self.version = version.strip()


### PR DESCRIPTION
The example to capture the package version from a CMakeLists.txt contains a wrong string suffix.
Executing the example will result in `TypeError: cannot use a bytes pattern on a string-like object`.
Replace with 'r' prefix.