### PR TITLE
- move cmake_find_package_multi generator to the top

### DIFF
--- a/reference/generators.rst
+++ b/reference/generators.rst
@@ -18,11 +18,11 @@ Available generators:
 .. toctree::
    :maxdepth: 1
 
+   generators/cmake_find_package_multi
    generators/cmake
    generators/cmakemulti
    generators/cmake_paths
    generators/cmake_find_package
-   generators/cmake_find_package_multi
    generators/msbuild
    generators/visualstudio
    generators/visualstudiomulti


### PR DESCRIPTION
for newbies, it's not obvious what should be the reasonable default choice for the cmake generator amongst others:
- cmake
- cmake_multi
- cmake_paths
- cmake_find_package
- cmake_find_package_multi
- CMakeDeps

as we expect (most of) readers to read the documentation from the top to the bottom, IMO it's reasonable to place a default choice to the top rather to the very bottom.