### PR TITLE
Fix broken links in documentation

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -393,7 +393,7 @@ epub_exclude_files = ['search.html']
 #epub_use_index = True
 
 # A list of regular expressions that match URIs that should not be checked when doing a linkcheck build.
-linkcheck_ignore = [r'http://localhost:\d+', r'https://github.com/conan-io/conan/pull/\d+', r'https://github.com/conan-io/docs/pull/\d+']
+linkcheck_ignore = [r'http://localhost:\d+', r'https://github.com/conan-io/conan/pull/\d+', r'https://github.com/conan-io/docs/pull/\d+', 'https://conan.bintray.com']
 linkcheck_workers = 15
 linkcheck_timeout = 90
 linkcheck_retries = 2

--- a/reference/conanfile/tools/intel.rst
+++ b/reference/conanfile/tools/intel.rst
@@ -23,7 +23,7 @@ This tool helps you to manage the new Intel oneAPI `DPC++/C++ <https://software.
 
 .. note::
 
-    Remember, you need to have installed previously the `Intel oneAPI software <https://software.intel.com/content/www/us/en/develop/tools/oneapi/all-toolkits.html#gs.cgeofk>`_.
+    Remember, you need to have installed previously the `Intel oneAPI software <https://software.intel.com/content/www/us/en/develop/tools/oneapi/all-toolkits.html>`_.
 
 .. note::
 


### PR DESCRIPTION
```
(line  278) broken    https://conan.bintray.com/ - HTTPSConnectionPool(host='[conan.bintray.com](http://conan.bintray.com/)', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:997)')))
(line   26) broken    https://software.intel.com/content/www/us/en/develop/tools/oneapi/all-toolkits.html#gs.cgeofk - Anchor 'gs.cgeofk' not found
```