### PR TITLE
Generate conan 2.0-alpha docs

### DIFF
--- a/.ci/publish.jenkins
+++ b/.ci/publish.jenkins
@@ -41,7 +41,8 @@ Map<String, String> versions = [
         'release/1.6.1': '1.6',
         'release/1.5.2': '1.5',
         'release/1.4.5': '1.4',
-        'release/1.3.3': '1.3'
+        'release/1.3.3': '1.3',
+        'release/2.0.0-alpha': '2.0-alpha'
         ]
 
 node('Linux') {


### PR DESCRIPTION
This will generate the docs for `conan 2.0-alpha` from the `release/2.0.0-alpha` branch.
We have to improve ci pipelines now that we want to generate 2.0 and 1.0 docs at the same time, they are not prepared for doing that easily.
