### PR TITLE
Add metadata for CLion plugin

### DIFF
--- a/integrations/ide/clion.rst
+++ b/integrations/ide/clion.rst
@@ -1,14 +1,17 @@
 .. _clion:
 
-|clion_logo| CLion Plugin
-_________________________
+.. meta::
+   :title: CLion Plugin
+   :description: An official Jetbrains Conan plugin for CLion. CLion uses CMake as the build system of projects, so you can use the CMake generator to manage your requirements.
+   :keywords: clion, conan, plugin, ide, jetbrains
 
-An official Jetbrains Conan plugin for CLion. CLion uses CMake as the build system of projects, so you can use the CMake generator to manage your requirements.
-
-|clion_plugin|
+|clion_logo| CLion
+__________________
 
 There is an `official Jetbrains plugin <https://plugins.jetbrains.com/plugin/11956-conan>`_ Conan
 plugin for CLion.
+
+|clion_plugin|
 
 You can read how to use it in the following `blog post <https://blog.jetbrains.com/clion/2019/05/getting-started-with-the-conan-clion-plugin/>`_
 


### PR DESCRIPTION
First PR was not totally clear according @BraverO suggestion.

This one uses HTML metadata only for CLion Plugin and its description.

The HTML pages doesn't show the metadata content, it is only displayed when reading the HTML source.

/cc @BraverO

Current result:

![Untitled](https://user-images.githubusercontent.com/4870173/93930104-35e9f900-fcf3-11ea-9357-254e9ccc7b8a.png)
