### PR TITLE
Fix typo in Conan toolchain filename

### DIFF
--- a/creating_packages/getting_started.rst
+++ b/creating_packages/getting_started.rst
@@ -105,11 +105,11 @@ Let's explain a little bit this recipe:
 
 - The ``generate()`` method prepares the build of the package from source. In this case, it could be simplified
   to an attribute ``generators = "CMakeToolchain"``, but it is left to show this important method. In this case,
-  the execution of ``CMakeToolchain`` ``generate()`` method will create a *conantoolchain.cmake* file that maps
+  the execution of ``CMakeToolchain`` ``generate()`` method will create a *conan_toolchain.cmake* file that maps
   the Conan ``settings`` and ``options`` to CMake syntax.
 
 - The ``build()`` method uses the ``CMake`` wrapper to call CMake commands, it is a thin layer that will manage
-  to pass in this case the ``-DCMAKE_TOOLCHAIN_FILE=conantoolchain.cmake`` argument. It will configure the
+  to pass in this case the ``-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake`` argument. It will configure the
   project and build it from source.
 
 - The ``package()`` method copies artifacts (headers, libs) from the build folder to the final

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -1407,7 +1407,7 @@ The purpose of ``generate()`` is to prepare the build, generating the necessary 
   Visual Studio property files.
 - Environment activation scripts, like ``conanbuildenv.bat`` or ``conanbuildenv.sh``, that define all the necessary environment
   variables necessary for the build.
-- Toolchain files, like ``conantoolchain.cmake``, that contains a mapping between the current Conan settings and options, and the
+- Toolchain files, like ``conan_toolchain.cmake``, that contains a mapping between the current Conan settings and options, and the
   build system specific syntax.
 - General purpose build information, as a ``conanbuild.conf`` file that could contain information like the CMake generator or
   CMake toolchain file to be used in the ``build()`` method.

--- a/reference/conanfile/tools/cmake/cmake.rst
+++ b/reference/conanfile/tools/cmake/cmake.rst
@@ -9,7 +9,7 @@ CMake
 
 The ``CMake`` build helper is a wrapper around the command line invocation of cmake. It will abstract the
 calls like ``cmake --build . --config Release`` into Python method calls. It will also add the argument
-``-DCMAKE_TOOLCHAIN_FILE=conantoolchain.cmake`` to the ``configure()`` call.
+``-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake`` to the ``configure()`` call.
 
 The helper is intended to be used in the ``build()`` method, to call CMake commands automatically
 when a package is being built directly by Conan (create, install)

--- a/reference/conanfile/tools/cmake/cmaketoolchain.rst
+++ b/reference/conanfile/tools/cmake/cmaketoolchain.rst
@@ -9,7 +9,7 @@ CMakeToolchain
 
 
 The ``CMakeToolchain`` is the toolchain generator for CMake. It will generate toolchain files that can be used in the
-command line invocation of CMake with the ``-DCMAKE_TOOLCHAIN_FILE=conantoolchain.cmake``. This generator translates
+command line invocation of CMake with the ``-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake``. This generator translates
 the current package configuration, settings, and options, into CMake toolchain syntax.
 
 


### PR DESCRIPTION
`conantoolchain.cmake` is actually `conan_toolchain.cmake`.