### PR TITLE
Add conan v1 cheatsheet

### DIFF
--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -221,7 +221,7 @@ Download a package, if it isn't already in `the local cache`_:
                     [-r=<remote ID>]                                    # Download dependencies from only the specified remote
 
 
-    $ conan install .  # Install a package requirement from a Conanfile.txt, saved in your current directory, with all
+    $ conan install .  # Install a package requirement from a conanfile.txt, saved in your current directory, with all
                        # options and settings coming from your default profile
 
     $ conan install . -o pkg_name:use_debug_mode=on -s compiler=clang   # As above, but override one option and one

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -28,6 +28,17 @@ Conan Cheatsheet
 Setup and configuration
 -----------------------
 
+Installation
+++++++++++++
+
+.. code-block:: bash
+
+    $ pip install conan
+    $ pip install conan --upgrade
+
+See `Install docs
+<https://docs.conan.io/en/latest/installation.html>`_.
+
 Configurations
 ++++++++++++++
 
@@ -41,17 +52,27 @@ Install configurations:
 
 Alternatively, copying files and editing conan.conf can be done manually.
 
+Set up configurations:
+
+.. code-block:: bash
+
+    $ conan config init     # Initializes Conan configuration files
+    $ conan config home     # See the Conan home directory
+
 View configurations:
 
 .. code-block:: bash
 
-    $ conan config get  # Shows the conan.conf file
+    $ conan config get      # Shows some or all configuration items
+    $ conan config get log.level
 
 Set configuration values:
 
 .. code-block:: bash
 
     $ conan config set <section>.<config>=<value>
+    $ conan config set log.level=10
+    $ conan config set log.print_run_commands=False # Make conan less verbose
 
 Profiles
 ++++++++
@@ -98,6 +119,7 @@ Show a profile:
 .. code-block:: bash
 
     $ conan profile show <profile>
+    $ conan profile show default
 
 Use profile while executing command (e.g., ``conan install`` or ``conan create``):
 
@@ -175,6 +197,16 @@ Download a package, if it isn't already in `the local cache`_:
     $ conan install <package>/<version>@[<user>/<channel>#<revision>]
                     [-r=<remote ID>]                                   # Download dependencies from only the specified remote
 
+    # Install a package requirement from a Conanfile.txt, saved in your current directory,
+    # with all options and settings coming from your default profile
+    $ conan install .
+
+    # As above, but override one option and one setting:
+    $ conan install . -o pkg_name:use_debug_mode=on -s compiler=clang
+
+See `'conan install' reference
+<https://docs.conan.io/en/latest/reference/commands/consumer/install.html>`_.
+
 The local cache
 +++++++++++++++
 
@@ -184,7 +216,12 @@ Clear packages from cache:
 
 .. code-block:: bash
 
-    $ conan remove "<package>" -f  # <package> can include wildcards
+    $ conan remove "<package>" --force  # <package> can include wildcards
+    $ conan remove 'boost/*'
+    $ conan remove 'MyPackage/1.2@user/channel'
+
+See `'conan remove' docs
+<https://docs.conan.io/en/latest/reference/commands/misc/remove.html>`_.
 
 Using packages as standalone applications
 +++++++++++++++++++++++++++++++++++++++++
@@ -238,12 +275,14 @@ Print the package recipe in full:
 .. code-block:: bash
 
     $ conan get <package>/<revision>@<user>/<channel>
+    $ conan get boost/1.74.0
 
 Print attributes of the package recipe:
 
 .. code-block:: bash
 
     $ conan inspect <package>/<revision>@<user>/<channel>
+    $ conan inspect boost/1.74.0
 
 Visualizing dependencies
 ++++++++++++++++++++++++

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -250,7 +250,7 @@ Using packages as standalone applications
 
 Packages can either be copied to the local project folder and run from there, or run directly from the local cache.
 
-In the `Conanfile.txt`__, this can be done in the [imports] or [generators] section. See below for the relevant
+In the `conanfile.txt`__, this can be done in the [imports] or [generators] section. See below for the relevant
 generators. In `the package recipe`_, this can be done using the ``imports()`` or ``deploy()`` methods.
 
 __ #using-conan-packages-in-an-application

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -452,7 +452,7 @@ A package recipe is a Python class, defined in a file called conanfile.py in the
 Python requires
 ###############
 
-Python requires allow the re-use of python methods across multiple recipes. Complex dependency graphs can be produced,
+Python requires allow the re-use of python code across multiple recipes. Complex dependency graphs can be produced,
 and the `same concepts`__ apply with python requires as with normal package requirements.
 
 __ #managing-dependencies

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -36,8 +36,7 @@ Installation
     $ pip install conan
     $ pip install conan --upgrade
 
-See `Install docs
-<https://docs.conan.io/en/latest/installation.html>`_.
+See `Install <https://docs.conan.io/en/latest/installation.html>`_ docs.
 
 Configurations
 ++++++++++++++
@@ -73,6 +72,8 @@ Set configuration values:
     $ conan config set <section>.<config>=<value>
     $ conan config set log.level=10
     $ conan config set log.print_run_commands=False # Make conan less verbose
+
+See `conan config <https://docs.conan.io/en/latest/reference/commands/consumer/config.html>`_ reference.
 
 Profiles
 ++++++++
@@ -128,6 +129,8 @@ Use profile while executing command (e.g., ``conan install`` or ``conan create``
     $ conan <command> . -pr=<profile1> -pr=<profile2>  # Use installed profile name, or file path
                                                        # Composable, last -pr wins for conflicts
                                                        
+See `conan profile <https://docs.conan.io/en/latest/reference/commands/misc/profile.html>`_ reference.
+
 Remote repositories
 +++++++++++++++++++
 
@@ -144,6 +147,8 @@ Add remote:
 .. code-block:: bash
 
     $ conan remote add <remote ID> <URL of remote repo>
+
+See `conan remote <https://docs.conan.io/en/latest/reference/commands/misc/remote.html>`_ reference.
 
 Consuming packages
 ------------------
@@ -204,8 +209,7 @@ Download a package, if it isn't already in `the local cache`_:
     # As above, but override one option and one setting:
     $ conan install . -o pkg_name:use_debug_mode=on -s compiler=clang
 
-See `'conan install' reference
-<https://docs.conan.io/en/latest/reference/commands/consumer/install.html>`_.
+See `conan install <https://docs.conan.io/en/latest/reference/commands/consumer/install.html>`_ reference.
 
 The local cache
 +++++++++++++++
@@ -220,8 +224,7 @@ Clear packages from cache:
     $ conan remove 'boost/*'
     $ conan remove 'MyPackage/1.2@user/channel'
 
-See `'conan remove' docs
-<https://docs.conan.io/en/latest/reference/commands/misc/remove.html>`_.
+See `conan remove <https://docs.conan.io/en/latest/reference/commands/misc/remove.html>`_ reference.
 
 Using packages as standalone applications
 +++++++++++++++++++++++++++++++++++++++++
@@ -267,6 +270,8 @@ Show revisions of a package:
 
     $ conan search <package>/<revision>@<user>/<channel> --revisions
 
+See `conan search <https://docs.conan.io/en/latest/reference/commands/consumer/search.html>`_ reference.
+
 Inspecting packages
 +++++++++++++++++++
 
@@ -284,6 +289,9 @@ Print attributes of the package recipe:
     $ conan inspect <package>/<revision>@<user>/<channel>
     $ conan inspect boost/1.74.0
 
+See `conan get <https://docs.conan.io/en/latest/reference/commands/consumer/get.html>`_ and `conan
+inspect <https://docs.conan.io/en/latest/reference/commands/misc/inspect.html>`_ reference.
+
 Visualizing dependencies
 ++++++++++++++++++++++++
 
@@ -293,6 +301,8 @@ Create a dependency graph for the package or application:
 
     $ conan info .
                  [--graph=file.html]  # Save output in an HTML file
+
+See `conan info <https://docs.conan.io/en/latest/reference/commands/consumer/info.html>`_ reference.
 
 Creating packages
 -----------------
@@ -346,6 +356,9 @@ Build a package into the local cache:
                                                      # If <package> is not specified, the option and setting applies to all dependencies.
                    [-pr=<profile name>]              # If -pr is not specified, the default profile is used
                    [--build=missing]                 # Builds all dependencies if they can't be downloaded
+
+See `conan new <https://docs.conan.io/en/latest/reference/commands/creator/new.html>`_ and `conan
+create <https://docs.conan.io/en/latest/reference/commands/creator/create.html>`_ reference.
 
 The package recipe
 ++++++++++++++++++
@@ -423,6 +436,8 @@ Use the exported conanfile.py:
 
            ...
            self.python_requires["<package>"].module.func()           # To call the method func() from the exported conanfile.py
+
+See `conan export <https://docs.conan.io/en/latest/reference/commands/creator/export.html>`_ reference.
 
 Hooks
 #####
@@ -553,6 +568,8 @@ Use lockfile during ``conan create`` or ``conan install``:
 
     $ conan <command> --lockfile conan.lock
 
+See `conan lock <https://docs.conan.io/en/latest/reference/commands/misc/lock.html>`_ reference.
+
 Uploading packages to a remote repository
 +++++++++++++++++++++++++++++++++++++++++
 
@@ -564,8 +581,12 @@ Packages are not uploaded to a remote repository automatically. This needs to be
                    [--all]                     # Upload all binaries and their recipes (recipes only uploaded by default)
                    [--confirm]                 # Auto-confirm
 
+See `conan upload <https://docs.conan.io/en/latest/reference/commands/creator/upload.html>`_ reference.
+
 Important points for enterprises
 --------------------------------
 
-Versioning, revisioning and dependency resolution should be consistent across a company. Configurations_ should be synchronised across all developers, in particular `package id calculation modes`_.
+Versioning, revisioning and dependency resolution should be consistent across a company. Configurations_ should be
+synchronised across all developers, in particular `package id calculation modes`_.
+
 In a CI/CD system, use lockfiles_ throughout, so that builds are reproducible.

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -368,7 +368,7 @@ Create a template package:
 
 .. code-block:: bash
 
-    $ conan new <package>/<version>@[<user>/<channel>]  # <user>/<channel> is not specified in Conan Centre, but otherwise they should be
+    $ conan new <package>/<version>@[<user>/<channel>]  # <user>/<channel> is not specified in Conan Center, but otherwise they should be
                 [-t]                                    # Create a recipe for a basic test to verify the package was created successfully
                 [-s]                                    # Create a recipe/source template for a package with local source code
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -31,6 +31,8 @@ Setup and configuration
 Installation
 ++++++++++++
 
+Conan is available as a Python package and installed via pip:
+
 .. code-block:: bash
 
     $ pip install conan
@@ -57,7 +59,8 @@ Set up configurations:
 
 .. code-block:: bash
 
-    $ conan config init     # Initialize Conan configuration files
+    $ conan config init     # Initialize Conan configuration files. If some are already present, missing files only are
+                            # created
 
 Set configuration values:
 
@@ -73,9 +76,11 @@ Inspect configurations:
 .. code-block:: bash
 
     $ conan config home     # See the Conan home directory
-    $ conan config get      # Show some or all configuration items
 
-    $ conan config get log.level
+    $ conan config get [<section>.<config>]  # Show some or all configuration items
+
+    $ conan config get                       # Show the full conan.conf file
+    $ conan config get log.level             # Show the "level" item in the "log" section
 
 See `conan config <https://docs.conan.io/en/latest/reference/commands/consumer/config.html>`_ reference.
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -43,7 +43,9 @@ See `Install <https://docs.conan.io/en/latest/installation.html>`_ docs.
 Configurations
 ++++++++++++++
 
-Configurations contain hooks_, profiles_, `remote repositories`_ and settings_, making them available for builds once installed. They are installed from a folder, zip, URL or git repo, and the installed items are recorded in ~/.conan/conan.conf.
+Configurations contain hooks_, profiles_, `remote repositories`_ and settings_, making them available for builds once
+installed. They are installed from a folder, zip, URL or git repo, and the installed items are recorded in
+~/.conan/conan.conf.
 
 Install configurations:
 
@@ -87,7 +89,9 @@ See `conan config <https://docs.conan.io/en/latest/reference/commands/consumer/c
 Profiles
 ++++++++
 
-Profiles allow users to set aspects of the build environment. This includes settings_, options_, environment variables and build requirements. They can be installed into ~/.conan/profiles. They can also be stored in project directories, which can be useful for specific compilation cases, for example cross-compiling.
+Profiles allow users to set aspects of the build environment. This includes settings_, options_, environment variables
+and build requirements. They can be installed into ~/.conan/profiles. They can also be stored in project directories,
+which can be useful for specific compilation cases, for example cross-compiling.
 
 Profiles are stored in text files with no file extension. An example profile:
 
@@ -138,7 +142,7 @@ Use profile while executing command (e.g., ``conan install`` or ``conan create``
 
     $ conan <command> . -pr=<profile1> -pr=<profile2>  # Use installed profile name, or file path
                                                        # Composable, last -pr wins for conflicts
-                                                       
+
 See `conan profile <https://docs.conan.io/en/latest/reference/commands/misc/profile.html>`_ reference.
 
 Remote repositories
@@ -151,7 +155,7 @@ List configured remotes:
 .. code-block:: bash
 
     $ conan remote list
-   
+
 Add remote:
 
 .. code-block:: bash
@@ -193,7 +197,8 @@ Using packages in an application
 
     $ conan install . [-o <package>:<option>=<value>]  # Specify options, e.g. shared=True
                       [-s <package>:<setting>=<value>] # Specify settings, e.g. build_type=Debug
-                                                       # <package> is optional: if not specified, the option/setting applies to all dependencies
+                                                       # <package> is optional: if not specified, the option/setting
+                                                       # applies to all dependencies
                       [-r=<remote ID>]                 # Download dependencies from only the specified remote
                       [-g=<generator>]                 # Specify generators at the command line
 
@@ -211,7 +216,7 @@ Download a package, if it isn't already in `the local cache`_:
     $ conan install <package>/<version>@[<user>/<channel>#<revision>]
                     [-r=<remote ID>]                                    # Download dependencies from only the specified remote
 
-    
+
     $ conan install .  # Install a package requirement from a Conanfile.txt, saved in your current directory, with all
                        # options and settings coming from your default profile
 
@@ -241,7 +246,8 @@ Using packages as standalone applications
 
 Packages can either be copied to the local project folder and run from there, or run directly from the local cache.
 
-In the `Conanfile.txt`__, this can be done in the [imports] or [generators] section. See below for the relevant generators. In `the package recipe`_, this can be done using the ``imports()`` or ``deploy()`` methods.
+In the `Conanfile.txt`__, this can be done in the [imports] or [generators] section. See below for the relevant
+generators. In `the package recipe`_, this can be done using the ``imports()`` or ``deploy()`` methods.
 
 __ #using-conan-packages-in-an-application
 
@@ -250,7 +256,8 @@ Prepare packages for use via the command line:
 .. code-block:: bash
 
     $ conan install . -g=deploy         # Copy dependencies to current folder
-    $ conan install . -g=virtualrunenv  # Create shell scripts to activate and deactivate environments where you can run dependencies from the local cache
+    $ conan install . -g=virtualrunenv  # Create shell scripts to activate and deactivate environments where you can run
+                                        # dependencies from the local cache
 
 Searching and introspecting packages
 ------------------------------------
@@ -270,10 +277,11 @@ Show package recipes or builds of a package:
 
 .. code-block:: bash
 
-    $ conan search <package>/<revision>@<user>/<channel>  # Output depends on how much of a package reference is given. Wildcards are supported
+    $ conan search <package>/<revision>@<user>/<channel>  # Output depends on how much of a package reference is given.
+                                                          # Wildcards are supported
                    [--table=file.html]                    # Save output in an HTML file
                    [-r=<remote>]                          # Look in a remote repository (default is the local cache)
-    
+
     $ conan search mylib/1.0@user/channel                 # Show all packages of mylib/1.0@user/channel in the local cache
     $ conan search "zlib/*" -r=all                        # Show all versions of zlib in all remotes
 
@@ -382,13 +390,17 @@ A package recipe is a Python class, defined in a file called conanfile.py in the
 .. code-block:: python
 
     class <Package>Conan(ConanFile):
-        ...                                                # Various package metadata 
+        ...                                                # Various package metadata
         settings = "os", "compiler", "build_type", "arch"  # Defines available settings
-        options = {"shared": [True, False]}                # Defines available options and defaults. "shared" is a common option which specifies whether a library is static or shared
+        options = {"shared": [True, False]}                # Defines available options and defaults. "shared" is a common
+                                                           # option which specifies whether a library is static or shared
+
         default_options = {"shared": False}
         requires = "RequiredLib/0.1@user/stable"           # Defines package requirements
-        build_requires = "tool_a/0.2@user/testing"         # Defines requirements that are only used when the package is built. These should be build and test tools only.
-        generators = "cmake"                               # Generator for the package: specifies which build system type will be generated
+        build_requires = "tool_a/0.2@user/testing"         # Defines requirements that are only used when the package is
+                                                           # built. These should be build and test tools only.
+        generators = "cmake"                               # Generator for the package: specifies which build system
+                                                           # type will be generated
 
         def source(self):                                                # Obtains the source code for the project
             self.run("git clone https://github.com/conan-io/hello.git")  # self.run() executes any command in the native shell
@@ -405,7 +417,9 @@ A package recipe is a Python class, defined in a file called conanfile.py in the
             self.copy("\*.h", dst="include", src="hello")                # self.copy() copies files from the cache to the project folder
             ...
 
-        def package_info(self):                                          # Responsible for defining variables that are passed to package consumers, for example library or include directories
+        def package_info(self):                                          # Responsible for defining variables that are
+                                                                         # passed to package consumers, for example
+                                                                         # library or include directories
             self.cpp_info.libs = ["hello"]                               # The cpp_info dictionary contains these variables
             ...
 
@@ -413,24 +427,29 @@ A package recipe is a Python class, defined in a file called conanfile.py in the
             if self.options.myoption2:                                   # Specify a conditional requirement
                 self.requires("RequiredLib2/0.3@user/stable")
 
-        def package_id(self):                                            # Responsible for changing the way the package ID is calculated from the default
+        def package_id(self):                                            # Responsible for changing the way the package
+                                                                         # ID is calculated from the default
             default_package_id_mode = full_version_mode
-            if self.settings.compiler.version == "4.9":                  # Make compiler versions 4.8 and 4.7 compatible with version4.9: i.e., they all result in the same package ID
+            if self.settings.compiler.version == "4.9":                  # Make compiler versions 4.8 and 4.7 compatible
+                                                                         # with version4.9: i.e., they all result in the same package ID
+
                 for version in ("4.8", "4.7"):
                     compatible_pkg = self.info.clone()
                     compatible_pkg.settings.compiler.version = version
-                    self.compatible_packages.append(compatible_pkg)      # The compatible_packages property is used to define this behaviour 
+                    self.compatible_packages.append(compatible_pkg)      # The compatible_packages property is used to
+                                                                         # define this behaviour 
 
-        def imports(self):                                               # Copies dependency files from the local cache to the project directory
-            ...
+        def imports(self):                                               # Copies dependency files from the local cache
+            ...                                                          # to the project directory
 
-        def deploy(self):                                                # Installs the project, which can include copying build artifacts
-            ...
+        def deploy(self):                                                # Installs the project, which can include
+            ...                                                          # copying build artifacts
 
 Python requires
 ###############
 
-Python requires allow the re-use of python methods across multiple recipes. Complex dependency graphs can be produced, and the `same concepts`__ apply with python requires as with normal package requirements. 
+Python requires allow the re-use of python methods across multiple recipes. Complex dependency graphs can be produced,
+and the `same concepts`__ apply with python requires as with normal package requirements.
 
 __ #managing-dependencies
 
@@ -456,7 +475,9 @@ See `conan export <https://docs.conan.io/en/latest/reference/commands/creator/ex
 Hooks
 #####
 
-Hooks are recipe methods which are defined globally. They should not affect the built binary. There are ``pre`` and ``post`` hooks for many methods in the recipe. Hooks reside in ~/.conan/hooks, and are include in ~/.conan/conan.conf under the [hooks] section. 
+Hooks are recipe methods which are defined globally. They should not affect the built binary. There are ``pre`` and
+``post`` hooks for many methods in the recipe. Hooks reside in ~/.conan/hooks, and are include in ~/.conan/conan.conf
+under the [hooks] section. 
 
 Install a hook:
 
@@ -470,9 +491,11 @@ Specifying build configuration items
 Settings
 ########
 
-Settings are configuration items which generally apply to all builds of all packages in the dependency tree, for example compiler, OS, and release or debug builds.
+Settings are configuration items which generally apply to all builds of all packages in the dependency tree, for example
+compiler, OS, and release or debug builds.
 
-Available settings are defined in a global settings file: ~/.conan/settings.yml. The settings for a given package are defined in `the package recipe`_.
+Available settings are defined in a global settings file: ~/.conan/settings.yml. The settings for a given package are
+defined in `the package recipe`_.
 
 Settings can then be set via profiles_ or via arguments to `conan install`__ or `conan create`__.
 
@@ -486,7 +509,8 @@ Options are configuration items which are generally package-specific.
 
 The available options for a package are defined in `the package recipe`_.
 
-Options can then be set via profiles_, an application's `Conanfile.txt`__, or via arguments to `conan install`__ or `conan create`__.
+Options can then be set via profiles_, an application's `Conanfile.txt`__, or via arguments to `conan install`__ or
+`conan create`__.
 
 __ #using-conan-packages-in-an-application
 __ #using-conan-packages-in-an-application
@@ -513,7 +537,8 @@ The version taken is otherwise the maximum available.
 Revisions
 #########
 
-Revisions allow changes to a package without increasing the version number or overwriting the existing version number. They are disabled by default.
+Revisions allow changes to a package without increasing the version number or overwriting the existing version number.
+They are disabled by default.
 
 There are two types of revisions:
 
@@ -547,28 +572,35 @@ Main application dependencies are set in the [requires] section of `Conanfile.tx
 
 __ #using-conan-packages-in-an-application
 
-Package dependencies - normal requirements, build requirements, conditional requirements - are set in `the package recipe`_. 
+Package dependencies - normal requirements, build requirements, conditional requirements - are set in `the package recipe`_.
 
 Package ID calculation modes
 ############################
 
-Conan performs dependency resolution via the calculation of package IDs. A package ID is calculated for a desired dependency, and then Conan searches for that package ID.
+Conan performs dependency resolution via the calculation of package IDs. A package ID is calculated for a desired
+dependency, and then Conan searches for that package ID.
 
-The package ID calculation, and therefore the dependency resolution, is affected by the default_package_id_mode and the default_python_requires_id_mode. They determine what exactly affects the calculation: which parts of version numbers; package revisions; immediate or transitive dependencies. This relates to both normal requirements and `Python requires`_. By default, only the main version number of direct dependencies are taken into account when calculating the package ID.
+The package ID calculation, and therefore the dependency resolution, is affected by the default_package_id_mode and the
+default_python_requires_id_mode. They determine what exactly affects the calculation: which parts of version numbers;
+package revisions; immediate or transitive dependencies. This relates to both normal requirements and `Python
+requires`_. By default, only the main version number of direct dependencies are taken into account when calculating the
+package ID.
 
 These modes can be set in the [general] section of configurations_, and in `the package recipe`_.
 
 Resolving dependency conflicts
 ##############################
 
-Versions defined in the `Conanfile.txt`__ take precedence over versions specified by dependencies. This can be used to resolve conflicts by dictating the use of only one version throughout the whole dependency graph.
+Versions defined in the `Conanfile.txt`__ take precedence over versions specified by dependencies. This can be used to
+resolve conflicts by dictating the use of only one version throughout the whole dependency graph.
 
 __ #using-conan-packages-in-an-application
 
 Lockfiles
 #########
 
-Lockfiles allow a snapshot of a dependency graph used for a build to be taken, and the build to be reproduced exactly at a later time.
+Lockfiles allow a snapshot of a dependency graph used for a build to be taken, and the build to be reproduced exactly at
+a later time.
 
 Create a lockfile:
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -389,7 +389,7 @@ A package recipe is a Python class, defined in a file called conanfile.py in the
 
 .. code-block:: python
 
-    class <Package>Conan(ConanFile):
+    class MypackageConan(ConanFile):
         ...                                                # Various package metadata
         settings = "os", "compiler", "build_type", "arch"  # Defines available settings
         options = {"shared": [True, False]}                # Defines available options and defaults. "shared" is a common

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -429,7 +429,7 @@ A package recipe is a Python class, defined in a file called conanfile.py in the
 
         def requirements(self):                                          # Responsible for specifying non-trivial requirements logic
             if self.options.myoption2:                                   # Specify a conditional requirement
-                self.requires("RequiredLib2/0.3@user/stable")
+                self.requires("requiredlib2/0.3@user/stable")
 
         def package_id(self):                                            # Responsible for changing the way the package
                                                                          # ID is calculated from the default

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -595,7 +595,7 @@ These modes can be set in the [general] section of configurations_, and in `the 
 Resolving dependency conflicts
 ##############################
 
-Versions defined in the `Conanfile.txt`__ take precedence over versions specified by dependencies. This can be used to
+Versions defined in the `conanfile.txt`__ take precedence over versions specified by dependencies. This can be used to
 resolve conflicts by dictating the use of only one version throughout the whole dependency graph.
 
 __ #using-conan-packages-in-an-application

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -1,8 +1,9 @@
+**********
 Cheatsheet
-============================================
+**********
 
 Single-Page Graphical Format
-----------------------------
+============================
 
 JFrog has created the following visual cheatsheet for basic Conan commands and
 concepts which users can print out and use as a handy reference. It is available
@@ -17,10 +18,13 @@ as both a PDF and PNG.
    :width: 800 px 
    :align: center
 
-.. cheatsheet:
+Community-Created Format 
+========================
 
-Conan Cheatsheet
-================
+Community contributors have also created the following extended cheatsheet
+providing a more narrative and workflow-centric cheatsheet. It is effectively, a
+single-page summary of other docs pages which community users found most
+relevant to daily Conan operations.
 
 .. contents::
     :local:

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -47,7 +47,9 @@ Install configurations:
 
 .. code-block:: bash
 
-    $ conan config install <item>  # Copies the relevant contents from <item> to the user's ~/.conan directory.
+    $ conan config install <item>  # Copy the relevant contents from <item> to the user's ~/.conan directory.
+
+    $ conan config install ./my_config.conf
 
 Alternatively, copying files and editing conan.conf can be done manually.
 
@@ -55,23 +57,25 @@ Set up configurations:
 
 .. code-block:: bash
 
-    $ conan config init     # Initializes Conan configuration files
-    $ conan config home     # See the Conan home directory
-
-View configurations:
-
-.. code-block:: bash
-
-    $ conan config get      # Shows some or all configuration items
-    $ conan config get log.level
+    $ conan config init     # Initialize Conan configuration files
 
 Set configuration values:
 
 .. code-block:: bash
 
     $ conan config set <section>.<config>=<value>
+
     $ conan config set log.level=10
-    $ conan config set log.print_run_commands=False # Make conan less verbose
+    $ conan config set log.print_run_commands=False  # Make conan less verbose
+
+Inspect configurations:
+
+.. code-block:: bash
+
+    $ conan config home     # See the Conan home directory
+    $ conan config get      # Show some or all configuration items
+
+    $ conan config get log.level
 
 See `conan config <https://docs.conan.io/en/latest/reference/commands/consumer/config.html>`_ reference.
 
@@ -120,6 +124,7 @@ Show a profile:
 .. code-block:: bash
 
     $ conan profile show <profile>
+
     $ conan profile show default
 
 Use profile while executing command (e.g., ``conan install`` or ``conan create``):
@@ -181,12 +186,11 @@ Using packages in an application
 
 .. code-block:: bash
 
-    $ conan install .
-                    [-o <package>:<option>=<value>]  # Specify options, e.g. shared=True
-                    [-s <package>:<setting>=<value>] # Specify settings, e.g. build_type=Debug
-                                                     # <package> is optional: if not specified, the option/setting applies to all dependencies
-                    [-r=<remote ID>]                 # Download dependencies from only the specified remote
-                    [-g=<generator>]                 # Specify generators at the command line
+    $ conan install . [-o <package>:<option>=<value>]  # Specify options, e.g. shared=True
+                      [-s <package>:<setting>=<value>] # Specify settings, e.g. build_type=Debug
+                                                       # <package> is optional: if not specified, the option/setting applies to all dependencies
+                      [-r=<remote ID>]                 # Download dependencies from only the specified remote
+                      [-g=<generator>]                 # Specify generators at the command line
 
 3. #include interface files to the Conan packages in the source code
 4. Modify the build system to use the files output from the Generator
@@ -200,14 +204,14 @@ Download a package, if it isn't already in `the local cache`_:
 .. code-block:: bash
 
     $ conan install <package>/<version>@[<user>/<channel>#<revision>]
-                    [-r=<remote ID>]                                   # Download dependencies from only the specified remote
+                    [-r=<remote ID>]                                    # Download dependencies from only the specified remote
 
-    # Install a package requirement from a Conanfile.txt, saved in your current directory,
-    # with all options and settings coming from your default profile
-    $ conan install .
+    
+    $ conan install .  # Install a package requirement from a Conanfile.txt, saved in your current directory, with all
+                       # options and settings coming from your default profile
 
-    # As above, but override one option and one setting:
-    $ conan install . -o pkg_name:use_debug_mode=on -s compiler=clang
+    $ conan install . -o pkg_name:use_debug_mode=on -s compiler=clang   # As above, but override one option and one
+                                                                        # setting
 
 See `conan install <https://docs.conan.io/en/latest/reference/commands/consumer/install.html>`_ reference.
 
@@ -221,8 +225,9 @@ Clear packages from cache:
 .. code-block:: bash
 
     $ conan remove "<package>" --force  # <package> can include wildcards
-    $ conan remove 'boost/*'
-    $ conan remove 'MyPackage/1.2@user/channel'
+
+    $ conan remove 'boost/*'                     # Remove all versions of Boost
+    $ conan remove 'MyPackage/1.2@user/channel'  # Remove all revisions of Mypackage/1.2@user/channel
 
 See `conan remove <https://docs.conan.io/en/latest/reference/commands/misc/remove.html>`_ reference.
 
@@ -240,7 +245,7 @@ Prepare packages for use via the command line:
 .. code-block:: bash
 
     $ conan install . -g=deploy         # Copy dependencies to current folder
-    $ conan install . -g=virtualrunenv  # create shell scripts to activate and deactivate environments where you can run dependencies from the local cache
+    $ conan install . -g=virtualrunenv  # Create shell scripts to activate and deactivate environments where you can run dependencies from the local cache
 
 Searching and introspecting packages
 ------------------------------------
@@ -254,7 +259,7 @@ List names of packages in local cache:
 
 .. code-block:: bash
 
-    $ conan search              # lists names of packages in local cache
+    $ conan search              # List names of packages in local cache
 
 Show package recipes or builds of a package:
 
@@ -263,6 +268,9 @@ Show package recipes or builds of a package:
     $ conan search <package>/<revision>@<user>/<channel>  # Output depends on how much of a package reference is given. Wildcards are supported
                    [--table=file.html]                    # Save output in an HTML file
                    [-r=<remote>]                          # Look in a remote repository (default is the local cache)
+    
+    $ conan search mylib/1.0@user/channel                 # Show all packages of mylib/1.0@user/channel in the local cache
+    $ conan search "zlib/*" -r=all                        # Show all versions of zlib in all remotes
 
 Show revisions of a package:
 
@@ -280,6 +288,7 @@ Print the package recipe in full:
 .. code-block:: bash
 
     $ conan get <package>/<revision>@<user>/<channel>
+
     $ conan get boost/1.74.0
 
 Print attributes of the package recipe:
@@ -287,6 +296,7 @@ Print attributes of the package recipe:
 .. code-block:: bash
 
     $ conan inspect <package>/<revision>@<user>/<channel>
+
     $ conan inspect boost/1.74.0
 
 See `conan get <https://docs.conan.io/en/latest/reference/commands/consumer/get.html>`_ and `conan
@@ -299,8 +309,7 @@ Create a dependency graph for the package or application:
 
 .. code-block:: bash
 
-    $ conan info .
-                 [--graph=file.html]  # Save output in an HTML file
+    $ conan info . [--graph=file.html]  # Save output in an HTML file
 
 See `conan info <https://docs.conan.io/en/latest/reference/commands/consumer/info.html>`_ reference.
 
@@ -350,12 +359,12 @@ Build a package into the local cache:
 
 .. code-block:: bash
 
-    $ conan create . <user>/<channel>
-                   [-o <package>:<option>=<value>]   # Specify options, for example shared=True.
-                   [-s <package>:<setting>=<value>]  # Specify settings, for example build_type=Debug.
-                                                     # If <package> is not specified, the option and setting applies to all dependencies.
-                   [-pr=<profile name>]              # If -pr is not specified, the default profile is used
-                   [--build=missing]                 # Builds all dependencies if they can't be downloaded
+    $ conan create . <user>/<channel> [-o <package>:<option>=<value>]   # Specify options, for example shared=True.
+                                      [-s <package>:<setting>=<value>]  # Specify settings, for example build_type=Debug.
+                                                                        # If <package> is not specified, the option and
+                                                                        # setting applies to all dependencies.
+                                      [-pr=<profile name>]              # If -pr is not specified, the default profile is used
+                                      [--build=missing]                 # Build all dependencies if they can't be downloaded
 
 See `conan new <https://docs.conan.io/en/latest/reference/commands/creator/new.html>`_ and `conan
 create <https://docs.conan.io/en/latest/reference/commands/creator/create.html>`_ reference.

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -275,7 +275,7 @@ __ #package-id-calculation-modes
 
 .. code-block:: text
 
-   09512ff863f37e98ed748e                 # Identifies a build of a package
+   09512ff863f37e98ed748e                 # Identifies a unique build configuration of a package
 
 Creating a basic package
 ++++++++++++++++++++++++
@@ -438,13 +438,19 @@ Revisions
 
 Revisions allow changes to a package without increasing the version number or overwriting the existing version number. They are disabled by default.
 
-Conan only holds one revision in the local cache. Many revisions can be stored in remote repositories. Revisions can be specified wherever a recipe is consumed. If a revision is not specified, the latest revision is used.
+There are two types of revisions:
+- "Recipe Revisions" (aka RREV) - Revision of the recipe and sources
+- "Package Revisions" (aka PREV) - Revision of a binary package
 
-Revisions are an extension to the recipe reference which consist by default of a hash generated from the recipe contents:
+Conan only holds one recipe revision in the local cache. Many recipe revisions can be stored in remote repositories. Recipe revisions can be specified wherever a recipe is consumed. If a recipe revision is not specified, the latest revision is used.
+
+Recipe revisions are an extension to the recipe reference which consist by default of a hash generated from the recipe contents:
 
 .. code-block:: text
 
-    <package>/<version>@<user>/<channel>#<revision>
+    <package>/<version>@<user>/<channel>#<recipe_revision>
+    
+Package revisions are very rarely used directly by users in commands or configurations, because it's fairly impactical to do so.  Instead, they are generally managed by the use of "Lockfiles". 
 
 Enable revisions:
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -418,8 +418,8 @@ A package recipe is a Python class, defined in a file called conanfile.py:
             ...                                                          # tasks, and using them is often preferable to using self.run()
                                                                          # See the link below for more information
 
-        def build_requirements(self):                                    # Defines requirements that are only used when the package is
-            if self.options.myoption1:                                   # built. Useful for specifying conditional build requirements
+        def build_requirements(self):                                    # Responsible for specifying non-trivial build requirements logic
+            if self.options.myoption1:                                   # Specify a conditional build requirement
                 self.build_requires("zlib/1.2@user/testing")
 
         def build(self):                                                 # Responsible for invoking the build system

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -344,7 +344,7 @@ A reference is used to identify packages:
 
     <package>/<version>@<user>/<channel>#RREV:PACKAGE_ID#PREV
 
-The recipe reference is used to identify a certain version of a package recipe:
+The recipe reference is used to identify a certain version of a recipe:
 
 .. code-block:: text
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -241,7 +241,7 @@ Clear packages from cache:
     $ conan remove "<package>" --force  # <package> can include wildcards
 
     $ conan remove 'boost/*'                     # Remove all versions of Boost
-    $ conan remove 'MyPackage/1.2@user/channel'  # Remove all revisions of Mypackage/1.2@user/channel
+    $ conan remove 'mypackage/1.2@user/channel'  # Remove all revisions of mypackage/1.2@user/channel
 
 See `conan remove <https://docs.conan.io/en/latest/reference/commands/misc/remove.html>`_ reference.
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -322,7 +322,7 @@ inspect <https://docs.conan.io/en/latest/reference/commands/misc/inspect.html>`_
 Visualizing dependencies
 ++++++++++++++++++++++++
 
-Create a dependency graph for the package or application:
+Show a dependency graph for the package or application:
 
 .. code-block:: bash
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -16,3 +16,160 @@ as both a PDF and PNG.
    :height: 600 px 
    :width: 800 px 
    :align: center
+
+.. cheatsheet:
+
+Cheatsheet
+==========
+
+Consuming Packages
+------------------
+
+'conan install' installs the requirements specified in a recipe (`conanfile.py` or `conanfile.txt`).
+
+conanfile.txt
+
+.. code-block:: text
+
+    [requires]
+    booost/1.72.0
+    poco/1.9.4
+
+    [generators]
+    cmake
+
+    [options]
+    boost:shared=False
+    poco:shared=False
+
+Release build:
+
+.. code-block:: bash
+
+    $ mkdir build
+    $ cd    build
+    $ conan install ..
+    $ cmake .. -DCMAKE_BUILD_TYPE=Release
+
+Debug build:
+
+.. code-block:: bash
+
+    $ conan install .. -s build_type=Debug
+    $ cmake .. -DCMAKE_BUILD_TYPE=Debug
+
+    conan search
+    conan search zlib/1.2.11@ --table=file.html -r=conan-center
+
+Visualizing Dependencies
+++++++++++++++++++++++++
+
+.. code-block:: bash
+
+    # In a directory with conanfile.txt or conanfile.py, create image of dependencies:
+    $ conan info . --graph=file.html
+
+Searching Packages
+++++++++++++++++++
+
+'conan search' searches package recipes and binaries in the local cache or a remote.
+
+.. code-block:: bash
+
+    $ conan search              # lists names of packages
+    $ conan search zlib/1.2.11@ # shows recipe's Package_ID, [options] and [settings]
+    $ conan search zlib/1.2.11@ --table=file.html -r=conan-center
+
+Inspecting Packages
++++++++++++++++++++
+
+'conan get'
+
+.. code-block:: bash
+
+    $ conan get     zlib/1.2.11@    # prints out the Python recipe of the package
+    $ conan inspect zlib/1.2.11@    # prints details of the package
+
+Creating Packages
+-----------------
+
+.. code-block:: bash
+
+    # in a directory that has a conanfile.py representing a package:
+    $ conan create . user/testing                     # Creates a release package
+    $ conan create . user/testing -s build_type=Debug # Creates a debug package
+    $ conan search hello/0.1@user/testing
+
+Notes:
+
+- ConanCenter does not use user/channel
+- Custom packages you create should use user/channel
+
+Options
++++++++
+
+.. code-block:: bash
+
+    $ conan create . user/testing -s build_type=Debug -o hello:shared=True
+
+Profiles
+++++++++
+
+.. code-block:: bash
+
+    $ conan profile list
+    $ conan profile show default
+    $ conan install . -pr=windows -pr=vs2017 # composable, last -pr wins
+
+Cross-Compiling
++++++++++++++++
+
+File rpi_armv7:
+
+.. code-block:: text
+
+    [settings]
+    os=Linux
+    compiler=gcc
+    compiler.version=6
+    compiler.libcxx=libstdc++11
+    build_type=Release
+    arch=armv7
+    os_build=Linus
+    arch_build=x86_64
+
+    [env]
+    CC=arm-linux-gnueabihf-gcc
+    CXX=arm-linux-gnueabihf-g++
+
+.. code-block:: bash
+
+    $ conan create . user/testing -pr=rpi_armv7 # Use a different profile
+    $ conan search hello/0.1@user/testing
+
+
+Publishing Packages
+-------------------
+
+Uploading Packages to Artifactory
++++++++++++++++++++++++++++++++++
+
+.. code-block:: bash
+
+    $ conan remote add artifactory http://35.223.57.164:8081/artifactory/api/conan/myconanrepo
+    $ conan remote list
+    $ conan upload "hello*" -r artifactory --all
+    $ conan search "*" -r=artifactory
+    $ conan search hello/0.1@user/testing -r=artifactory
+    $ conan upload "*" -r artifactory --all --confirm
+
+
+Other Information
+-----------------
+
+Local Cache
++++++++++++
+
+.. code-block:: text
+
+    ~/.conan/

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -300,21 +300,30 @@ Creating packages
 Package terminology
 +++++++++++++++++++
 
-Each package recipe relates to a single package. However, a package can be built in different ways and result in multiple binaries, each with its own package ID.
+Each package recipe relates to a single package. However, a package can be built in different ways.
 
-A recipe reference is used to identify a certain version/revision of a package and its recipe:
+A reference is used to identify packages:
 
 .. code-block:: text
 
-    <package>/<version>@<user>/<channel>  # Identifies a package version/revision
+    <package>/<version>@<user>/<channel>#RREV:PACKAGE_ID#PREV
 
-A package ID is a SHA-1 hash, calculated from the build options_ and settings_ and from dependencies (according to certain modes__):
+The recipe reference is used to identify a certain version of a package recipe:
+
+.. code-block:: text
+
+    <package>/<version>@<user>/<channel>  # <package> and <version> are defined in the recipe; <user> and <channel> are
+                                          # defined by the user when exporting the package
+
+    lib/1.0@conan/stable
+
+
+The package ID is a SHA-1 hash calculated from the build options_ and settings_ and from dependencies (according to
+certain modes__).
 
 __ #package-id-calculation-modes
 
-.. code-block:: text
-
-   09512ff863f37e98ed748e                 # Identifies a unique build configuration of a package
+See `Revisions`_ for further details of the recipe revision and package revision (RREV and PREV).
 
 Creating a basic package
 ++++++++++++++++++++++++
@@ -478,18 +487,20 @@ Revisions
 Revisions allow changes to a package without increasing the version number or overwriting the existing version number. They are disabled by default.
 
 There are two types of revisions:
-- "Recipe Revisions" (aka RREV) - Revision of the recipe and sources
-- "Package Revisions" (aka PREV) - Revision of a binary package
 
-Conan only holds one recipe revision in the local cache. Many recipe revisions can be stored in remote repositories. Recipe revisions can be specified wherever a recipe is consumed. If a recipe revision is not specified, the latest revision is used.
+- "Recipe Revisions" (RREV) - Revision of the recipe and sources
+- "Package Revisions" (PREV) - Revision of a binary package
 
-Recipe revisions are an extension to the recipe reference which consist by default of a hash generated from the recipe contents:
+The recipe revision (RREV) is a SHA-1 hash either calculated over the recipe, or taken from the version control system.
+Conan only holds one recipe revision in the local cache. Many recipe revisions can be stored in remote repositories.
+This helps differentiate between packages that have been changed and built without changing the version number. Recipe
+revisions can be specified wherever a recipe is consumed. If a recipe revision is not specified, the latest revision is
+used.
 
-.. code-block:: text
-
-    <package>/<version>@<user>/<channel>#<recipe_revision>
-    
-Package revisions are very rarely used directly by users in commands or configurations, because it's fairly impactical to do so.  Instead, they are generally managed by the use of "Lockfiles". 
+The package revision (PREV) is a SHA-1 hash calculated over the package contents. Package revisions provide the most
+precise identification for a built package. They are very rarely used directly by users in commands or configurations,
+because it's fairly impactical to do so.  Instead, they are generally managed by
+the use of "Lockfiles". 
 
 Enable revisions:
 

--- a/cheatsheet.rst
+++ b/cheatsheet.rst
@@ -174,7 +174,7 @@ Consuming packages
 Using packages in an application
 ++++++++++++++++++++++++++++++++
 
-1. Write a Conanfile.txt. This captures the project configuration:
+1. Write a conanfile.txt. This captures the project configuration:
 
 .. code-block:: text
 

--- a/index.rst
+++ b/index.rst
@@ -46,7 +46,6 @@ commitment to stability, with no breaking changes across all Conan 1.X versions.
    integrations
    configuration
    howtos
-   cheatsheet
    reference
    videos
    faq

--- a/index.rst
+++ b/index.rst
@@ -46,6 +46,7 @@ commitment to stability, with no breaking changes across all Conan 1.X versions.
    integrations
    configuration
    howtos
+   cheatsheet
    reference
    videos
    faq


### PR DESCRIPTION
The aim of this cheatsheet is to provide a reference for people who have already learnt Conan using some other method. It aims to quickly answer the question for such people: "how do I do xxx, again?". 

Sub-aims:

- reduce the need for memorizing common commands
- avoid more time-consuming usage of the docs where possible
- clarify the purpose of the commands and help users get a better intuition of their context.

It collates the information in the three [JFrog Academy tutorials](https://academy.jfrog.com/path/conan).

See https://github.com/conan-io/docs/issues/1726 for related discussion.

Thanks to @claremacrae and @solvingj for their contributions.