### PR TITLE
Renamed all the base_source_folder -> export_sources_folder

### DIFF
--- a/developing_packages/package_layout.rst
+++ b/developing_packages/package_layout.rst
@@ -443,8 +443,8 @@ also able to locate the ``my_tool`` correctly, because it is using the same ``fo
 
 
 
-Example: base_source_folder
----------------------------
+Example: export_sources_folder
+-------------------------------
 
 If we have this project, intended to create a package for a third party library which code is located externally:
 
@@ -475,19 +475,19 @@ The ``conanfile.py`` would look like this:
           def source(self):
               # we are inside a "src" subfolder, as defined by layout
               # download something, that will be inside the "src" subfolder
-              base_source = self.base_source_folder
+              base_source = self.export_sources_folder
               # access to paches and CMakeLists, to apply them, replace files is done with:
               mypatch_path = os.path.join(base_source, "patches/mypatch")
               cmake_path = os.path.join(base_source, "CMakeLists.txt")
               # patching, replacing, happens here
 
           def build(self):
-              # If necessary, the build() method also has access to the base_source_folder
+              # If necessary, the build() method also has access to the export_sources_folder
               # for example if patching happens in build() instead of source()
-              cmake_path = os.path.join(self.base_source_folder, "CMakeLists.txt")
+              cmake_path = os.path.join(self.export_sources_folder, "CMakeLists.txt")
 
 
-We can see that the ``Conanfile.base_source_folder`` can provide access to the root folder of the sources:
+We can see that the ``Conanfile.export_sources_folder`` can provide access to the root folder of the sources:
 
 - Locally it will be the folder where the conanfile.py lives
 - In the cache it will be the "source" folder, that will contain a copy of ``CMakeLists.txt`` and ``patches``,

--- a/developing_packages/package_layout.rst
+++ b/developing_packages/package_layout.rst
@@ -475,10 +475,9 @@ The ``conanfile.py`` would look like this:
           def source(self):
               # we are inside a "src" subfolder, as defined by layout
               # download something, that will be inside the "src" subfolder
-              base_source = self.export_sources_folder
               # access to paches and CMakeLists, to apply them, replace files is done with:
-              mypatch_path = os.path.join(base_source, "patches/mypatch")
-              cmake_path = os.path.join(base_source, "CMakeLists.txt")
+              mypatch_path = os.path.join(self.export_sources_folder, "patches/mypatch")
+              cmake_path = os.path.join(self.export_sources_folder, "CMakeLists.txt")
               # patching, replacing, happens here
 
           def build(self):

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -722,7 +722,7 @@ Exclude patterns are also possible, with the ``!`` prefix:
 Note, if the recipe defines the ``layout()`` method and specifies a ``self.folders.source = "src"`` it won't affect
 where the files (from the ``exports_sources``) are copied. They will be copied to the base source folder. So, if you
 want to replace some file that got into the ``source()`` method, you need to explicitly copy it from the parent folder
-or even better, from ``self.base_source_folder``.
+or even better, from ``self.export_sources_folder``.
 
 
 .. code-block:: python
@@ -744,7 +744,7 @@ or even better, from ``self.base_source_folder``.
           save(self, "CMakeLists.txt", "MISTAKE: Very old CMakeLists to be replaced")
           # Now I fix it with one of the exported files
           shutil.copy("../CMakeLists.txt", ".")
-          shutil.copy(os.path.join(self.base_source_folder, "CMakeLists.txt", "."))
+          shutil.copy(os.path.join(self.export_sources_folder, "CMakeLists.txt", "."))
 
 
 

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -1381,7 +1381,7 @@ The current folder (``os.getcwd()``) and the ``self.export_sources_folder`` can 
             save(os.path.join(self.export_sources_folder, "myfile.txt"), content)
 
 Note, if the recipe defines the ``layout()`` method and specifies a ``self.folders.source = "src"`` it won't change the
-current folder in the ``export_sources`` method. The current dir will be the base source folder (``self.base_source_folder``).
+current folder in the ``export_sources`` method. The current dir will be the base source folder (``self.export_sources_folder``).
 
 The ``self.copy`` support ``src`` and ``dst`` subfolder arguments. The ``src`` is relative to the
 current folder (the one containing the *conanfile.py*). The ``dst`` is relative to the cache

--- a/reference/conanfile/tools/files/patches.rst
+++ b/reference/conanfile/tools/files/patches.rst
@@ -18,7 +18,7 @@ Parameters:
 
 - **patch_file**: Patch file that should be applied. The path is relative to the **conanfile.source_folder** unless
   an absolute path is provided.
-- **base_path**: The path is a relative path to **conanfile.base_source_folder** unless an absolute path is provided.
+- **base_path**: The path is a relative path to **conanfile.export_sources_folder** unless an absolute path is provided.
 - **patch_string**: Patch string that should be applied.
 - **strip**: Number of folders to be stripped from the path.
 - **output**: Stream object.


### PR DESCRIPTION
Docs for https://github.com/conan-io/conan/pull/11055

_Coming from the original Conan PR https://github.com/conan-io/conan/pull/11055:_

> Changelog: Fix: Renamed self.base_source_folder to self.export_source_folder. That variable was introduced to reference the folder where the export_sources are. Currently, they are copied to the source folder but might be changed in the future to avoid copying them, so self.export_source_folder will always point to the exports_sources.
