### PR TITLE
Update ci.rst to with a warning about packages that set their own package ID mode overriding the default

### DIFF
--- a/versioning/lockfiles/ci.rst
+++ b/versioning/lockfiles/ci.rst
@@ -48,6 +48,10 @@ need to build a new binary because a new ``package_id`` will be computed.
 
     $ conan config set general.default_package_id_mode=full_version_mode
 
+This sets the *default* package ID mode.  Be aware, however, that if any of your packages provide their own 
+`package_id()` implementation, for example explicitly setting a different mode for a dependency, `full_version_mode` 
+might not be used for that package.
+
 This example will use version ranges, and it is not necessary to have revisions enabled. It also does not require
 a server, everything can be reproduced locally, although the usage of different repositories will be introduced.
 


### PR DESCRIPTION

We got burned by this as we had set `self.info.requires["MyOtherLib"].minor_mode()` in `package_id()` implementations of several of our packages to deal our lack of semver, and then later changed our config to a more agressive `[general]` `default_package_id_mode`=`package_version_mode` but found some expected package rebuilds weren't happening.

Related: https://github.com/conan-io/conan/issues/4640