### PR TITLE
feature: add recipe name to constrained settings error

### DIFF
--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -8,7 +8,7 @@ When you install or create a package you might have error like the following one
 
 .. code-block:: text
 
-    ERROR: The recipe is constraining settings. Invalid setting 'Linux' is not a valid 'settings.os' value.
+    ERROR: The recipe wtl/10.0.9163 is constraining settings. Invalid setting 'Linux' is not a valid 'settings.os' value.
     Possible values are ['Windows']
     Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-the-recipe-is-contraining-settings"
 


### PR DESCRIPTION
Update the example message in the docs with a real recipe from conan-center-index.

Issue: conan-io/conan#8557