### PR TITLE
Make CI fail when the linkcheck of PR's fail

### DIFF
--- a/.ci/test.jenkins
+++ b/.ci/test.jenkins
@@ -32,7 +32,7 @@ node('Linux') {
         linkcheck: {
             image.inside {
                 int output = sh(script: 'make linkcheck', returnStatus: true)
-                if (output != 0 && isMaster) {
+                if (output != 0) {
                     currentBuild.result = 'FAILURE'
                     error('Stop here, linkcheck failed!')
                 }

--- a/integrations/cross_platform/buildroot.rst
+++ b/integrations/cross_platform/buildroot.rst
@@ -236,3 +236,4 @@ If you are interested in knowing more, we have a complete `blog post`_ about Bui
 .. _`Buildroot Project`: https://buildroot.org/
 .. _`GPL-2.0-or-later`: https://spdx.org/licenses/GPL-2.0-or-later.html
 .. _`blog post`: https://blog.conan.io/2019/08/27/Creating-small-Linux-images-with-Buildroot.html
+.. _`pkg-conan.mk`: https://github.com/conan-community/buildroot/blob/feature/conan/package/pkg-conan.mk

--- a/integrations/cross_platform/buildroot.rst
+++ b/integrations/cross_platform/buildroot.rst
@@ -236,4 +236,3 @@ If you are interested in knowing more, we have a complete `blog post`_ about Bui
 .. _`Buildroot Project`: https://buildroot.org/
 .. _`GPL-2.0-or-later`: https://spdx.org/licenses/GPL-2.0-or-later.html
 .. _`blog post`: https://blog.conan.io/2019/08/27/Creating-small-Linux-images-with-Buildroot.html
-.. _`pkg-conan.mk`: https://github.com/conan-io/examples/blob/features/buildroot/package/pkg-conan.mk


### PR DESCRIPTION
We only fail the CI job if the linkcheck fails when the commit is merged to master. That avoids some spurious fails when the PR is made but is making that sometimes we do not detect broken links in the PR and after merging to master the job fails and the docs are not published. 
Temporary we could disable that check so that the PR's fail (I think it's better to fail the PR even if it's caused by spurious fails). 
IMHO in case that after the merge to master the job fails because we have spurious fails, or a link changed in between the PR was checked and the PR was merged, we should let the documentation be published and create an active alert system (slack, dashboard...) to fix the problem as soon as possible. We could also let the job fail and don't publish the docs, then through the alert system fix the problem, but my personal preference is publishing even if we have one or two links broken for a couple of hours. We should discuss the best strategy.

This PR should fail first. Then after the broken links are fixed, it should pass.

Please @uilianries, be aware that I had to put conan-community buildroot link back because the buildroot example is not merged yet on the new repo. This should be fixed when it's merged.