### PR TITLE
Fix conanfile.py in make.rst

### DIFF
--- a/integrations/build_system/make.rst
+++ b/integrations/build_system/make.rst
@@ -93,7 +93,7 @@ workflow.
         exports_sources = "*"
 
         def generate(self):
-            tc = Make(self)
+            tc = MakeToolchain(self)
             tc.generate()
 
         def build(self):


### PR DESCRIPTION
There is no "Make" in scope, this is also consistent with docs/creating_packages/toolchains/make.rst.