### PR TITLE
Add prefix url for 404

### DIFF
--- a/deploy_gh_pages.py
+++ b/deploy_gh_pages.py
@@ -97,15 +97,16 @@ def should_deploy():
 
 def update_404_html(filepath, folder_name):
     content = None
+    prefix = "https://docs.conan.io/{}".format(folder_name)
     with open(filepath, "r") as fd:
         content = fd.read()
-    content = content.replace('href="_', 'href="{}/_'.format(folder_name))
-    content = content.replace('src="_', 'src="{}/_'.format(folder_name))
-    content = content.replace('alt="_', 'alt="{}/_'.format(folder_name))
-    content = content.replace('alt="_', 'alt="{}/_'.format(folder_name))
-    content = content.replace('internal" href="', 'internal" href="{}/'.format(folder_name))
-    content = content.replace('"search.html"', '"{}/search.html"'.format(folder_name))
-    content = content.replace('"genindex.html"', '"{}/genindex.html"'.format(folder_name))
+    content = content.replace('href="_', 'href="{}/_'.format(prefix))
+    content = content.replace('src="_', 'src="{}/_'.format(prefix))
+    content = content.replace('alt="_', 'alt="{}/_'.format(prefix))
+    content = content.replace('alt="_', 'alt="{}/_'.format(prefix))
+    content = content.replace('internal" href="', 'internal" href="{}/'.format(prefix))
+    content = content.replace('"search.html"', '"{}/search.html"'.format(prefix))
+    content = content.replace('"genindex.html"', '"{}/genindex.html"'.format(prefix))
     with open(filepath, "w") as fd:
         fd.write(content)
 


### PR DESCRIPTION
I hope this should be our last fix ...

So far, the URL https://docs.conan.io/foobar works well, 404 intercepts the bad address and shows https://docs.conan.io/404.html instead.

However, it doesn't work for https://docs.conan.io/en/latest/foobar, but why? All references in 404.html points to en/latest/404.html, including theme folder, thus the result is the current url + the url in 404.html = https://docs.conan.io/en/latest/en/latest/404.html (same for theme)

As I can't reproduce it locally, because requires some configuration for redirection, so I uploaded to my personal github pages: https://uilianries.github.io/en/latest/dasdadasd. As you can see, now it works.

As 404.html is an unique file, I forced to en/latest, so it points now to the absolute URL for docs.conan.io instead of appending the current URL + href.
