### PR TITLE
Updated conan.cmake URL to latest version

### DIFF
--- a/howtos/vs2017_cmake.rst
+++ b/howtos/vs2017_cmake.rst
@@ -108,7 +108,7 @@ configuration, that will match the Visual Studio one. This script can be used to
     # Download automatically, you can also just copy the conan.cmake file
     if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.9/conan.cmake"
+        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
                     "${CMAKE_BINARY_DIR}/conan.cmake")
     endif()
     


### PR DESCRIPTION
Version 0.14 of conan.cmake added support for Visual Studio 2019.  Updated URL to latest to avoid confusion for VS2019 users.