### PR TITLE
Fix bad link on FAQ

### DIFF
--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -264,4 +264,4 @@ Here we choose ``foo/1.3.0`` because is newer. Now we can proceed:
         [...]
         WARN: baz/1.0.0: requirement foo/1.0.0 overridden by foobar/1.0.0 to foo/1.3.0
 
-Conan still warns us about the conflict, but as we have [overridden](docs.conan.io/en/latest/versioning/introduction.html?#dependencies-overriding) the ``foo`` version, it's no longer an error.
+Conan still warns us about the conflict, but as we have :ref:`versioning_dependencies_overriding` the ``foo`` version, it's no longer an error.

--- a/versioning/introduction.rst
+++ b/versioning/introduction.rst
@@ -137,6 +137,8 @@ user decide which one.
 The same situation happens if the different packages require different configurations of the same upstream package, even if the same version is used. In the example above, both **PkgB** and **PkgC** can be requiring the same version **pkga/1.0**, but one of them will try to use it as a static library and the other one will try to use it as shared library.
 The dependency resolution algorithm will also raise an error.
 
+.. _versioning_dependencies_overriding:
+
 Dependencies overriding
 -----------------------
 
@@ -156,4 +158,3 @@ It is important to note and this point that versioning approaches and strategies
 consistent with the binary management.
 
 By default, Conan assumes *semver* compatibility, so it will not require to build a new binary for a package when its dependencies change their minor or patch versions. This might not be enough for C or C++ libraries which versioning scheme doesn't strictly follow semver. It is strongly suggested to read more about this in :ref:`define_abi_compatibility`
-


### PR DESCRIPTION
The current link: https://docs.conan.io/en/latest/faq/troubleshooting.html#error-incompatible-requirements-obtained-in-different-evaluations-of-requirements shows a bad markdown link to section in docs. This PR uses `:refs:` feature to avoid that situation.