### PR TITLE
Publish docs if merged to pre-release branch

### DIFF
--- a/.ci/test.jenkins
+++ b/.ci/test.jenkins
@@ -2,7 +2,9 @@
 
 node('Linux') {
     String masterBranch = 'master'
+    String preReleaseBranch = 'release/2.0.0-alpha'
     boolean isMaster = env.BRANCH_NAME == masterBranch
+    boolean isPreRelease = env.BRANCH_NAME == preReleaseBranch
 
     stage('Clone sources') {
         checkout scm
@@ -44,8 +46,8 @@ node('Linux') {
         }
     }
 
-    // 'master' branch is published to GH pages
-    if (isMaster) {
+    // Publish docs when we merge to master or the pre-release branch
+    if (isMaster || isPreRelease) {
         build(job: 'Conan-Docs-Publish', propagate: true, wait: true, parameters: [
             [$class: 'StringParameterValue', name: 'latest', value: masterBranch],
             [$class: 'StringParameterValue', name: 'prefix', value: 'https://docs.conan.io/'],


### PR DESCRIPTION
Now, if we merge anything to the pre-release branch (currently `release/2.0.0-alpha`) it will be automatically published...