### PR TITLE
add "available since" to all functions & classes in conan.tools & fix few links

### DIFF
--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -643,7 +643,7 @@ validate_build()
 
     This is an **experimental** feature subject to breaking changes in future releases.
 
-Available since: `1.51.0 <https://github.com/conan-io/conan/releases/tag/1.41.0>`_
+Available since: `1.51.0 <https://github.com/conan-io/conan/releases/tag/1.51.0>`_
 
 The ``validate_build()`` method is used to verify if a configuration is valid for building a package. It is different
 from the ``validate()`` method that checks if the binary package is "impossible" or invalid for a given configuration.
@@ -1516,7 +1516,7 @@ layout()
     (:ref:`in the conan.tools space <conan_tools>`). If you are using other integrations, they
     might not fully support this feature.
 
-Available since: `1.37.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.37.0 <https://github.com/conan-io/conan/releases/tag/1.37.0>`_
 
 Read about the feature :ref:`here<package_layout>`.
 

--- a/reference/conanfile/tools/apple.rst
+++ b/reference/conanfile/tools/apple.rst
@@ -13,7 +13,7 @@ conan.tools.apple
 XcodeDeps
 ---------
 
-Available since: `1.42.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.42.0 <https://github.com/conan-io/conan/releases/tag/1.42.0>`_
 
 The ``XcodeDeps`` tool is the dependency information generator for *Xcode*. It will generate multiple
 *.xcconfig* configuration files, the can be used by consumers using *xcodebuild* or *Xcode*. To use
@@ -104,7 +104,7 @@ If you want to add this dependencies to you Xcode project, you just have to add 
 Components support
 ++++++++++++++++++
 
-Since Conan version `1.49.0 <https://github.com/conan-io/conan/releases>`_, this generator
+Since Conan version `1.49.0 <https://github.com/conan-io/conan/releases/tag/1.49.0>`_, this generator
 supports packages with components. That means that:
 
 * If a **dependency** ``package_info()`` declares ``cpp_info.requires`` on some
@@ -151,7 +151,7 @@ want to link with shared or static libraries.
 XcodeToolchain
 --------------
 
-Available since: `1.46.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 The ``XcodeToolchain`` is the toolchain generator for Xcode. It will generate *.xcconfig*
 configuration files that can be added to Xcode projects. This generator translates the
@@ -260,7 +260,7 @@ file.
 XcodeBuild
 ----------
 
-Available since: `1.46.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 The ``Xcode`` build helper is a wrapper around the command line invocation of Xcode. It
 will abstract the calls like ``xcodebuild -project app.xcodeproj -configuration <config>
@@ -327,6 +327,8 @@ conf
 
 conan.tools.apple.fix_apple_shared_install_name()
 -------------------------------------------------
+
+Available since: `1.49.0 <https://github.com/conan-io/conan/releases/tag/1.49.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/build.rst
+++ b/reference/conanfile/tools/build.rst
@@ -6,6 +6,8 @@ conan.tools.build
 conan.tools.build.cross_building()
 ----------------------------------
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
+
 .. code-block:: python
 
     def cross_building(conanfile=None, skip_x64_x86=False):
@@ -25,6 +27,8 @@ Parameters:
 conan.tools.build.can_run()
 ---------------------------
 
+Available since: `1.49.0 <https://github.com/conan-io/conan/releases/tag/1.49.0>`_
+
 .. code-block:: python
 
     def can_run(conanfile):
@@ -43,6 +47,7 @@ Parameters:
 conan.tools.build.check_min_cppstd
 ----------------------------------
 
+Available since: `1.50.0 <https://github.com/conan-io/conan/releases/tag/1.50.0>`_
 
 .. code-block:: python
 
@@ -61,6 +66,8 @@ Parameters:
 
 conan.tools.build.default_cppstd
 ----------------------------------
+
+Available since: `1.50.0 <https://github.com/conan-io/conan/releases/tag/1.50.0>`_
 
 .. code-block:: python
 
@@ -82,6 +89,8 @@ Parameters:
 conan.tools.build.supported_cppstd
 ----------------------------------
 
+Available since: `1.50.0 <https://github.com/conan-io/conan/releases/tag/1.50.0>`_
+
 .. code-block:: python
 
     def supported_cppstd(conanfile, compiler=None, compiler_version=None):
@@ -102,6 +111,8 @@ Parameters:
 
 conan.tools.build.build_jobs()
 ------------------------------
+
+Available since: `1.43.0 <https://github.com/conan-io/conan/releases/tag/1.43.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/cmake/cmake.rst
+++ b/reference/conanfile/tools/cmake/cmake.rst
@@ -8,6 +8,7 @@ CMake
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.32.0 <https://github.com/conan-io/conan/releases/tag/1.32.0>`_
 
 The ``CMake`` build helper is a wrapper around the command line invocation of cmake. It will abstract the
 calls like ``cmake --build . --config Release`` into Python method calls. It will also add the argument

--- a/reference/conanfile/tools/cmake/cmake_layout.rst
+++ b/reference/conanfile/tools/cmake/cmake_layout.rst
@@ -8,6 +8,7 @@ cmake_layout
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 For example, this would implement the standard CMake project layout:
 

--- a/reference/conanfile/tools/cmake/cmaketoolchain.rst
+++ b/reference/conanfile/tools/cmake/cmaketoolchain.rst
@@ -8,6 +8,7 @@ CMakeToolchain
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.32.0 <https://github.com/conan-io/conan/releases/tag/1.32.0>`_
 
 The ``CMakeToolchain`` is the toolchain generator for CMake. It will generate toolchain files that can be used in the
 command line invocation of CMake with the ``-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake``. This generator translates

--- a/reference/conanfile/tools/cmake/cmaketoolchain.rst
+++ b/reference/conanfile/tools/cmake/cmaketoolchain.rst
@@ -165,6 +165,8 @@ Will generate the sentences: ``set(FOO ON ...)`` and ``set(VAR OFF ...)``.
 cache_variables
 +++++++++++++++
 
+Available since: `1.50.0 <https://github.com/conan-io/conan/releases/tag/1.50.0>`_
+
 This attribute allows defining CMake cache-variables. These variables, unlike the ``variables``, are single-config. They
 will be stored in the ``CMakePresets.json`` file (at the `cacheVariables` in the `configurePreset`) and will be
 applied with ``-D`` arguments when calling ``cmake.configure`` using the :ref:`CMake() build helper<conan-cmake-build-helper>`.

--- a/reference/conanfile/tools/env/environment.rst
+++ b/reference/conanfile/tools/env/environment.rst
@@ -8,6 +8,7 @@ Environment
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 ``Environment`` is a generic class that helps defining modifications to the environment variables.
 This class is used by other tools like the :ref:`conan.tools.gnu<conan_tools_gnu>` autotools helpers and

--- a/reference/conanfile/tools/env/virtualbuildenv.rst
+++ b/reference/conanfile/tools/env/virtualbuildenv.rst
@@ -8,6 +8,7 @@ VirtualBuildEnv
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.39.0 <https://github.com/conan-io/conan/releases/tag/1.39.0>`_
 
 The ``VirtualBuildEnv`` generator can be used by name in conanfiles:
 

--- a/reference/conanfile/tools/env/virtualrunenv.rst
+++ b/reference/conanfile/tools/env/virtualrunenv.rst
@@ -8,6 +8,7 @@ VirtualRunEnv
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.39.0 <https://github.com/conan-io/conan/releases/tag/1.39.0>`_
 
 The ``VirtualRunEnv`` generator can be used by name in conanfiles:
 

--- a/reference/conanfile/tools/files/autopackager.rst
+++ b/reference/conanfile/tools/files/autopackager.rst
@@ -3,6 +3,8 @@
 conan.tools.files.AutoPackager
 ------------------------------
 
+Available since: `1.42.0 <https://github.com/conan-io/conan/releases/tag/1.42.0>`_
+
 The ``AutoPackager`` together with the :ref:`package layouts<package_layout>` feature, allow to automatically
 package the files following the declared information in the ``layout()`` method:
 

--- a/reference/conanfile/tools/files/basic.rst
+++ b/reference/conanfile/tools/files/basic.rst
@@ -11,6 +11,8 @@ conan.tools.files basic operations
 conan.tools.files.copy()
 ------------------------
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
+
 .. code-block:: python
 
     def copy(conanfile, pattern, src, dst, keep_path=True, excludes=None, ignore_case=True)
@@ -44,6 +46,8 @@ Parameters:
 conan.tools.files.load()
 ------------------------
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
+
 .. code-block:: python
 
     def load(conanfile, path, encoding="utf-8")
@@ -65,6 +69,8 @@ Parameters:
 
 conan.tools.files.save()
 ------------------------
+
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 .. code-block:: python
 
@@ -92,6 +98,8 @@ Parameters:
 conan.tools.files.rename()
 --------------------------
 
+Available since: `1.37.0 <https://github.com/conan-io/conan/releases/tag/1.37.0>`_
+
 .. code-block:: python
 
     def rename(conanfile, src, dst)
@@ -113,6 +121,8 @@ Parameters:
 
 conan.tools.files.replace_in_file()
 -----------------------------------
+
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 .. code-block:: python
 
@@ -141,6 +151,8 @@ Parameters:
 conan.tools.files.rm()
 ----------------------
 
+Available since: `1.50.0 <https://github.com/conan-io/conan/releases/tag/1.50.0>`_
+
 .. code-block:: python
 
     def rm(conanfile, pattern, folder, recursive=False)
@@ -166,6 +178,8 @@ Parameters:
 conan.tools.files.mkdir()
 -------------------------
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
+
 .. code-block:: python
 
     def mkdir(path)
@@ -188,6 +202,8 @@ Parameters:
 
 conan.tools.files.rmdir()
 -------------------------
+
+Available since: `1.47.0 <https://github.com/conan-io/conan/releases/tag/1.47.0>`_
 
 .. code-block:: python
 
@@ -216,6 +232,8 @@ it can be an absolute path.
 conan.tools.files.chdir()
 -------------------------
 
+Available since: `1.40.0 <https://github.com/conan-io/conan/releases/tag/1.40.0>`_
+
 .. code-block:: python
 
     def chdir(conanfile, newdir):
@@ -237,6 +255,8 @@ Parameters:
 
 conan.tools.files.unzip()
 -------------------------
+
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 .. code-block:: python
 
@@ -293,6 +313,8 @@ Parameters:
 
 conan.tools.files.update_conandata()
 ------------------------------------
+
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/files/checksum.rst
+++ b/reference/conanfile/tools/files/checksum.rst
@@ -10,6 +10,8 @@ conan.tools.files checksums
 conan.tools.files.check_md5()
 -----------------------------
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
+
 .. code-block:: python
 
     def check_md5(conanfile, file_path, signature)
@@ -27,6 +29,7 @@ Parameters:
 conan.tools.files.check_sha1()
 ------------------------------
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 .. code-block:: python
 
@@ -44,6 +47,8 @@ Parameters:
 
 conan.tools.files.check_sha256()
 --------------------------------
+
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/files/downloads.rst
+++ b/reference/conanfile/tools/files/downloads.rst
@@ -10,6 +10,8 @@ conan.tools.files downloads
 conan.tools.files.get()
 -----------------------
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
+
 .. code-block:: python
 
     def get(conanfile, url, md5='', sha1='', sha256='', destination=".", filename="",
@@ -42,6 +44,8 @@ Examples:
 conan.tools.files.ftp_download()
 --------------------------------
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
+
 .. code-block:: python
 
     def ftp_download(conanfile, ip, filename, login='', password='')
@@ -71,6 +75,8 @@ Examples:
 
 conan.tools.files.download()
 ----------------------------
+
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 Download a file
 
@@ -139,8 +145,3 @@ Examples:
                     "file:///home/myuser/localmirror/gcc-9.3.0/gcc-9.3.0.tar.gz"],
                     "gcc-9.3.0.tar.gz",
                    sha256="5258a9b6afe9463c2e56b9e8355b1a4bee125ca828b8078f910303bc2ef91fa6")
-
-
-
-Available since: `1.42.0 <https://github.com/conan-io/conan/releases>`_
-

--- a/reference/conanfile/tools/files/patches.rst
+++ b/reference/conanfile/tools/files/patches.rst
@@ -6,6 +6,8 @@ conan.tools.files patches
 conan.tools.files.patch()
 -------------------------
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
+
 .. code-block:: python
 
     def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0, fuzz=False, **kwargs):
@@ -38,6 +40,8 @@ Parameters:
 
 conan.tools.files.apply_conandata_patches()
 -------------------------------------------
+
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/files/symlinks.rst
+++ b/reference/conanfile/tools/files/symlinks.rst
@@ -7,6 +7,8 @@ conan.tools.files.symlinks
 conan.tools.files.symlinks.absolute_to_relative_symlinks()
 ----------------------------------------------------------
 
+Available since: `1.44.0 <https://github.com/conan-io/conan/releases/tag/1.44.0>`_
+
 .. code-block:: python
 
     def absolute_to_relative_symlinks(conanfile, base_folder):
@@ -24,6 +26,8 @@ Parameters:
 conan.tools.files.symlinks.remove_external_symlinks()
 ----------------------------------------------------------
 
+Available since: `1.44.0 <https://github.com/conan-io/conan/releases/tag/1.44.0>`_
+
 .. code-block:: python
 
     def remove_external_symlinks(conanfile, base_folder):
@@ -38,6 +42,8 @@ Parameters:
 
 conan.tools.files.symlinks.remove_broken_symlinks()
 ----------------------------------------------------------
+
+Available since: `1.44.0 <https://github.com/conan-io/conan/releases/tag/1.44.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/gnu/autotools.rst
+++ b/reference/conanfile/tools/gnu/autotools.rst
@@ -8,6 +8,7 @@ Autotools
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 The ``Autotools`` build helper is a wrapper around the command line invocation of autotools. It will abstract the
 calls like ``./configure`` or ``make`` into Python method calls.

--- a/reference/conanfile/tools/gnu/autotoolsdeps.rst
+++ b/reference/conanfile/tools/gnu/autotoolsdeps.rst
@@ -6,6 +6,7 @@ AutotoolsDeps
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 The ``AutotoolsDeps`` is the dependencies generator for Autotools. It will generate shell scripts containing
 environment variable definitions that the autotools build system can understand.

--- a/reference/conanfile/tools/gnu/autotoolstoolchain.rst
+++ b/reference/conanfile/tools/gnu/autotoolstoolchain.rst
@@ -8,6 +8,7 @@ AutotoolsToolchain
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.35.0 <https://github.com/conan-io/conan/releases/tag/1.35.0>`_
 
 The ``AutotoolsToolchain`` is the toolchain generator for Autotools. It will generate shell scripts containing
 environment variable definitions that the autotools build system can understand.

--- a/reference/conanfile/tools/gnu/pkgconfig.rst
+++ b/reference/conanfile/tools/gnu/pkgconfig.rst
@@ -6,8 +6,7 @@ PkgConfig
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
-
-Available since: `1.43.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 
 This tool can execute ``pkg_config`` executable to extract information from existing ``.pc`` files.

--- a/reference/conanfile/tools/gnu/pkgconfigdeps.rst
+++ b/reference/conanfile/tools/gnu/pkgconfigdeps.rst
@@ -15,8 +15,7 @@ PkgConfigDeps
 PkgConfigDeps
 -------------
 
-Available since: `1.38.0 <https://github.com/conan-io/conan/releases>`_
-
+Available since: `1.38.0 <https://github.com/conan-io/conan/releases/tag/1.38.0>`_
 
 The ``PkgConfigDeps`` is the dependencies generator for pkg-config. Generates pkg-config files named *<PKG-NAME>.pc*
 (where ``<PKG-NAME`` is the name declared by dependencies in ``cpp_info.names["pkg_config"]`` if specified),
@@ -128,7 +127,7 @@ Example:
 Names and aliases
 ++++++++++++++++++
 
-Aliases are available since: `1.43.0 <https://github.com/conan-io/conan/releases>`_
+Aliases are available since: `1.43.0 <https://github.com/conan-io/conan/releases/tag/1.43.0>`_
 
 By default, the ``*.pc`` files will be named following these rules:
 

--- a/reference/conanfile/tools/google.rst
+++ b/reference/conanfile/tools/google.rst
@@ -11,7 +11,7 @@ conan.tools.google
 BazelDeps
 ---------
 
-Available since: `1.37.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.37.0 <https://github.com/conan-io/conan/releases/tag/1.37.0>`_
 
 The ``BazelDeps`` helper will generate one **conandeps/xxxx/BUILD** file per dependency. This dependencies will be
 automatically added to the project if you add the following lines to the project's **WORKSPACE** file:
@@ -36,6 +36,8 @@ The dependencies should be added to the **conanfile.py** file as usual:
 
 BazelToolchain
 --------------
+
+Available since: `1.37.0 <https://github.com/conan-io/conan/releases/tag/1.37.0>`_
 
 The ``BazelToolchain`` is the toolchain generator for Bazel. It will generate a file called
 ``conanbuild.conf`` containing two keys:
@@ -89,6 +91,9 @@ constructor
 
 Bazel
 -----
+
+Available since: `1.37.0 <https://github.com/conan-io/conan/releases/tag/1.37.0>`_
+
 The ``Bazel`` build helper is a wrapper around the command line invocation of bazel. It will abstract the
 calls like ``bazel build //main:hello-world`` into Python method calls.
 

--- a/reference/conanfile/tools/intel.rst
+++ b/reference/conanfile/tools/intel.rst
@@ -8,7 +8,7 @@ conan.tools.intel
 IntelCC
 --------
 
-Available since: `1.41.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.41.0 <https://github.com/conan-io/conan/releases/tag/1.41.0>`_
 
 This tool helps you to manage the new Intel oneAPI `DPC++/C++ <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html>`_ and
 `Classic <https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top.html>`_ ecosystem in Conan.

--- a/reference/conanfile/tools/layout.rst
+++ b/reference/conanfile/tools/layout.rst
@@ -52,6 +52,8 @@ check the :ref:`package layout<package_layout>` section.
 basic_layout
 ------------
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
+
 Usage:
 
 .. code:: python

--- a/reference/conanfile/tools/meson/meson.rst
+++ b/reference/conanfile/tools/meson/meson.rst
@@ -8,6 +8,7 @@ Meson
 
     This is an **experimental** feature subject to breaking changes in future releases.
 
+Available since: `1.33.0 <https://github.com/conan-io/conan/releases/tag/1.33.0>`_
 
 The ``Meson()`` build helper that works with the ``MesonToolchain`` is also experimental,
 and subject to breaking change in the future. It will evolve to adapt and complement the

--- a/reference/conanfile/tools/meson/mesondeps.rst
+++ b/reference/conanfile/tools/meson/mesondeps.rst
@@ -8,6 +8,8 @@ MesonDeps
     These tools are still **experimental** (so subject to breaking changes) but with very stable syntax.
     We encourage the usage of it to be prepared for Conan 2.0.
 
+Available since: `1.51.0 <https://github.com/conan-io/conan/releases/tag/1.51.0>`_
+
 :ref:`MesonToolchain<conan-meson-toolchain>` normally works together with :ref:`PkgConfigDeps<PkgConfigDeps>` to manage all the dependencies,
 but sometimes we need to gather some flags coming from ``Autotools`` tool so that's what ``MesonDeps`` is meant for. In other words, it is typically used
 when Meson cannot find a dependency using the already known `detection mechanisms <https://mesonbuild.com/Dependencies.html>`__ like: `pkg-config`, `cmake`, `config-tool`, etc.

--- a/reference/conanfile/tools/microsoft.rst
+++ b/reference/conanfile/tools/microsoft.rst
@@ -15,6 +15,8 @@ but using directly Visual Studio solutions, projects and property files).
 MSBuildDeps
 -----------
 
+Available since: `1.32.0 <https://github.com/conan-io/conan/releases/tag/1.32.0>`_
+
 The ``MSBuildDeps`` is the dependency information generator for Microsoft MSBuild build system.
 It will generate multiple *xxxx.props* properties files one per dependency of a package,
 to be used by consumers using MSBuild or Visual Studio, just adding the generated properties files
@@ -151,6 +153,8 @@ dependencies will be translated to properties files:
 MSBuildToolchain
 ----------------
 
+Available since: `1.32.0 <https://github.com/conan-io/conan/releases/tag/1.32.0>`_
+
 The ``MSBuildToolchain`` is the toolchain generator for MSBuild. It will generate MSBuild properties files
 that can be added to the Visual Studio solution projects. This generator translates
 the current package configuration, settings, and options, into MSBuild properties files syntax.
@@ -237,6 +241,8 @@ conf
 MSBuild
 -------
 
+Available since: `1.32.0 <https://github.com/conan-io/conan/releases/tag/1.32.0>`_
+
 The ``MSBuild`` build helper is a wrapper around the command line invocation of MSBuild. It will abstract the
 calls like ``msbuild "MyProject.sln" /p:Configuration=<conf> /p:Platform=<platform>`` into Python method calls.
 
@@ -281,6 +287,8 @@ conf
 
 VCVars
 ------
+
+Available since: `1.39.0 <https://github.com/conan-io/conan/releases/tag/1.39.0>`_
 
 Generates a file called ``conanvcvars.bat`` that activate the Visual Studio developer command prompt according
 to the current settings by wrapping the `vcvarsall <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2017>`_
@@ -343,6 +351,8 @@ Parameters:
 conan.tools.microsoft.is_msvc()
 -------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 .. code-block:: python
 
     def is_msvc(conanfile):
@@ -366,6 +376,8 @@ Parameters:
 
 conan.tools.microsoft.is_msvc_static_runtime()
 ----------------------------------------------
+
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 .. code-block:: python
 
@@ -394,6 +406,8 @@ Parameters:
 conan.tools.microsoft.msvc_runtime_flag()
 -----------------------------------------
 
+Available since: `1.33.0 <https://github.com/conan-io/conan/releases/tag/1.33.0>`_
+
 .. code-block:: python
 
     def msvc_runtime_flag(conanfile):
@@ -419,6 +433,8 @@ Parameters:
 
 conan.tools.microsoft.unix_path()
 ---------------------------------
+
+Available since: `1.47.0 <https://github.com/conan-io/conan/releases/tag/1.47.0>`_
 
 .. code-block:: python
 
@@ -461,6 +477,8 @@ In the example above, ``adjusted_path`` will be:
 
 check_min_vs()
 --------------
+
+Available since: `1.49.0 <https://github.com/conan-io/conan/releases/tag/1.49.0>`_
 
 Helper method to allow the migration to 2.0 more easily. It will handle internally both ``Visual Studio``
 and ``msvc`` compiler settings, raising a ``ConanInvalidConfiguration`` error if the minimum version

--- a/reference/conanfile/tools/qbs.rst
+++ b/reference/conanfile/tools/qbs.rst
@@ -73,6 +73,8 @@ etc. This includes the following:
 Qbs
 ---
 
+Available since: `1.33.0 <https://github.com/conan-io/conan/releases/tag/1.33.0>`_
+
 If you are using **Qbs** as your build system, you can use the **Qbs** build helper.
 
 .. code-block:: python

--- a/reference/conanfile/tools/scm/git.rst
+++ b/reference/conanfile/tools/scm/git.rst
@@ -7,6 +7,7 @@ Git
 
     This tool is **experimental** and subject to breaking changes. This tool is intended to replace the current ``conans.tools.Git`` and the current ``scm`` attribute, that will be removed in Conan 2.0.
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 constructor
 -----------

--- a/reference/conanfile/tools/scm/other.rst
+++ b/reference/conanfile/tools/scm/other.rst
@@ -7,6 +7,7 @@ Version
 
     This tool is **experimental** and subject to breaking changes.
 
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 constructor
 -----------

--- a/reference/conanfile/tools/system/package_manager.rst
+++ b/reference/conanfile/tools/system/package_manager.rst
@@ -110,6 +110,8 @@ There are some specific arguments for each of these tools. Here is the complete 
 conan.tools.system.package_manager.Apt
 --------------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 Will invoke the *apt-get* command. Enabled by default for **Linux** with distribution
 names: *ubuntu* and *debian*.
 
@@ -174,6 +176,8 @@ Methods
 conan.tools.system.package_manager.Yum
 --------------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 Will invoke the *yum* command. Enabled by default for **Linux** with distribution names:
 *pidora*, *scientific*, *xenserver*, *amazon*, *oracle*, *amzn* and *almalinux*.
 
@@ -208,12 +212,16 @@ The default mapping Conan uses for *Yum* packages architecture is:
 conan.tools.system.package_manager.Dnf
 --------------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 Will invoke the *dnf* command. Enabled by default for **Linux** with distribution names:
 *fedora*, *rhel*, *centos* and *mageia*. This tool has exactly the same default values,
 constructor and methods than the :ref:`Yum<conan_tools_system_package_manager_yum>` tool.
 
 conan.tools.system.package_manager.PacMan
 -----------------------------------------
+
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 Will invoke the *pacman* command. Enabled by default for **Linux** with distribution
 names: *arch*, *manjaro* and when using **Windows** with *msys2*
@@ -241,6 +249,8 @@ The default mapping Conan uses for *PacMan* packages architecture is:
 conan.tools.system.package_manager.Zypper
 -----------------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 Will invoke the *zypper* command. Enabled by default for **Linux** with distribution
 names: *opensuse*, *sles*.
 
@@ -256,6 +266,8 @@ Constructor
 conan.tools.system.package_manager.Brew
 ---------------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 Will invoke the *brew* command. Enabled by default for **macOS**.
 
 Constructor
@@ -269,6 +281,8 @@ Constructor
 
 conan.tools.system.package_manager.Pkg
 --------------------------------------
+
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 Will invoke the *pkg* command. Enabled by default for **Linux** with distribution names: *freebsd*.
 
@@ -284,6 +298,8 @@ Constructor
 conan.tools.system.package_manager.PkgUtil
 ------------------------------------------
 
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
+
 Will invoke the *pkgutil* command. Enabled by default for **Solaris**.
 
 Constructor
@@ -297,6 +313,8 @@ Constructor
 
 conan.tools.system.package_manager.Chocolatey
 ---------------------------------------------
+
+Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 Will invoke the *choco* command. Enabled by default for **Windows**.
 

--- a/reference/config_files/global_conf.rst
+++ b/reference/config_files/global_conf.rst
@@ -95,7 +95,7 @@ To list all possible configurations available, run :command:`conan config list`.
 Configuration file template
 ---------------------------
 
-Available since: `1.46.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 It is possible to use **jinja2** template engine for *global.conf*. When Conan loads this file, immediately parses
 and renders the template, which must result in a standard tools-configuration text.
@@ -116,7 +116,7 @@ and renders the template, which must result in a standard tools-configuration te
 Configuration data types
 ------------------------
 
-Available since: `1.46.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 All the values will be interpreted by Conan as the result of the python built-in `eval()` function:
 
@@ -137,7 +137,7 @@ All the values will be interpreted by Conan as the result of the python built-in
 Configuration data operators
 ----------------------------
 
-Available since: `1.46.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>`_
 
 It's also possible to use some extra operators when you're composing tool configurations in your *global.conf* or
 any of your profiles:

--- a/reference/config_files/settings.yml.rst
+++ b/reference/config_files/settings.yml.rst
@@ -243,7 +243,7 @@ the final release. It will be considered as **experimental** in case of incompat
 intel-cc
 ++++++++
 
-Available since: `1.41.0 <https://github.com/conan-io/conan/releases>`_
+Available since: `1.41.0 <https://github.com/conan-io/conan/releases/tag/1.41.0>`_
 
 This compiler is a new, **experimental** one, aimed to handle the new Intel oneAPI DPC++/C++/Classic compilers. Instead of having *n* different compilers, you have 3 different **modes** of working:
 


### PR DESCRIPTION
Very useful when you migrate recipe to conan v2 and you want to properly document `required_conan_version` or check whether it will be compatible with conan client installed in your CI.