### PR TITLE
Remove need to update an out-of-date number

### DIFF
--- a/reference/generators/cmake_paths.rst
+++ b/reference/generators/cmake_paths.rst
@@ -9,7 +9,7 @@ cmake_paths
     This is the reference page for ``cmake_paths`` generator.
     Go to :ref:`Integrations/CMake<cmake>` if you want to learn how to integrate your project or recipes with CMake.
 
-It generates a file named ``conan_paths.cmake`` and declares two variables:
+It generates a file named ``conan_paths.cmake`` and declares these variables:
 
 .. _conan_paths_cmake_variables:
 


### PR DESCRIPTION
The text said "and declares two variables" - but there seems to be three variables in the table.

This PR changes the text to "and declares these variables" - to remove the need to update the number in future...