### PR TITLE
Fix typo in self.cpp documentation.

### DIFF
--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -1510,7 +1510,7 @@ self.cpp
 The ``layout()`` method allows to declare ``cpp_info`` objects not only for the final package (like the classic approach with
 the ``self.cpp_info`` in the ``package_info(self)`` method) but for the ``self.source_folder`` and ``self.build_folder``.
 
-The fields of the cpp_info objects at ``self.info.build`` and ``self.info.source`` are the same described :ref:`here<cpp_info_attributes_reference>`.
+The fields of the cpp_info objects at ``self.cpp.build`` and ``self.cpp.source`` are the same described :ref:`here<cpp_info_attributes_reference>`.
 Components are also supported.
 
 


### PR DESCRIPTION
The `self.cpp` documentation refers to `self.info` in one sentence.