### PR TITLE
Fix CLI example for creating a new package from a template

### DIFF
--- a/tutorial/creating_packages/getting_started.rst
+++ b/tutorial/creating_packages/getting_started.rst
@@ -21,7 +21,7 @@ Using the :command:`conan new` command will create a "Hello World" C++ library e
 .. code-block:: bash
 
     $ mkdir hellopkg && cd hellopkg
-    $ conan new hello/0.1 --template=cmake_lib
+    $ conan new cmake_lib --name=hello --version=0.1
     File saved: CMakeLists.txt
     File saved: conanfile.py
     File saved: src/hello.cpp


### PR DESCRIPTION
The command line as is produces this error:
```
conan new: error: unrecognized arguments: --template=cmake_lib
```

I had to read the code to figure out what the problem was. In particular, the command `conan new cmake_lib` produces a cryptic error form Jinja. It would be good to have a better error output from the command as well.