### PR TITLE
Fix the name of the parameter for the tools.cmake.CMake configure function

### DIFF
--- a/reference/conanfile/tools/cmake/cmake.rst
+++ b/reference/conanfile/tools/cmake/cmake.rst
@@ -65,7 +65,7 @@ configure()
 
 .. code:: python
 
-    def configure(self, source_folder=None):
+    def configure(self, build_script_folder=None):
 
 Calls ``cmake``, with the generator defined in the ``cmake_generator`` field of the
 ``conanbuild.conf`` file, and passing ``-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake``.
@@ -75,7 +75,7 @@ Calls ``cmake``, with the generator defined in the ``cmake_generator`` field of 
     If ``conanbuild.conf`` file is not there, Conan will raise an exception because it's a mandatory one even though it's empty.
 
 
-- ``source_folder``: Relative path to the folder containing the root *CMakeLists.txt*
+- ``build_script_folder``: Relative path to the folder containing the root *CMakeLists.txt*
 
 
 build()


### PR DESCRIPTION
The parameter name for tools.cmake.CMake's configure method is `build_script_folder` instead of `source_folder`.
See https://github.com/conan-io/conan/blob/ad42f722372e4ef9d57b4136f08140ac9641c680/conan/tools/cmake/cmake.py#L74