### PR TITLE
updating the git link

### DIFF
--- a/using_packages/workflows.rst
+++ b/using_packages/workflows.rst
@@ -21,7 +21,7 @@ When working with a  single configuration, your conanfile will be quite simple a
 
 .. code-block:: bash
 
-    $ git clone git@github.com:conan-io/examples
+    $ git clone https://github.com/conan-io/examples.git
     $ cd libraries/poco
     $ conan install ./md5 --install-folder=md5_build
 


### PR DESCRIPTION
The existing command `git clone git@github.com:conan-io/examples` 
gave me an error: 
$ git clone git@github.com:conan-io/examples
Cloning into 'examples'...
`The authenticity of host 'github.com (140.82.121.3)' can't be established.
ECDSA key fingerprint is SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com,140.82.121.3' (ECDSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
`