### PR TITLE
Add Xcode 12

### DIFF
--- a/reference/config_files/settings.yml.rst
+++ b/reference/config_files/settings.yml.rst
@@ -82,7 +82,7 @@ are possible. These are the **default** values, but it is possible to customize 
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
             runtime: [None, MD, MT, MTd, MDd]
         apple-clang: &apple_clang
-            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
+            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0"]
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         intel:

--- a/reference/config_files/settings.yml.rst
+++ b/reference/config_files/settings.yml.rst
@@ -30,7 +30,7 @@ are possible. These are the **default** values, but it is possible to customize 
             version: ["5.0", "6.0", "7.0", "8.0"]
         Linux:
         Macos:
-            version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15"]
+            version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15", "11.0"]
         Android:
             api_level: ANY
         iOS:


### PR DESCRIPTION
Corresponding docs PR to conan-io/conan#7601.

Updates the `settings.yml` page to include Xcode 12 as a supported compiler.