### PR TITLE
More explicit instructions in the note about gcc libcxx ABI compatibility

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -119,7 +119,9 @@ An MD5 hash calculator using the Poco Libraries
     .. important::
 
         If you are using **GCC compiler >= 5.1**, Conan will set the ``compiler.libcxx`` to the old
-        ABI for backwards compatibility. You can change this with the following commands:
+        ABI for backwards compatibility. In the context of this getting started example, this is a bad choice though:
+        Recent gcc versions will compile the example by default with the new ABI and linking will fail without further
+        customization of your cmake configuration. You can avoid this with the following commands:
 
         .. code-block:: bash
 

--- a/howtos/manage_gcc_abi.rst
+++ b/howtos/manage_gcc_abi.rst
@@ -15,6 +15,13 @@ You can choose which ABI to use in your Conan packages by adjusting the ``compil
 
 When Conan creates the default profile the first time it runs, it adjusts the ``compiler.libcxx`` setting to ``libstdc++`` for backwards
 compatibility. However, if you are using GCC >= 5 your compiler is likely to be using the new CXX11 ABI by default (libstdc++11).
+This can be checked with the following command:
+
+.. code-block:: bash
+
+  $ gcc -v 2>&1 | sed -n 's/.*\(--with-default-libstdcxx-abi=new\).*/\1/p'
+  --with-default-libstdcxx-abi=new
+
 
 If you want Conan to use the new ABI, edit the default profile at ``~/.conan/profiles/default`` adjusting ``compiler.libcxx=libstdc++11``
 or override this setting in the profile you are using.


### PR DESCRIPTION
When trying out conan, I also ran into the issue documented here:
https://github.com/conan-io/examples/issues/40

I interpreted the existing text in the note as if I had the choice which ABI to use. While that's true in theory ( I could set the corresponding gcc flag in the cmake configuration), no further instructions are provided and it really doesn't make much sense in the context of the Getting Started tutorial to go with the compatibility profile.

Therefore I want to suggest the following changes:

* More explicit instructions on the Getting Started page
* Provide a command to check gccs default configuration value on the Manage gcc >= 5 ABI page.
