### PR TITLE
self.cpp_info.builddirs defaults

### DIFF
--- a/conan_v2.rst
+++ b/conan_v2.rst
@@ -123,6 +123,19 @@ Conan won't alter any symlink while exporting or packaging files.
 If any manipulation to the symlinks is required, the package :ref:`conan.tools.files.symlinks<conan_tools_files_symlinks>`
 contains some tools to help with that.
 
+Default cpp_info.builddirs
+--------------------------
+
+The default root package folder (``self.cpp_info.builddirs = ['']``) has been removed. Also assign it
+will be discouraged because it affects how :ref:`CMakeToolchain<conan-cmake-toolchain>` and
+:ref:`CMakeDeps<CMakeDeps>` locate executables, libraries, headers... from the right context (host vs build).
+
+To be prepared for Conan 2.0:
+
+- If you are not assigning any ``self.cpp_info.builddirs`` assign an empty list: ``self.cpp_info.builddirs = []``.
+- Instead of appending new values to the default list, assign it: ``self.cpp_info.builddirs = ["cmake"]``
+
+
 .. _conanv2_properties_model:
 
 New properties model for the cpp_info in Conan 2.0 generators

--- a/conan_v2.rst
+++ b/conan_v2.rst
@@ -132,6 +132,8 @@ will be discouraged because it affects how :ref:`CMakeToolchain<conan-cmake-tool
 
 To be prepared for Conan 2.0:
 
+- If you have *cmake modules* or *cmake config files* at the root of the package, it is strongly recommended to move them
+  to a subfolder ``cmake`` and assing it: ``self.cpp_info.builddirs = ["cmake"]``
 - If you are not assigning any ``self.cpp_info.builddirs`` assign an empty list: ``self.cpp_info.builddirs = []``.
 - Instead of appending new values to the default list, assign it: ``self.cpp_info.builddirs = ["cmake"]``
 


### PR DESCRIPTION
Not really for 1.45, but can be merged anytime after https://github.com/conan-io/conan/pull/10394