### PR TITLE
Troubleshooting: How to fix incompatible requirements

### DIFF
--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -244,7 +244,7 @@ As we can see the follow situation: our ``conanfile.txt`` wants 2 packages (``ba
 both require the package named ``foo``. However, ``baz`` requires ``foo/1.0.0``, but ``foobar`` requires ``foo/1.3.0``.
 As the required versions are different, it's considered a conflict and Conan will not solve it.
 
-To solve this kind of collision, you have to choose a version for ``foo`` and add into ``conanfile.txt`` as explicit
+To solve this kind of collision, you have to choose a version for ``foo`` and add it to the ``conanfile.txt`` as an explicit
 requirement:
 
 .. code-block:: text

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -240,7 +240,7 @@ When two different packages require the same package as a dependency, but with d
             Previous requirements: [foo/1.0.0]
             New requirements: [foo/1.3.0]
 
-As we can see the follow situation: our ``conanfile.txt`` wants 2 packages (``baz/1.0.0`` and ``foobar/1.0.0``) which
+As we can see in the following situation: the ``conanfile.txt`` requires 2 packages (``baz/1.0.0`` and ``foobar/1.0.0``) which
 both require the package named ``foo``. However, ``baz`` requires ``foo/1.0.0``, but ``foobar`` requires ``foo/1.3.0``.
 As the required versions are different, it's considered a conflict and Conan will not solve it.
 

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -223,8 +223,7 @@ solve this problem you need to remove existing upper case variant ``OpenSSL``:
 ERROR: Incompatible requirements obtained in different evaluations of 'requirements'
 ------------------------------------------------------------------------------------
 
-When two different packages require a same package as dependency, but with different versions, will result on the follow error:
-
+When two different packages require the same package as a dependency, but with different versions, will result in the following error:
 .. code-block:: bash
 
     $ cat conanfile.txt

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -237,8 +237,8 @@ When two different packages require the same package as a dependency, but with d
         [...]
         WARN: foobar/1.0.0: requirement foo/1.3.0 overridden by baz/1.0.0 to foo/1.0.0
         ERROR: baz/1.0.0: Incompatible requirements obtained in different evaluations of 'requirements'
-            Previous requirements: [foo/1.0.0]
-            New requirements: [foo/1.3.0]
+        Previous requirements: [foo/1.0.0]
+        New requirements: [foo/1.3.0]
 
 As we can see in the following situation: the ``conanfile.txt`` requires 2 packages (``baz/1.0.0`` and ``foobar/1.0.0``) which
 both require the package named ``foo``. However, ``baz`` requires ``foo/1.0.0``, but ``foobar`` requires ``foo/1.3.0``.

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -218,3 +218,50 @@ solve this problem you need to remove existing upper case variant ``OpenSSL``:
 .. code-block:: bash
 
     $ conan remove "OpenSSL/*"
+
+
+ERROR: Incompatible requirements obtained in different evaluations of 'requirements'
+------------------------------------------------------------------------------------
+
+When two different packages require a same package as dependency, but with different versions, will result on the follow error:
+
+.. code-block:: bash
+
+    $ cat conanfile.txt
+
+    [requires]
+    baz/1.0.0
+    foobar/1.0.0
+
+    $ conan install conanfile.txt
+
+        [...]
+        WARN: foobar/1.0.0: requirement foo/1.3.0 overridden by baz/1.0.0 to foo/1.0.0
+        ERROR: baz/1.0.0: Incompatible requirements obtained in different evaluations of 'requirements'
+            Previous requirements: [foo/1.0.0]
+            New requirements: [foo/1.3.0]
+
+As we can see the follow situation: our ``conanfile.txt`` wants 2 packages (``baz/1.0.0`` and ``foobar/1.0.0``) which
+both require the package named ``foo``. However, ``baz`` requires ``foo/1.0.0``, but ``foobar`` requires ``foo/1.3.0``.
+As the required versions are different, it's considered a conflict and Conan will not solve it.
+
+To solve this kind of collision, you have to choose a version for ``foo`` and add into ``conanfile.txt`` as explicit
+requirement:
+
+.. code-block:: text
+
+    [requires]
+    foo/1.3.0
+    baz/1.0.0
+    foobar/1.0.0
+
+Here we choose ``foo/1.3.0`` because is newer. Now we can proceed:
+
+.. code-block:: bash
+
+    $ conan install conanfile.txt
+
+        [...]
+        WARN: baz/1.0.0: requirement foo/1.0.0 overridden by foobar/1.0.0 to foo/1.3.0
+
+Conan still warns us about the conflict, but as we overridden ``foo`` version, it's no longer an error.

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -263,4 +263,4 @@ Here we choose ``foo/1.3.0`` because is newer. Now we can proceed:
         [...]
         WARN: baz/1.0.0: requirement foo/1.0.0 overridden by foobar/1.0.0 to foo/1.3.0
 
-Conan still warns us about the conflict, but as we overridden ``foo`` version, it's no longer an error.
+Conan still warns us about the conflict, but as we have overridden the ``foo`` version, it's no longer an error.

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -263,4 +263,4 @@ Here we choose ``foo/1.3.0`` because is newer. Now we can proceed:
         [...]
         WARN: baz/1.0.0: requirement foo/1.0.0 overridden by foobar/1.0.0 to foo/1.3.0
 
-Conan still warns us about the conflict, but as we have overridden the ``foo`` version, it's no longer an error.
+Conan still warns us about the conflict, but as we have [overridden](docs.conan.io/en/latest/versioning/introduction.html?#dependencies-overriding) the ``foo`` version, it's no longer an error.


### PR DESCRIPTION
This FAQ comes from:

https://stackoverflow.com/questions/66078352/conan-error-incompatible-requirements-obtained-in-different-evaluations-of-req

I can't remember if we have such solution in docs, but when looking for ` Incompatible requirements obtained in different evaluations of 'requirements'` I find anything.
