### PR TITLE
remove training banner

### DIFF
--- a/_themes/conan/layout.html
+++ b/_themes/conan/layout.html
@@ -158,13 +158,11 @@
           {% include "breadcrumbs.html" %}
           <!--<select id="search" name="state" multiple="true" onchange="window.location = reldir + this.value;" style="width:90%"></select>
           <hr/>-->
-          <!--<div class="admonition important"> Join the <a href=https://blog.conan.io/2020/07/28/Launching-Conan-2.0-Tribe.html>Conan 2.0 Tribe</a> and contribute to define the next Conan 2.0 major version</div>-->
-          <div class="admonition important">
+          <!--<div class="admonition important">
             <p class="admonition-title">Announcement</p>
             <p>Check out the new free <a
-            href=https://blog.conan.io/2020/09/24/New-conan-training-series.html>Conan
-            training courses on JFrog Academy</a>!
-          </div>
+            href=https://blog.conan.io/2020/09/24/New-conan-training-series.html>Conan training courses on JFrog Academy</a>!
+          </div>-->
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
             {% block body %}{% endblock %}


### PR DESCRIPTION
Clean the banner. We will add it back when we have news, the CI/CD training is launched, or similar announcements.