### PR TITLE
Update custom.rst

### DIFF
--- a/reference/generators/custom.rst
+++ b/reference/generators/custom.rst
@@ -52,7 +52,7 @@ filenames and contents in the ``content`` property, like this:
             pass
     
     class MyCustomGeneratorPackage(ConanFile):
-        name = "MultiGeneratorPkg"
+        name = "multi_generator_package"
         version = "0.1"
         url = "https://github.com/..."
         license = "MIT"


### PR DESCRIPTION
docs probably should not encourage upper-case package names with examples