### PR TITLE
Remove conan community from docs

### DIFF
--- a/devtools/create_installer_packages.rst
+++ b/devtools/create_installer_packages.rst
@@ -4,7 +4,7 @@ Creating conan packages to install dev tools
 ============================================
 
 One of the most useful features of Conan is to package executables like compilers or build tools and
-distribute them in a controlled way to the team of developers. This way Conan helps not only with the 
+distribute them in a controlled way to the team of developers. This way Conan helps not only with the
 graph of dependencies of the application itself, but also with all the ecosystem needed to generate the
 project, making it really easy to control everything involved in the deployed application.
 
@@ -38,7 +38,7 @@ the ``nasm`` tool for building assembler:
        name = "nasm"
        version = "2.13.02"
        license = "BSD-2-Clause"
-       url = "https://github.com/conan-community/conan-nasm-installer"
+       url = "https://github.com/conan-io/conan-center-index"
        settings = "os", "arch"
        description="Nasm for windows. Useful as a build_require."
 
@@ -91,9 +91,9 @@ Using the tool packages in other recipes
 These kind of tools are not usually part of the application graph itself, they are needed only to build the library, so
 you should usually declare them as :ref:`build requirements <build_requires>`, in the recipe itself or in a profile.
 
-For example, there are many recipes that can take advantage of the ``nasm`` package we've seen above, like 
+For example, there are many recipes that can take advantage of the ``nasm`` package we've seen above, like
 `flac <https://conan.io/center/flac?tab=recipe>`_ or `libx264 <https://conan.io/center/libx264?tab=recipe>`_
-that are already available in `ConanCenter <https://conan.io/center/>`_. Those recipes will take advantage of ``nasm`` 
+that are already available in `ConanCenter <https://conan.io/center/>`_. Those recipes will take advantage of ``nasm``
 being in the PATH to run some assembly optimizations.
 
 
@@ -107,7 +107,7 @@ being in the PATH to run some assembly optimizations.
 
         def build(self):
             ... # ``nasm.exe`` will be in the PATH here
-        
+
         def package_info(self):
             self.cpp_info.libs = [...]
 
@@ -126,7 +126,7 @@ of adding the required paths to the corresponding environment variables:
 
 Here we are telling Conan to create the package for the ``libx264`` for the ``host`` platform defined
 in the profile ``profile_host`` file and to use the profile ``windows`` for all the build requirements
-that are in the ``build`` context. In other words: in this example we are running a Windows machine 
+that are in the ``build`` context. In other words: in this example we are running a Windows machine
 and we need a version of ``nasm`` compatible with this machine, so we are providing a ``windows`` profile
 for the ``build`` context, and we are generating the library for the ``host`` platform which is declared
 in the ``profile_host`` profile (read more about :ref:`build requires context <build_requires_context>`).
@@ -195,7 +195,7 @@ For example: Working in Windows with the ``nasm`` package we've already defined:
 
        > NASM version 2.13.02 compiled on Dec 18 2019
 
-       
+
 #. You can deactivate the virtual environment with the *deactivate.bat* script
 
    .. code-block:: bash

--- a/howtos/run_conan_in_docker.rst
+++ b/howtos/run_conan_in_docker.rst
@@ -38,9 +38,9 @@ It is always recommended to upgrade Conan from pip first:
 .. code-block:: bash
 
     $ sudo pip install conan --upgrade # We make sure we are running the latest Conan version
-    $ git clone https://github.com/conan-community/conan-openssl
-    $ cd conan-openssl
-    $ conan create . user/channel
+    $ git clone https://github.com/conan-io/conan-center-index
+    $ cd conan-center-index/recipes/openssl/1.x.x
+    $ conan create . 1.1.1i@
 
 
 Sharing a local folder with a Docker container
@@ -50,8 +50,8 @@ You can share a local folder with your container, for example a project:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/conan-community/conan-openssl
-    $ cd conan-openssl
+    $ git clone https://github.com/conan-io/conan-center-index
+    $ cd conan-center-index/recipes/openssl/1.x.x
     $ docker run -it -v$(pwd):/home/conan/project --rm conanio/gcc7 /bin/bash
 
 
@@ -90,8 +90,8 @@ Building and uploading a package along with all its missing dependencies for ``L
 
 .. code-block:: bash
 
-    $ git clone https://github.com/conan-community/conan-openssl
-    $ cd conan-openssl
+    $ git clone https://github.com/conan-io/conan-center-index
+    $ cd conan-center-index/recipes/openssl/1.x.x
     $ docker run -it -v$(pwd):/home/conan/project --rm conanio/gcc49-armv7hf /bin/bash
 
     # Now we are running on the conangcc49-armv7hf container

--- a/integrations/build_system/cmake/find_packages.rst
+++ b/integrations/build_system/cmake/find_packages.rst
@@ -85,5 +85,5 @@ Then repeat for the library names with CONAN_LIBS_XXX and the paths where the li
            self.copy("FindXXX.cmake", ".", ".")
 
 
-.. _`conan's boost package`: https://github.com/conan-community/conan-boost.git
-.. _`conan's zlib package`: https://github.com/conan-community/conan-zlib.git
+.. _`conan's boost package`: https://github.com/conan-io/conan-center-index/tree/master/recipes/boost/all
+.. _`conan's zlib package`: https://github.com/conan-io/conan-center-index/tree/master/recipes/zlib/1.2.11

--- a/integrations/ci/jenkins.rst
+++ b/integrations/ci/jenkins.rst
@@ -84,13 +84,15 @@ Example: Build a Conan package and upload it to Artifactory
 In this example we will call Conan :ref:`test package<creating_and_testing_packages>` command to create a binary packages
 and then upload it to Artifactory. We also upload the `build information`_:
 
- 
+
 .. code-block:: groovy
 
     def artifactory_name = "artifactory"
     def artifactory_repo = "conan-local"
-    def repo_url = 'https://github.com/conan-community/conan-zlib.git'
-    def repo_branch = "release/1.2.11"
+    def repo_url = 'https://github.com/conan-io/conan-center-index.git'
+    def repo_branch = "master"
+    def recipe_folder = "recipes/zlib/1.2.11"
+    def recipe_version = "1.2.11"
 
     node {
         def server = Artifactory.server artifactory_name
@@ -102,7 +104,9 @@ and then upload it to Artifactory. We also upload the `build information`_:
         }
 
         stage("Test recipe"){
-            client.run(command: "create")
+            dir (recipe_folder) {
+              client.run(command: "create . ${recipe_version}@")
+            }
         }
 
         stage("Upload packages"){

--- a/integrations/cross_platform/buildroot.rst
+++ b/integrations/cross_platform/buildroot.rst
@@ -117,8 +117,9 @@ Now let's go to the *conan-zlib.mk* that contains the Zlib data:
     CONAN_ZLIB_VERSION = 1.2.11
     CONAN_ZLIB_LICENSE = Zlib
     CONAN_ZLIB_LICENSE_FILES = licenses/LICENSE
-    CONAN_ZLIB_SITE = $(call github,conan-community,conan-zlib,92d34d0024d64a8f307237f211e43ab9952ef0a1)
+    CONAN_ZLIB_SITE = $(call github,conan-io,conan-center-index,134dd3b84d629d27ba3474e01b688e9c0f25b9c8)
     CONAN_ZLIB_REFERENCE = zlib/$(CONAN_ZLIB_VERSION)@
+    CONAN_ZLIB_SUBDIR = recipes/zlib/1.2.11
 
     $(eval $(conan-package))
 
@@ -235,4 +236,4 @@ If you are interested in knowing more, we have a complete `blog post`_ about Bui
 .. _`Buildroot Project`: https://buildroot.org/
 .. _`GPL-2.0-or-later`: https://spdx.org/licenses/GPL-2.0-or-later.html
 .. _`blog post`: https://blog.conan.io/2019/08/27/Creating-small-Linux-images-with-Buildroot.html
-.. _`pkg-conan.mk`: https://github.com/conan-community/buildroot/blob/feature/conan/package/pkg-conan.mk
+.. _`pkg-conan.mk`: https://github.com/conan-io/examples/blob/features/buildroot/package/pkg-conan.mk

--- a/reference/commands/output/user.rst
+++ b/reference/commands/output/user.rst
@@ -30,7 +30,7 @@ List users per remote: :command:`conan user --json user.json`
 
       {
           "error":false,
-          "remotes":[  
+          "remotes":[
               {
                   "name":"conan-center",
                   "user_name":"danimtb",
@@ -40,11 +40,6 @@ List users per remote: :command:`conan user --json user.json`
                   "name":"bincrafters",
                   "user_name":null,
                   "authenticated":false
-              },
-              {
-                  "name":"conan-community",
-                  "user_name":"danimtb",
-                  "authenticated":true
               },
               {
                   "name":"the_remote",

--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -591,13 +591,13 @@ RPI one:
 
 .. code-block:: bash
 
-    git clone https://github.com/conan-community/conan-zlib.git
+    git clone https://github.com/conan-io/conan-center-index.git
 
 - Call :command:`conan create` using the created profile.
 
 .. code-block:: bash
 
-    $ cd conan-zlib && conan create . -pr:h ../android_21_arm_clang -pr:b default
+    $ cd conan-center-index/recipes/zlib/1.2.11 && conan create . 1.2.11@ -pr:h ../android_21_arm_clang -pr:b default
 
     ...
     -- Build files have been written to: /tmp/conan-zlib/test_package/build/ba0b9dbae0576b9a23ce7005180b00e4fdef1198
@@ -623,7 +623,7 @@ integration section<darwin_toolchain>` in the documentation.
     - Check the :ref:`Creating conan packages to install dev tools<create_installer_packages>` to learn
       more about how to create Conan packages for tools.
 
-    - Check the `mingw-installer <https://github.com/conan-community/conan-mingw-installer/blob/master/conanfile.py>`_ build require recipe as an example of packaging a compiler.
+    - Check the `msys2 <https://github.com/conan-io/conan-center-index/blob/master/recipes/msys2/all/conanfile.py>`_ build require recipe as an example of packaging a compiler.
 
 
 

--- a/uploading_packages/remotes.rst
+++ b/uploading_packages/remotes.rst
@@ -85,15 +85,6 @@ Bincrafters
 
         $ conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
-Conan Community
-+++++++++++++++
-
-.. warning::
-
-    The conan community repository is deprecated and no longer maintained. Packages in this repository
-    have been moved or are in the process of being added to `conan-center-index <https://github.com/conan-io/conan-center-index>`_
-    and served in `ConanCenter <https://conan.io/center>`_.
-
 .. note::
 
     If you are working in a team, you probably want to use the same remotes everywhere: developer machines, CI. The ``conan config install``


### PR DESCRIPTION
As Conan Community is officially deprecated, it should not be listed in the official documentation.

Some examples in docs are still present in Conan Community (because we didn't have conan-io/examples when they were created). Thus, this PR is linked to https://github.com/conan-io/examples/pull/74 and https://github.com/conan-io/examples/pull/75 