### PR TITLE
[getting started] add reference to cmake section

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -204,7 +204,7 @@ An MD5 hash calculator using the Poco Libraries
     .. note::
 
         There are other integrations with CMake, like the ``cmake_find_package`` generators, that will
-        use the ``find_package()`` CMake syntax.
+        use the ``find_package()`` CMake syntax (see :ref:`cmake` section).
 
 7. Now we are ready to build and run our MD5 app:
 


### PR DESCRIPTION
Just a minor improvement.
I think it's useful to give the link to the section describing the cmake integration when mentioned in the getting started