### PR TITLE
[videos] ACCU 2022: Advanced Dependencies Model in Conan 2.0

### DIFF
--- a/videos.rst
+++ b/videos.rst
@@ -14,6 +14,15 @@
 Videos and links
 =================
 
+- ACCU 2022: Advanced Dependencies Model in Conan 2.0 C, C++ Package Manager by Diego Rodriguez-Losada
+
+  .. raw:: html
+
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/kKGglzm5ous" frameborder="0" allow="autoplay; encrypted-media; allowfullscreen>
+      </iframe>
+
+      <br/><br/>
+
 
 - Conan in Practice: Interactive Exercises of common commands
 


### PR DESCRIPTION
Add video entry related to Diego's presentation about Conan 2.0 at ACCU 2022.

Preview:

![Screenshot 2022-07-28 at 09-00-32 Videos and links — conan 1 50 0 documentation](https://user-images.githubusercontent.com/4870173/181441662-06ecb652-e0ae-429d-9a4f-d7b3f05f0958.png)

