### PR TITLE
- move cmake_find_package_multi generator to the top

### DIFF
--- a/integrations/build_system/cmake.rst
+++ b/integrations/build_system/cmake.rst
@@ -15,11 +15,11 @@ Conan can be integrated with CMake using different generators, build helpers and
 .. toctree::
    :maxdepth: 2
 
+   cmake/cmake_find_package_multi_generator
    cmake/cmake_generator
    cmake/cmake_multi_generator
    cmake/cmake_paths_generator
    cmake/cmake_find_package_generator
-   cmake/cmake_find_package_multi_generator
    cmake/build_automation
    cmake/find_packages
 


### PR DESCRIPTION
for newbies, it's not obvious what should be the reasonable default choice for the cmake generator amongst others:
- cmake
- cmake_multi
- cmake_paths
- cmake_find_package
- cmake_find_package_multi
- CMakeDeps

as we expect (most of) readers to read the documentation from the top to the bottom, IMO it's reasonable to place a default choice to the top rather to the very bottom.