### PR TITLE
update Make generator reference with rpath and new globals, CONAN_BASIC_SETUP 

### DIFF
--- a/_themes/conan/layout.html
+++ b/_themes/conan/layout.html
@@ -158,7 +158,7 @@
           {% include "breadcrumbs.html" %}
           <!--<select id="search" name="state" multiple="true" onchange="window.location = reldir + this.value;" style="width:90%"></select>
           <hr/>-->
-          <div class="admonition important"> Join the <a href=https://blog.conan.io/2020/07/28/Launching-Conan-2.0-Tribe.html>Conan 2.0 Tribe</a> and contribute to define the next Conan 2.0 major version</div>
+          <!--<div class="admonition important"> Join the <a href=https://blog.conan.io/2020/07/28/Launching-Conan-2.0-Tribe.html>Conan 2.0 Tribe</a> and contribute to define the next Conan 2.0 major version</div>-->
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
             {% block body %}{% endblock %}

--- a/reference/generators/make.rst
+++ b/reference/generators/make.rst
@@ -95,7 +95,7 @@ of 5 **global variables** by prepending the associated compiler or linker flags
 and then combining them together. The 5 variables correspond to 5 standard GnuMake variables: 
 
 `Gnu Make Well-Known Variables
-<https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html/>`__
+<https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html>`_
 
 
 +-------------------------+--------------------------------------------------------------------------------------------+

--- a/reference/generators/make.rst
+++ b/reference/generators/make.rst
@@ -95,7 +95,7 @@ of 5 **global variables** by prepending the associated compiler or linker flags
 and then combining them together. The 5 variables correspond to 5 standard GnuMake variables: 
 
 `Gnu Make Well-Known Variables
-<https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html/>`_
+<https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html/>`__
 
 
 +-------------------------+--------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Also, removed examples of compiler flags because all those listed should be handled by the `MakeToolchain` moving forward. 

Also removed mention of aggregate `ROOTPATH` and `SYSROOT`. Those are invalid and not created. 

Removed outdated guidance for mapping `CONAN_` variables to standard ones because it was actually a bit misleading, and the new globals and functions make the relationships obvious.