### PR TITLE
Limit docutils requirement to <0.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==1.7.9
-docutils==0.16
+docutils<0.18
 sphinx-sitemap>=2.1.0
 sphinxcontrib-spelling
 sphinx-notfound-page


### PR DESCRIPTION
Looks like version 0.18 [was making the ci](https://ci.conan.io/blue/organizations/jenkins/conan_docs/detail/develop/162/pipeline) fail, let's limit until we can investigate the issue.