### PR TITLE
Docs for Support cmake_module_target_name and cmake_module_file_name in cmake_find_package

### DIFF
--- a/reference/conanfile/tools/cmake/cmakedeps.rst
+++ b/reference/conanfile/tools/cmake/cmakedeps.rst
@@ -155,6 +155,7 @@ Use the **build_context_build_modules** attribute to specify require names to in
     The ``build_context_build_modules`` feature will fail if no "build" profile is used. This feature only work when using
     the two host and build profiles.
 
+.. _CMakeDeps Properties:
 
 Properties
 ++++++++++

--- a/reference/conanfile/tools/gnu/pkgconfigdeps.rst
+++ b/reference/conanfile/tools/gnu/pkgconfigdeps.rst
@@ -8,6 +8,7 @@ PkgConfigDeps
 
     These tools are **experimental** and subject to breaking changes.
 
+.. _PkgConfigDeps Properties:
 
 PkgConfigDeps
 -------------


### PR DESCRIPTION
Docs for: https://github.com/conan-io/conan/pull/9832
Some refactoring of the docs related to `set/get_property`
Also marking names and filenames as deprecated from 1.42
