### PR TITLE
Use validate instead of configure

### DIFF
--- a/devtools/create_installer_packages.rst
+++ b/devtools/create_installer_packages.rst
@@ -42,7 +42,7 @@ the ``nasm`` tool for building assembler:
        settings = "os", "arch"
        description="Nasm for windows. Useful as a build_require."
 
-       def configure(self):
+       def validate(self):
            if self.settings.os != "Windows":
                raise ConanInvalidConfiguration("Only windows supported for nasm")
 

--- a/mastering/conditional.rst
+++ b/mastering/conditional.rst
@@ -9,12 +9,12 @@ Remember, in your ``conanfile.py`` you can use the value of your options to:
 * Change values of other options
 * Assign values to options of your requirements
 
-The ``configure()`` method might be used to hardcode values for options of the requirements.
+The ``configure()`` method might be used to hardcoded values for options of the requirements.
 It is strongly discouraged to use it to change the settings values. Please remember that ``settings``
 are a configuration *input*, so it doesn't make sense to modify it in the recipes.
 
 Also, for options, a more flexible solution is to define dependencies options values in the ``default_options``,
-not in the ``configure()`` method. Setting the values in ``configure()`` won't allow to override them and it 
+not in the ``configure()`` method. Setting the values in ``configure()`` won't allow to override them and it
 will make really hard (even impossible) to resolve some conflicts. Use it only when it is absolutely
 necessary that the package dependencies use those options.
 
@@ -64,7 +64,7 @@ settings under development.
 
 There are two approaches for this situation:
 
-- **Use** ``configure()`` **to raise an error for non-supported configurations**:
+- **Use** ``validate()`` **to raise an error for non-supported configurations**:
 
   This approach is the first one evaluated when Conan loads the recipe so it is quite handy to perform checks of the input settings. It
   relies on the set of possible settings inside your *settings.yml* file, so it can be used to constrain any recipe.
@@ -73,7 +73,7 @@ There are two approaches for this situation:
 
       from conans.errors import ConanInvalidConfiguration
       ...
-      def configure(self):
+      def validate(self):
           if self.settings.os == "Windows":
             raise ConanInvalidConfiguration("This library is not compatible with Windows")
 

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -478,7 +478,7 @@ If the package options and settings are related, and you want to configure eithe
             # If header only, the compiler, etc, does not affect the package!
             if self.options.header_only:
                 self.settings.clear()
-                self.options.remove("static")
+                del self.options.static
 
 The package has 2 options set, to be compiled as a static (as opposed to shared) library, and also not to involve any builds, because
 header-only libraries will be used. In this case, the settings that would affect a normal build, and even the other option (static vs
@@ -520,12 +520,12 @@ Invalid configuration
 
 Conan allows the recipe creator to declare invalid configurations, those that are known not to work
 with the library being packaged. There is an especial kind of exception that can be raised from
-the ``configure()`` method to state this situation: ``conans.errors.ConanInvalidConfiguration``. Here
+the ``validate()`` method to state this situation: ``conans.errors.ConanInvalidConfiguration``. Here
 it is an example of a recipe for a library that doesn't support Windows operating system:
 
 .. code-block:: python
 
-    def configure(self):
+    def validate(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Library MyLib is only supported for Windows")
 

--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1752,7 +1752,7 @@ It raises a ``ConanInvalidConfiguration`` when is not supported.
     class Recipe(ConanFile):
         ...
 
-        def configure(self):
+        def validate(self):
             tools.check_min_cppstd(self, "17")
 
 * If the current cppstd does not support C++17, ``check_min_cppstd`` will raise an ``ConanInvalidConfiguration`` error.
@@ -1784,7 +1784,7 @@ It returns ``True`` when is valid, otherwise, ``False``.
     class Recipe(ConanFile):
         ...
 
-        def configure(self):
+        def validate(self):
             if not tools.valid_min_cppstd(self, "17"):
                 self.output.error("C++17 is required.")
 

--- a/systems_cross_building/cross_building.rst
+++ b/systems_cross_building/cross_building.rst
@@ -201,7 +201,7 @@ the build requires using the ``profile_build`` and then it will compile the libr
 settings applying the environment of the former ones.
 
 Starting with Conan v1.25 (if the user provides the ``--profile:build``) it is possible to get the relative context
-where a recipe is running during a Conan invocation. The object instatiated from the recipe contains the following
+where a recipe is running during a Conan invocation. The object instantiated from the recipe contains the following
 attributes:
 
 * ``self.settings`` will always contain the settings corresponding to the binary to build/retrieve. It will contain
@@ -211,7 +211,7 @@ attributes:
   recipe appears in the ``build`` context, the build requirements of the build requirements are expected to
   run in the ``build`` machine too.
 * ``self.settings_target``: for recipes in the ``host`` context this attribute will be equal to ``None``, for those
-  in the ``build`` context, if will depend on the level of anidation:
+  in the ``build`` context, if will depend on the level of validation:
 
   + for recipes that are build requirements of packages in the ``host`` context, this attribute will contain
     the settings from the profile ``profile_host``, while
@@ -229,7 +229,7 @@ With previous attributes, a draft for a recipe that packages a cross compiler co
         options = {"target": "ANY"}
         default_options = {"shared": False, "target": None}
 
-        def configure(self):
+        def validate(self):
             settings_target = getattr(self, 'settings_target', None)
             if settings_target is None:
                 # It is running in 'host', so Conan is compiling this package


### PR DESCRIPTION
The current documentation shows `ConanInvalidConfiguration` associated mainly to `configure` method. However, since Conan 1.32, the new method `validate` has been used for validation, which is well reflected on CCI.

As this is not clear in Docs, users still can [get confused](https://github.com/conan-io/conan-center-index/pull/6468#discussion_r678351314) about the correct usage.

This PR replaces `configure` by `validate` when assuming `ConanInvalidConfiguration` and `check_min_cppstd`. The difference between both is well explained [here](https://docs.conan.io/en/latest/reference/conanfile/methods.html#validate), so I believe this PR is clear enough in terms of need.