### PR TITLE
Add file:/// handling in download tool

### DIFF
--- a/reference/conanfile/tools/files/downloads.rst
+++ b/reference/conanfile/tools/files/downloads.rst
@@ -90,6 +90,8 @@ Parameters:
 
 - **conanfile** (Required): Conanfile object, use ``self`` always
 - **url** (Required): URL to download. It can be a list, which only the first one will be downloaded, and the follow URLs will be used as mirror in case of download error.
+                      Files accessible in the local filesystem can be referenced with a URL starting with ``file:///`` followed by the file path
+                      (where the third ``/`` implies ``localhost``).
 - **filename** (Required): Name of the file to be created in the local storage
 - **verify** (Optional, Defaulted to ``True``): When False, disables https certificate validation.
 - **retry** (Optional, Defaulted to ``1``): Number of retries in case of failure.
@@ -127,9 +129,13 @@ Examples:
     # Download and check file checksum
     download(self, "http://someurl/somefile.zip", "myfilename.zip", md5="e5d695597e9fa520209d1b41edad2a27")
 
+    # Retrieve file that is visible in the local filesystem
+    tools.download("file:///home/myuser/downloads/somefile.zip", "myfilename.zip", md5="e5d695597e9fa520209d1b41edad2a27")
+
     # to add mirrors
     download(self, ["https://ftp.gnu.org/gnu/gcc/gcc-9.3.0/gcc-9.3.0.tar.gz",
-                    "http://mirror.linux-ia64.org/gnu/gcc/releases/gcc-9.3.0/gcc-9.3.0.tar.gz"],
+                    "http://mirror.linux-ia64.org/gnu/gcc/releases/gcc-9.3.0/gcc-9.3.0.tar.gz",
+                    "file:///home/myuser/localmirror/gcc-9.3.0/gcc-9.3.0.tar.gz"],
                     "gcc-9.3.0.tar.gz",
                    sha256="5258a9b6afe9463c2e56b9e8355b1a4bee125ca828b8078f910303bc2ef91fa6")
 

--- a/reference/conanfile/tools/files/downloads.rst
+++ b/reference/conanfile/tools/files/downloads.rst
@@ -90,7 +90,7 @@ Parameters:
 
 - **conanfile** (Required): Conanfile object, use ``self`` always
 - **url** (Required): URL to download. It can be a list, which only the first one will be downloaded, and the follow URLs will be used as mirror in case of download error.
-                      Files accessible in the local filesystem can be referenced with a URL starting with ``file:///`` followed by the file path
+                      Files accessible in the local filesystem can be referenced with a URL starting with ``file:///`` followed by an absolute path to a file
                       (where the third ``/`` implies ``localhost``).
 - **filename** (Required): Name of the file to be created in the local storage
 - **verify** (Optional, Defaulted to ``True``): When False, disables https certificate validation.
@@ -130,6 +130,7 @@ Examples:
     download(self, "http://someurl/somefile.zip", "myfilename.zip", md5="e5d695597e9fa520209d1b41edad2a27")
 
     # Retrieve file that is visible in the local filesystem
+    tools.download("file:///C:/Users/MyUser/Downloads/somefile.zip", "myfilename.zip", md5="e5d695597e9fa520209d1b41edad2a27")
     tools.download("file:///home/myuser/downloads/somefile.zip", "myfilename.zip", md5="e5d695597e9fa520209d1b41edad2a27")
 
     # to add mirrors


### PR DESCRIPTION
Docs for https://github.com/conan-io/conan/pull/11569

Ability for `conan.tools.files.get()`  and `conan.tools.files.download()` to retrieve files from the local filesystem referenced with a `file:///` URI.

