### PR TITLE
Add tools.microsoft.msvc_runtime_flag

### DIFF
--- a/reference/conanfile/tools/microsoft.rst
+++ b/reference/conanfile/tools/microsoft.rst
@@ -346,7 +346,7 @@ conan.tools.microsoft.msvc_runtime_flag()
     def msvc_runtime_flag(conanfile):
 
 If the current compiler is ``Visual Studio``, ``msvc`` or ``intel-cc``, then detects the runtime type and returns between
-``MD``, ``MT``, ``MDd`` or ``MTd``, otherwise, returns ``None``.
+``MD``, ``MT``, ``MDd`` or ``MTd``, otherwise, returns ``""`` (empty string).
 When the runtime type is ``static``, it returns ``MT``, otherwise, ``MD``. The suffix ``d`` is added when running on Debug mode.
 
 Parameters:

--- a/reference/conanfile/tools/microsoft.rst
+++ b/reference/conanfile/tools/microsoft.rst
@@ -327,7 +327,6 @@ Parameters:
 
 - **conanfile**: ConanFile instance.
 
-
 .. code-block:: python
 
     from conan.tools.microsoft import is_msvc
@@ -335,3 +334,29 @@ Parameters:
     def validate(self):
         if not is_msvc(self):
             raise ConanInvalidConfiguration("Only supported by Visual Studio and msvc.")
+
+
+.. _conan_tools_microsoft_msvc_runtime_flag:
+
+conan.tools.microsoft.msvc_runtime_flag()
+-----------------------------------------
+
+.. code-block:: python
+
+    def msvc_runtime_flag(conanfile):
+
+If the current compiler is ``Visual Studio``, ``msvc`` or ``intel-cc``, then detects the runtime type and returns between
+``MD``, ``MT``, ``MDd`` or ``MTd``, otherwise, returns ``None``.
+When the runtime type is ``static``, it returns ``MT``, otherwise, ``MD``. The suffix ``d`` is added when running on Debug mode.
+
+Parameters:
+
+- **conanfile**: Conanfile instance.
+
+.. code-block:: python
+
+    from conan.tools.microsoft import msvc_runtime_flag
+
+    def validate(self):
+         if "MT" in msvc_runtime_flag(self):
+            self.output.warning("Runtime MT/MTd is not well tested.")


### PR DESCRIPTION
Available since Conan 1.35.0 and now stated to appear in Conan Center Index, not still not documented.

closes #2362 

![Screenshot 2022-01-19 at 19-26-49 conan tools microsoft — conan 1 44 1 documentation](https://user-images.githubusercontent.com/4870173/150192037-36709a29-3204-46b8-96a9-cd4096e8481b.png)
