### PR TITLE
Add documentation for CONAN_INTEL_INSTALLATION_PATH,

### DIFF
--- a/reference/env_vars.rst
+++ b/reference/env_vars.rst
@@ -708,3 +708,13 @@ CONAN_KEEP_PYTHON_FILES
 
 This environment variable will allow Python *.pyc* files to be packaged. If not set as ``True``/``1``,
 all the generated *.pyc* files will be filtered when packaging.
+
+.. _env_vars_conan_intel_installation_path:
+
+CONAN_INTEL_INSTALLATION_PATH
+--------------------------------
+
+**Defaulted to**: Not defined
+
+If this environment variable is set, Conan will use this path for the Intel compiler installation 
+instead of trying to find it at default locations.

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1879,7 +1879,7 @@ The values of the variables ``INCLUDE``, ``LIB``, ``LIBPATH`` and ``PATH`` will 
     from conans import tools
 
     def build(self):
-        env_vars = tools.intel_compilervars_dict(self.settings)
+        env_vars = tools.intel_compilervars_dict(self)
         with tools.environment_append(env_vars):
             # Do something
 
@@ -1911,7 +1911,7 @@ This is a context manager that allows to append to the environment all the varia
     from conans import tools
 
     def build(self):
-        with tools.intel_compilervars(self.settings):
+        with tools.intel_compilervars(self):
             do_something()
 
 .. tools_intel_installation_path:
@@ -1928,7 +1928,7 @@ tools.intel_installation_path()
     def intel_installation_path(version, arch)
 
 Returns the Intel Compiler installation path for the given version and target arch. If the tool is not able to return the path it will raise a
-``ConanException``.
+``ConanException``. Will return the value of the the environment variable :ref:`env_vars_conan_intel_installation_path` if set.
 
 .. code-block:: python
 


### PR DESCRIPTION
fixes two example snippets.