### PR TITLE
New cppinfo defaults for components and root cpp_info when 2.0 mode

### DIFF
--- a/migrating_to_2.0/recipes.rst
+++ b/migrating_to_2.0/recipes.rst
@@ -401,32 +401,27 @@ The ``self.copy`` has been replaced by the explicit tool :ref:`copy<conan_tools_
         copy(self, "*.lib", self.build_folder, join(self.package_folder, "lib"), keep_path=False)
         copy(self, "*.dll", self.build_folder, join(self.package_folder, "bin"), keep_path=False)
 
-
+.. _conan2_migration_guide_recipes_package_info:
 
 The package_info() method
 -------------------------
 
-Removed cpp_info defaults in components
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changed cpp_info default values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are some defaults in the general ``self.cpp_info`` object:
+There are some defaults in ``self.cpp_info`` object that are not the same in Conan 2.X than in Conan 1.X (except
+for ``Conan >= 1.50`` if the ``layout()`` method is declared):
 
 .. code-block:: text
 
     self.cpp_info.includedirs => ["include"]
     self.cpp_info.libdirs => ["lib"]
-    self.cpp_info.resdirs => ["res"]
+    self.cpp_info.resdirs => []
     self.cpp_info.bindirs => ["bin"]
     self.cpp_info.builddirs => []
-    self.cpp_info.frameworkdirs => ["Frameworks"]
+    self.cpp_info.frameworkdirs => []
 
-If you declare components, you need to explicitly specify these directories, because by default are empty:
-
-.. code-block:: python
-
-    def cpp_info(self):
-        self.cpp_info.components["mycomponent"].includedirs = ["my_include"]
-        self.cpp_info.components["myothercomponent"].bindirs = ["myother_bin"]
+If you declare components, the defaults are the same, so you only need to change the defaults if they are not correct.
 
 
 .. note::

--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -963,67 +963,74 @@ library names, library paths... There are some default values that will be appli
 
 This object should be filled in ``package_info()`` method.
 
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| NAME                                 | DESCRIPTION                                                                                             |
-+======================================+=========================================================================================================+
-| self.cpp_info.includedirs            | Ordered list with include paths. Defaulted to ``["include"]``                                           |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.libdirs                | Ordered list with lib paths. Defaulted to ``["lib"]``                                                   |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.resdirs                | Ordered list of resource (data) paths. Defaulted to ``["res"]``                                         |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.bindirs                | Ordered list with paths to binaries (executables, dynamic libraries,...). Defaulted to ``["bin"]``      |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.builddirs              | | Ordered list with build scripts directory paths. Defaulted to ``[""]`` (Package folder directory)     |
-|                                      | | CMake generators will search in these dirs for files like *findXXX.cmake*                             |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.libs                   | Ordered list with the library names, Defaulted to ``[]`` (empty)                                        |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.defines                | Preprocessor definitions. Defaulted to ``[]`` (empty)                                                   |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cflags                 | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                             |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cppflags               | [DEPRECATED: Use cxxflags instead]                                                                      |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.cxxflags               | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.sharedlinkflags        | Ordered list with linker flags (shared libs). Defaulted to ``[]`` (empty)                               |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.exelinkflags           | Ordered list with linker flags (executables). Defaulted to ``[]`` (empty)                               |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.frameworks             | Ordered list with the framework names (OSX), Defaulted to ``[]`` (empty)                                |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.frameworkdirs          | Ordered list with frameworks search paths (OSX). Defaulted to ``["Frameworks"]``                        |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.rootpath               | Filled with the root directory of the package, see ``deps_cpp_info``                                    |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.name                   | **[DEPRECATED]** Use ``self.cpp_info.names`` instead.                                                   |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.names["generator"]     | | Alternative name for the package used by an specific generator to create files or variables.          |
-|                                      | | If set for a generator it will override the information provided by self.cpp_info.name.               |
-|                                      | | Like the cpp_info.name, this is only supported by `cmake`, `cmake_multi`, `cmake_find_package`,       |
-|                                      | | `cmake_find_package_multi`, `cmake_paths` and `pkg_config` generators.                                |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.filenames["generator"] | | Alternative name for the filename produced by a specific generator. If set for a generator it will    |
-|                                      | | override the "names" value. This is only supported by the `cmake_find_package` and                    |
-|                                      | | `cmake_find_package_multi` generators.                                                                |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.system_libs            | Ordered list with the system library names. Defaulted to ``[]`` (empty)                                 |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.build_modules          | | Dictionary of lists per generator containing relative paths to build system related utility module    |
-|                                      | | files created by the package. Used by CMake generators to export *.cmake* files with functions for    |
-|                                      | | consumers. Defaulted to ``{}`` (empty)                                                                |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.components             | | **[Experimental]** Dictionary with different components a package may have: libraries, executables... |
-|                                      | | **Warning**: Using components with other ``cpp_info`` non-default values or configs is not supported  |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.requires               | | **[Experimental]** List of components to consume from requirements (it applies only to                |
-|                                      | | generators that implements components feature).                                                       |
-|                                      | | **Warning**: If declared, only the components listed here will used by the linker and consumers.      |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
-| self.cpp_info.objects                | | **[Experimental]** List of object libraries (*.obj* or *.o*). Defaulted to ``[]`` (empty)             |
-|                                      | | Only supported by new :ref:`CMakeDeps<conan_tools_cmake>` generator                                   |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------+
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| NAME                                 | DESCRIPTION                                                                                                          |
++======================================+======================================================================================================================+
+| self.cpp_info.includedirs            | Ordered list with include paths. Defaulted to ``["include"]``                                                        |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.libdirs                | Ordered list with lib paths. Defaulted to ``["lib"]``                                                                |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.resdirs                | Ordered list of resource (data) paths. Defaulted to ``["res"]``. If layout() is declared, defaulted to ``[]`` \*     |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.bindirs                | Ordered list with paths to binaries (executables, dynamic libraries,...). Defaulted to ``["bin"]``                   |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.builddirs              | | Ordered list with build scripts directory paths. Defaulted to ``[""]`` (Package folder directory)                  |
+|                                      | | CMake generators will search in these dirs for files like *findXXX.cmake*                                          |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.libs                   | Ordered list with the library names, Defaulted to ``[]`` (empty)                                                     |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.defines                | Preprocessor definitions. Defaulted to ``[]`` (empty)                                                                |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cflags                 | Ordered list with pure C flags. Defaulted to ``[]`` (empty)                                                          |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cppflags               | [DEPRECATED: Use cxxflags instead]                                                                                   |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.cxxflags               | Ordered list with C++ flags. Defaulted to ``[]`` (empty)                                                             |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.sharedlinkflags        | Ordered list with linker flags (shared libs). Defaulted to ``[]`` (empty)                                            |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.exelinkflags           | Ordered list with linker flags (executables). Defaulted to ``[]`` (empty)                                            |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.frameworks             | Ordered list with the framework names (OSX), Defaulted to ``[]`` (empty)                                             |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.frameworkdirs          | Ordered list with frameworks search paths (OSX). Defaulted to ``["Frameworks"]`` or ``[]`` if layout() is declared \*|
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.rootpath               | Filled with the root directory of the package, see ``deps_cpp_info``                                                 |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.name                   | **[DEPRECATED]** Use ``self.cpp_info.names`` instead.                                                                |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.names["generator"]     | | Alternative name for the package used by an specific generator to create files or variables.                       |
+|                                      | | If set for a generator it will override the information provided by self.cpp_info.name.                            |
+|                                      | | Like the cpp_info.name, this is only supported by `cmake`, `cmake_multi`, `cmake_find_package`,                    |
+|                                      | | `cmake_find_package_multi`, `cmake_paths` and `pkg_config` generators.                                             |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.filenames["generator"] | | Alternative name for the filename produced by a specific generator. If set for a generator it will                 |
+|                                      | | override the "names" value. This is only supported by the `cmake_find_package` and                                 |
+|                                      | | `cmake_find_package_multi` generators.                                                                             |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.system_libs            | Ordered list with the system library names. Defaulted to ``[]`` (empty)                                              |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.build_modules          | | Dictionary of lists per generator containing relative paths to build system related utility module                 |
+|                                      | | files created by the package. Used by CMake generators to export *.cmake* files with functions for                 |
+|                                      | | consumers. Defaulted to ``{}`` (empty)                                                                             |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.components             | | **[Experimental]** Dictionary with different components a package may have: libraries, executables...              |
+|                                      | | **Warning**: Using components with other ``cpp_info`` non-default values or configs is not supported               |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.requires               | | **[Experimental]** List of components to consume from requirements (it applies only to                             |
+|                                      | | generators that implements components feature).                                                                    |
+|                                      | | **Warning**: If declared, only the components listed here will used by the linker and consumers.                   |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| self.cpp_info.objects                | | **[Experimental]** List of object libraries (*.obj* or *.o*). Defaulted to ``[]`` (empty)                          |
+|                                      | | Only supported by new :ref:`CMakeDeps<conan_tools_cmake>` generator                                                |
++--------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+   (*) If the ``layout()`` is declared, for Conan >= 1.50, the default values for ``self.cpp_info.frameworkdirs`` and ``self.cpp_info.resdirs``
+   change to ``[]``, being a way to migrate to Conan 2.0, where the default values for these field changed. Read more in the
+   :ref:`migration guide<conan2_migration_guide_recipes_package_info>`.
+
 
 The paths of the directories in the directory variables indicated above are relative to the
 :ref:`self.package_folder<folders_attributes_reference>` directory.


### PR DESCRIPTION
Docs for https://github.com/conan-io/conan/pull/11471