### PR TITLE
Add available since to generate feature

### DIFF
--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -1395,6 +1395,8 @@ generate()
 
     This is an **experimental** feature subject to breaking changes in future releases.
 
+Available since: `1.32.0 <https://github.com/conan-io/conan/releases/tag/1.32.0>`_
+
 This method will run after the computation and installation of the dependency graph. This means that it will
 run after a :command:`conan install` command, or when a package is being built in the cache, it will be run before
 calling the ``build()`` method.


### PR DESCRIPTION
New features should show which Conan version is required.

Related to #2087

`generate()` is listed on 1.32 changelog: https://docs.conan.io/en/latest/changelog.html#id126