### PR TITLE
Remove experimental warning

### DIFF
--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -101,8 +101,9 @@ Capturing the Remote and Commit: ``scm``
 
 .. warning::
 
-    Depending on the use, this feature may be considered **experimental** and subject to breaking
-    changes in future releases. See :ref:`note <scm_to_conandata_note>` below.
+    This is an **experimental** feature subject to breaking changes in future releases. Depending on
+    the use, this is feature may be considered **experimental**. See :ref:`note
+    <scm_to_conandata_note>` below.
 
 You can use the :ref:`scm attribute <scm_attribute>` with the ``url`` and ``revision`` field set to ``auto``.
 When you export the recipe (or when :command:`conan create` is called) the exported recipe will capture the

--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -101,9 +101,9 @@ Capturing the Remote and Commit: ``scm``
 
 .. warning::
 
-    This is an **experimental** feature subject to breaking changes in future releases. Depending on
-    the use, this is feature may be considered **experimental**. See :ref:`note
-    <scm_to_conandata_note>` below.
+    This is an **experimental** feature subject to breaking changes in future releases. Although this
+    is an experimental feature, the use of the feature using ``scm_to_conandata`` is considered
+    stable.
 
 You can use the :ref:`scm attribute <scm_attribute>` with the ``url`` and ``revision`` field set to ``auto``.
 When you export the recipe (or when :command:`conan create` is called) the exported recipe will capture the
@@ -160,12 +160,6 @@ Whichever option you choose, the data resolved will be asigned by Conan to the c
 file is loaded, and they will be available for all the methods defined in the recipe. Also, if building the package
 from sources, Conan will fetch the code in the captured url/commit before running the method ``source()`` in the
 recipe (if defined).
-
-.. _scm_to_conandata_note:
-.. note::
-
-    Although this is an experimental feature, the use of the feature using ``scm_to_conandata`` is
-    considered stable.
 
 As SCM attributes are evaluated in the local directory context (see :ref:`scm attribute <scm_attribute>`),
 you can write more complex functions to retrieve the proper values, this source *conanfile.py* will

--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -101,7 +101,7 @@ Capturing the Remote and Commit: ``scm``
 
 .. warning::
 
-    Depending on the use, this is feature may be considered **experimental** and subject to breaking
+    Depending on the use, this feature may be considered **experimental** and subject to breaking
     changes in future releases. See :ref:`note <scm_to_conandata_note>` below.
 
 You can use the :ref:`scm attribute <scm_attribute>` with the ``url`` and ``revision`` field set to ``auto``.

--- a/creating_packages/package_repo.rst
+++ b/creating_packages/package_repo.rst
@@ -101,7 +101,8 @@ Capturing the Remote and Commit: ``scm``
 
 .. warning::
 
-    This is an **experimental** feature subject to breaking changes in future releases.
+    Depending on the use, this is feature may be considered **experimental** and subject to breaking
+    changes in future releases. See :ref:`note <scm_to_conandata_note>` below.
 
 You can use the :ref:`scm attribute <scm_attribute>` with the ``url`` and ``revision`` field set to ``auto``.
 When you export the recipe (or when :command:`conan create` is called) the exported recipe will capture the
@@ -158,6 +159,12 @@ Whichever option you choose, the data resolved will be asigned by Conan to the c
 file is loaded, and they will be available for all the methods defined in the recipe. Also, if building the package
 from sources, Conan will fetch the code in the captured url/commit before running the method ``source()`` in the
 recipe (if defined).
+
+.. _scm_to_conandata_note:
+.. note::
+
+    Although this is an experimental feature, the use of the feature using ``scm_to_conandata`` is
+    considered stable.
 
 As SCM attributes are evaluated in the local directory context (see :ref:`scm attribute <scm_attribute>`),
 you can write more complex functions to retrieve the proper values, this source *conanfile.py* will

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -1257,7 +1257,8 @@ scm
 
 .. warning::
 
-    This is an **experimental** feature subject to breaking changes in future releases.
+    Depending on the use, this is feature may be considered **experimental** and subject to breaking
+    changes in future releases. See :ref:`note <scm_to_conandata_note>` below.
 
 Used to clone/checkout a repository. It is a dictionary with the following possible values:
 
@@ -1307,6 +1308,12 @@ from a :ref:`python_requires <python_requires>` package.
     However, you can activate the :ref:`scm_to_conandata<conan_conf>` config option, the *conanfile.py*
     won't be modified (data is stored in a different file) and the fields ``username`` and ``password`` won't be
     stored, so these one will be computed each time the recipe is loaded.
+
+.. _scm_to_conandata_note:
+.. note::
+
+    Although this is an experimental feature, the use of the feature using ``scm_to_conandata`` is
+    considered stable.
 
 .. note::
 

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -1257,8 +1257,9 @@ scm
 
 .. warning::
 
-    Depending on the use, this is feature may be considered **experimental** and subject to breaking
-    changes in future releases. See :ref:`note <scm_to_conandata_note>` below.
+    This is an **experimental** feature subject to breaking changes in future releases. Depending on
+    the use, this is feature may be considered **experimental**. See :ref:`note
+    <scm_to_conandata_note>` below.
 
 Used to clone/checkout a repository. It is a dictionary with the following possible values:
 

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -1257,9 +1257,9 @@ scm
 
 .. warning::
 
-    This is an **experimental** feature subject to breaking changes in future releases. Depending on
-    the use, this is feature may be considered **experimental**. See :ref:`note
-    <scm_to_conandata_note>` below.
+    This is an **experimental** feature subject to breaking changes in future releases. Although this
+    is an experimental feature, the use of the feature using ``scm_to_conandata`` is considered
+    stable.
 
 Used to clone/checkout a repository. It is a dictionary with the following possible values:
 
@@ -1309,12 +1309,6 @@ from a :ref:`python_requires <python_requires>` package.
     However, you can activate the :ref:`scm_to_conandata<conan_conf>` config option, the *conanfile.py*
     won't be modified (data is stored in a different file) and the fields ``username`` and ``password`` won't be
     stored, so these one will be computed each time the recipe is loaded.
-
-.. _scm_to_conandata_note:
-.. note::
-
-    Although this is an experimental feature, the use of the feature using ``scm_to_conandata`` is
-    considered stable.
 
 .. note::
 

--- a/versioning/revisions.rst
+++ b/versioning/revisions.rst
@@ -3,10 +3,6 @@
 Package Revisions
 =================
 
-.. warning::
-
-    This is an **experimental** feature subject to breaking changes in future releases.
-
 The goal of the revisions feature is to achieve package immutability, the packages in a server are never overwritten.
 
 .. note::


### PR DESCRIPTION
This PR removes from experimental two conan features:

- Revisions
- The use of scm mode but only when used with `scm_to_conandata`