### PR TITLE
Update conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -94,7 +94,7 @@ author = u'The Conan team'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Fix errors related to lack of language while building the docs

Without conf.py having a defualt language sphinx shows this:

```py
sphinx-build -W -b html -d _build/doctrees   . _build/html
Running Sphinx v5.1.1

Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
make: *** [Makefile:57: html] Error 2
```