### PR TITLE
add more layout packager details

### DIFF
--- a/reference/conanfile/tools/layout.rst
+++ b/reference/conanfile/tools/layout.rst
@@ -83,7 +83,7 @@ Here is the equivalent `package()` method:
 
 
 In the example above, we defined explicit values for the directories and
-patterns for illustration purposes. However, the many of the directories and
+patterns for illustration purposes. However, many of the directories and
 patterns have default values. So, here we show the equivalent `self.copy()`
 statements for the case where ``LayoutPackager.package()`` is used with the
 default values of `self.cpp` and `self.patterns`. 

--- a/reference/conanfile/tools/layout.rst
+++ b/reference/conanfile/tools/layout.rst
@@ -8,19 +8,9 @@ Available since: `1.37.0 <https://github.com/conan-io/conan/releases>`_
 LayoutPackager
 --------------
 
-The ``LayoutPackager`` together with the :ref:`package layouts<package_layout>` feature, allow to automatically
-package the files following the declared information in the ``layout()`` method:
-
-It will copy (being xxx => ``build`` and ``source`` (if destination is only one dir):
-
-- Files from ``self.cpp.xxx.includedirs`` to ``self.cpp.package.includedirs`` matching ``self.patterns.xxx.include`` patterns.
-- Files from ``self.cpp.xxx.libdirs`` to ``self.cpp.package.libdirs`` matching ``self.patterns.xxx.lib`` patterns.
-- Files from ``self.cpp.xxx.bindirs`` to ``self.cpp.package.bindirs`` matching ``self.patterns.xxx.bin`` patterns.
-- Files from ``self.cpp.xxx.srcdirs`` to ``self.cpp.package.srcdirs`` matching ``self.patterns.xxx.src`` patterns.
-- Files from ``self.cpp.xxx.builddirs`` to ``self.cpp.package.builddirs`` matching ``self.patterns.xxx.build`` patterns.
-- Files from ``self.cpp.xxx.resdirs`` to ``self.cpp.package.resdirs`` matching ``self.patterns.xxx.res`` patterns.
-- Files from ``self.cpp.xxx.frameworkdirs`` to ``self.cpp.package.frameworkdirs`` matching ``self.patterns.xxx.framework`` patterns.
-
+The ``LayoutPackager`` together with the :ref:`package layouts<package_layout>`
+feature, allow to automatically package the files following the declared
+information in the ``layout()`` method:
 
 Usage:
 
@@ -36,3 +26,78 @@ Usage:
 
             def package(self):
                 LayoutPackager(self).package()
+
+
+It works by going through all the directories under ``self.cpp.source`` and
+``self.cpp.build`` and copying files which match the patterns to the associated
+destination directories under ``self.cpp.package``. The ``LayoutPackager`` has a
+lot of assumptions baked in as defaults, which provides a lot of automatic
+behavior for convenience. However, let's provide an example to show what it will
+actually do. 
+
+Here, we'll show a fully-declared ``layout`` method, to be packaged using the
+``LayoutPackager`` class. Then, we'll show the equivalent ``self.copy()``
+statements that one would write in the ``package()`` method.
+
+Here is the fully-declared ``layout`` method:
+
+.. code:: python
+
+        def layout(self):
+        
+            # Declaring the roots of source and build directories
+            # Used during package(), and when making packages editable
+            self.folders.source = "src"
+            self.folders.build = "build"
+
+            # Declaring the layout of source and build directories
+            # Used during package(), and when making packages editable
+            self.cpp.source.includedirs = ["include"]
+            self.cpp.build.libdirs = ["build_subdir"]
+            self.cpp.build.bindirs = ["build_subdir"]
+            
+            # Declaring the patterns for files to-be-packaged
+            # Only used when copying files during package()
+            self.patterns.source.include = ["*.hpp"]
+            self.patterns.build.lib = ["*.lib"]
+            self.patterns.build.bin = ["*.dll"]
+
+
+            # Declaring the destination directories for the final package
+            # Only used when copying files during package()
+            self.cpp.package.includedirs = ["include"]
+            self.cpp.package.libdirs = ["lib"]
+            self.cpp.package.bindirs = ["bin"]
+            
+        def package(self):
+                LayoutPackager(self).package()
+   
+Here is the equivalent `package()` method:
+
+.. code:: python
+                
+        def package(self):
+            self.copy("*.hpp", src="src/include", dst="include")
+            self.copy("*.lib", src="build/build_subdir", dst="lib")
+            self.copy("*.dll", src="build/build_subdir", dst="bin")
+
+
+In the example above, we defined explicit values for the directories and
+patterns for illustration purposes. However, the many of the directories and
+patterns have default values. So, here we show the equivalent `self.copy()`
+statements for the case where ``LayoutPackager.package()`` is used with the
+default values of `self.cpp` and `self.patterns`. 
+
+.. code:: python
+
+            def package(self):
+                self.copy("*.h", src="include", dst="include")
+                self.copy("*.hpp", src=include", dst="include")
+                self.copy("*.hxx", src="include", dst="include")
+                self.copy("*.a", src=".", dst="lib")
+                self.copy("*.so", src=".", dst="lib")
+                self.copy("*.so.*", src=".", dst="lib")
+                self.copy("*.lib", src=".", dst="lib")
+                self.copy("*.dylib", src=".", dst="lib")
+                self.copy("*.dll", src=".", dst="bin")
+                self.copy("*.exe", src=".", dst="bin")


### PR DESCRIPTION
I was reading the documentation and trying to understand the `layouts()` feature in order to write the blog post.  One thing I noticed is that it feels difficult to comprehend all the implications of all the values one can set in layouts (at least for me).  

I think this makes sense and is a natural consequence of the tradeoffs we're chosing to make.  Previously, `self.copy()` had the nice property that the `src=` and `dest=` and `pattern=`  were all basically declared exactly where they were used. However, now that we've realized we need to use that information in other places, and compose that information in different ways, we needed to raise the level of abstraction. The unfortunate loss is that it will now be difficult to look at a recipe and determine what patterns will be copied from what directories.  You have to do the composition in your head, which looks like it's going to be exceptionally difficult because it's a matrix of root paths, sub-paths and patterns, and then doubled due to `cpp.source` and `cpp.build`.  

This PR is actually just an initial pass at helping people connect the dots. I think we need to spend quite a bit more effort making it "make sense". 
