### PR TITLE
Fix release/1.5.2

### DIFF
--- a/conan1.0.rst
+++ b/conan1.0.rst
@@ -85,7 +85,7 @@ New features
 .. important::
 
     **Do not** use cross-build settings ``os_build`` and ``arch_build`` for standard packages and libraries.
-  They are only useful for packages that are used via ``build_requires``, like ``cmake_installer`` or ``mingw_installer``.
+    They are only useful for packages that are used via ``build_requires``, like ``cmake_installer`` or ``mingw_installer``.
 
 
 - Model and utilities for Windows subsystems

--- a/conf.py
+++ b/conf.py
@@ -398,7 +398,9 @@ def copy_legacy_redirects(app, docname): # Sphinx expects two arguments
     if app.builder.name == 'html':
         for html_src_path, dst_path in redirect_files.items():
             target_path = app.outdir + '/' + html_src_path
-            html = redirect_template % dst_path      
+            html = redirect_template % dst_path
+            if not os.path.exists(os.path.dirname(target_path)):
+                os.makedirs(os.path.dirname(target_path))
             with open(target_path, "w") as f:
                 f.write(html)
 


### PR DESCRIPTION
Two minor fixes to release:
 * An indent typo in the format.
 * Problem in `conf.py` file, fails if building out of sources.