### PR TITLE
Add warnings for BuildInfo

### DIFF
--- a/howtos/generic_ci_artifactory.rst
+++ b/howtos/generic_ci_artifactory.rst
@@ -3,6 +3,16 @@
 Use a generic CI with Conan and Artifactory
 ===========================================
 
+.. warning::
+
+    Some problems regarding the use of BuildInfo with Conan packages `have been reported
+    <https://www.jfrog.com/jira/browse/RTFACT-9343>`_. If the BuildInfo contains artifacts that have
+    the same checksum as other artifacts, this may result in losing the path of the artifact in the
+    BuildInfo in Artifactory and also fail in the promotion process. 
+
+    We are currently working along with the Artifactory team to solve those problems. Until this
+    issue gets fixed, we do not recommend using BuildInfo's for Conan.
+
 Uploading the BuildInfo
 -----------------------
 

--- a/reference/commands/misc/conan_build_info.rst
+++ b/reference/commands/misc/conan_build_info.rst
@@ -1,6 +1,20 @@
 
 .. _conan_build_info:
 
+.. warning::
+
+    This is an **experimental** feature subject to breaking changes in future releases.
+
+.. warning::
+
+    Some problems regarding the use of BuildInfo with Conan packages `have been reported
+    <https://www.jfrog.com/jira/browse/RTFACT-9343>`_. If the BuildInfo contains artifacts that have
+    the same checksum as other artifacts, this may result in losing the path of the artifact in the
+    BuildInfo in Artifactory and also fail in the promotion process. 
+
+    We are currently working along with the Artifactory team to solve those problems. Until this
+    issue gets fixed, we do not recommend using BuildInfo's for Conan.
+
 conan_build_info v1
 -------------------
 


### PR DESCRIPTION
Do not recommend the use of the BuildInfo until problems are solved.