### PR TITLE
Fix ci spelling step

### DIFF
--- a/.ci/test.jenkins
+++ b/.ci/test.jenkins
@@ -38,6 +38,7 @@ node('Linux') {
         },
         spelling: {
             image.inside {
+                sh(script: 'pip3 install colorama')
                 sh(script: 'make spelling')
             }
         },


### PR DESCRIPTION
For some reason the spelling step needs the colorama dependency that looks like can't be mocked for autodoc. Let's fix this for the moment and investigate in the future.