### PR TITLE
Feature/conf cli support

### DIFF
--- a/reference/commands/consumer/info.rst
+++ b/reference/commands/consumer/info.rst
@@ -15,6 +15,7 @@ conan info
                  [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
                  [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                  [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                 [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                  path_or_reference
 
 Gets information about the dependency graph of a recipe.
@@ -116,6 +117,16 @@ your local cache.
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the
                             defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
+
 
 
 **Examples**:

--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -322,6 +322,24 @@ With the :command:`-o` parameters you can only define specific package options.
     You can use :ref:`profiles <profiles>` files to create predefined sets of **settings**,
     **options** and **environment variables**.
 
+conf
+----
+
+With the :command:`-c` parameters you can define specific package configurations.
+
+.. code-block:: bash
+
+    $ conan install . -c tools.microsoft.msbuild:verbosity=Diagnostic
+    $ conan install . -c core:required_conan_version>=1.34 -c tools.build:processes=10
+
+
+.. note::
+    To list all possible configurations available, run :command:`conan config list`.
+
+.. seealso::
+
+    You can see more information about configurations in :ref:`global.conf section <conan_cfg>`.
+
 
 reference
 ---------

--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -325,6 +325,10 @@ With the :command:`-o` parameters you can only define specific package options.
 conf
 ----
 
+.. warning::
+
+    This is an **experimental** feature subject to breaking changes in future releases.
+
 With the :command:`-c` parameters you can define specific package configurations.
 
 .. code-block:: bash

--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -338,7 +338,7 @@ With the :command:`-c` parameters you can define specific package configurations
 
 .. seealso::
 
-    You can see more information about configurations in :ref:`global.conf section <conan_cfg>`.
+    You can see more information about configurations in :ref:`global.conf section <global_conf>`.
 
 
 reference

--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -15,6 +15,7 @@ conan install
                     [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
                     [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                     [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                    [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                     [--lockfile-node-id LOCKFILE_NODE_ID]
                     path_or_reference [reference]
 
@@ -137,6 +138,15 @@ generators.
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the
                             defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       --lockfile-node-id LOCKFILE_NODE_ID
                             NodeID of the referenced package in the lockfile
 

--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -330,7 +330,7 @@ With the :command:`-c` parameters you can define specific package configurations
 .. code-block:: bash
 
     $ conan install . -c tools.microsoft.msbuild:verbosity=Diagnostic
-    $ conan install . -c core:required_conan_version>=1.34 -c tools.build:processes=10
+    $ conan install . -c tools.microsoft.msbuild:verbosity=Detailed -c tools.build:processes=10
 
 
 .. note::

--- a/reference/commands/creator/create.rst
+++ b/reference/commands/creator/create.rst
@@ -20,6 +20,7 @@ conan create
                    [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
                    [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                    [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                   [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                    path [reference]
 
 Builds a binary package for a recipe (conanfile.py).
@@ -143,6 +144,16 @@ to know more about 'test_folder' project.
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the
                             defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
+
 
 
 :command:`conan create . demo/testing` is equivalent to:

--- a/reference/commands/creator/export-pkg.rst
+++ b/reference/commands/creator/export-pkg.rst
@@ -13,8 +13,8 @@ conan export-pkg
                        [-e:h ENV_HOST] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
                        [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
                        [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
-                       [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
-                       [-s:h SETTINGS_HOST]
+                       [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                       [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                        path [reference]
 
 Exports a recipe, then creates a package from local source and build folders.
@@ -98,6 +98,15 @@ the binary package.
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the
                             defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
 
 
 The :command:`export-pkg` command let you create a package from already existing files

--- a/reference/commands/creator/test.rst
+++ b/reference/commands/creator/test.rst
@@ -11,8 +11,8 @@ conan test
                  [-e:b ENV_BUILD] [-e:h ENV_HOST] [-o OPTIONS_HOST]
                  [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
                  [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
-                 [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
-                 [-s:h SETTINGS_HOST]
+                 [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                 [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                  path reference
 
 Tests a package consuming it from a conanfile.py with a test() method.
@@ -110,6 +110,16 @@ to be tested must exist in the local cache or any configured remote.
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the
                             defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
+
 
 
 This command is useful for testing existing packages, that have been previously built (with :command:`conan create`, for example).

--- a/reference/commands/development/workspace.rst
+++ b/reference/commands/development/workspace.rst
@@ -39,6 +39,7 @@ conan workspace install
                               [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
                               [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                               [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                              [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                               [-if INSTALL_FOLDER]
                               path
 
@@ -109,6 +110,15 @@ conan workspace install
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the defaults (host
                             machine). e.g.: -s compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -if INSTALL_FOLDER, --install-folder INSTALL_FOLDER
                             Folder where the workspace files will be created (default to
                             current working directory)

--- a/reference/commands/misc/lock.rst
+++ b/reference/commands/misc/lock.rst
@@ -46,6 +46,7 @@ conan lock create
     $ conan lock create [-h] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--reference REFERENCE] [-l LOCKFILE] [--base]
                          [--lockfile-out LOCKFILE_OUT] [-b [BUILD]] [-r REMOTE] [-u] [-e ENV_HOST] [-e:b ENV_BUILD] [-e:h ENV_HOST] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
                          [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                         [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                          [path]
 
 
@@ -98,6 +99,16 @@ conan lock create
                             Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
+
 
 
 conan lock update

--- a/reference/profiles.rst
+++ b/reference/profiles.rst
@@ -134,6 +134,10 @@ They accept patterns too, like ``-s *@myuser/*``, which means that packages that
 Tools configurations
 --------------------
 
+.. warning::
+
+    This is an **experimental** feature subject to breaking changes in future releases.
+
 Tools configurations can also be used in profile files and *global.conf* one. Profile values will have priority over globally defined ones in *global.conf*, and can be defined as:
 
 .. code-block:: text

--- a/reference/profiles.rst
+++ b/reference/profiles.rst
@@ -151,7 +151,7 @@ Tools configurations can also be used in profile files and *global.conf* one. Pr
 
 .. seealso::
 
-    You can see more information about configurations in :ref:`global.conf section <conan_cfg>`.
+    You can see more information about configurations in :ref:`global.conf section <global_conf>`.
 
 
 Profile composition

--- a/reference/profiles.rst
+++ b/reference/profiles.rst
@@ -131,6 +131,29 @@ They accept patterns too, like ``-s *@myuser/*``, which means that packages that
         [env]
         PATH=[/some/path/to/my/tool]
 
+Tools configurations
+--------------------
+
+Tools configurations can also be used in profile files and *global.conf* one. Profile values will have priority over globally defined ones in *global.conf*, and can be defined as:
+
+.. code-block:: text
+
+    [settings]
+    ...
+
+    [conf]
+    tools.microsoft.msbuild:verbosity=Diagnostic
+    tools.microsoft.msbuild:max_cpu_count=20
+    tools.microsoft.msbuild:vs_version = 16
+    tools.build:processes=10
+    tools.ninja:jobs=30
+    tools.gnu.make:jobs=40
+
+.. seealso::
+
+    You can see more information about configurations in :ref:`global.conf section <conan_cfg>`.
+
+
 Profile composition
 -------------------
 


### PR DESCRIPTION
Added documentation related to new conan/feature: https://github.com/conan-io/conan/pull/9103

Added new parameter -c, --conf to provide inline configuration

```
  -c CONF_HOST, --conf CONF_HOST
                        Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
                        tools.cmake.cmaketoolchain:generator=Xcode
  -c:b CONF_BUILD, --conf:build CONF_BUILD
                        Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
                        tools.cmake.cmaketoolchain:generator=Xcode
  -c:h CONF_HOST, --conf:host CONF_HOST
                        Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
                        tools.cmake.cmaketoolchain:generator=Xcode
```

You can use these options for the following commands: export_pkg, test, create, install, info, workspace install and lock create