### PR TITLE
Provide short git.checkout_submodules doc line

### DIFF
--- a/reference/tools.rst
+++ b/reference/tools.rst
@@ -1492,6 +1492,7 @@ Methods:
       e.g. `master`).
     - **checkout(element, submodule=None)**: Checkout a branch, commit or tag given by ``element``. Argument ``submodule`` can get values in
       ``shallow`` or ``recursive`` to instruct what to do with submodules.
+    - **checkout_submodules(submodule=None)**: Checkout submodules. Argument ``submodule`` can get values in ``shallow`` or ``recursive``.
     - **get_remote_url(remote_name=None)**: Returns the remote URL of the specified remote. If not ``remote_name`` is specified ``origin``
       will be used.
     - **get_qualified_remote_url()**: Returns the remote url (see ``get_remote_url()``) but with forward slashes if it is a local folder.


### PR DESCRIPTION
Hi!

I realised there's a missing line of documentation for a neat function in the `Git` helper tool.

Basically, I was looking for the most straightforward way to checkout submodules after a shallow clone. Luckily enough my IDE pointed me to `checkout_submodules`, which does the submodule checkout only, without duplicating checkout for root repository (as `checkout` would).

I would be happy to see this accepted, unless I am doing something horribly wrong, in which case I am open to criticism.

R.