### PR TITLE
[bug] get_cpus is not supporting cgroup2 #11635

### DIFF
--- a/reference/conanfile/tools/build.rst
+++ b/reference/conanfile/tools/build.rst
@@ -98,3 +98,30 @@ Parameters:
 - **conanfile**: The current recipe object. Always use ``self``.
 - **compiler**: Name of the compiler e.g: gcc
 - **compiler_version**: Version of the compiler e.g: 12
+
+
+conan.tools.build.build_jobs()
+------------------------------
+
+.. code-block:: python
+
+    def build_jobs(conanfile):
+
+
+
+Returns the number of CPUs available for parallel builds.
+It returns the configuration value for ``tools.build:jobs`` if exists, otherwise,
+it defaults to the helper function ``_cpu_count()``.
+``_cpu_count()`` reads cgroup to detect the configured number of CPUs.
+Currently, there are two versions of cgroup available.
+
+In the case of cgroup v1, if the data in cgroup is invalid, processor detection comes into play.
+Whenever processor detection is not enabled, ``build_jobs()`` will safely return 1.
+
+In the case of cgroup v2, if no limit is set, processor detection is used. When the limit is set,
+the behavior is as described in cgroup v1.
+
+
+Parameters:
+
+- **conanfile**: The current recipe object. Always use ``self``.


### PR DESCRIPTION
Docs for: https://github.com/conan-io/conan/pull/11667

Documents the changes made for the cgroupv2 support in the `cpu_count()` function.