### PR TITLE
Document min conan version of few classes, methods, functions & arguments

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -315,9 +315,9 @@ If you want to do a safe check of settings values, you could use the ``get_safe(
 
 The ``get_safe()`` method will return ``None`` if that setting or subsetting doesn't exist and there is no default value assigned.
 
-If you want to do a safe deletion of settings, you could use the ``rm_safe()``
-method. For example, in the ``configure()`` method a typical pattern for a C library would
-be:
+If you want to do a safe deletion of settings, you could use the ``rm_safe()`` method (available since
+`1.53.0 <https://github.com/conan-io/conan/releases/tag/1.53.0>`_). For example, in the ``configure()`` method
+a typical pattern for a C library would be:
 
 .. code-block:: python
 
@@ -491,8 +491,9 @@ you can use the ``get_safe()`` method:
 
 The ``get_safe()`` method will return ``None`` if that option doesn't exist and there is no default value assigned.
 
-If you want to do a safe deletion of options, you could use the ``rm_safe()`` method. For
-example, in the ``config_options()`` method a typical pattern for Windows library would be:
+If you want to do a safe deletion of options, you could use the ``rm_safe()`` method (available since
+`1.53.0 <https://github.com/conan-io/conan/releases/tag/1.53.0>`_). For example, in the ``config_options()`` method
+a typical pattern for Windows library would be:
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/apple.rst
+++ b/reference/conanfile/tools/apple.rst
@@ -393,6 +393,8 @@ tool, if needed, in the conanfile's ``package()`` method like:
 is_apple_os()
 -------------
 
+Available since: `1.51.3 <https://github.com/conan-io/conan/releases/tag/1.51.3>`_
+
 .. code-block:: python
 
     def is_apple_os(conanfile):
@@ -408,6 +410,8 @@ This tool returns ``True`` if the OS is from Apple (Macos, iOS, watchOS or tvOS)
 to_apple_arch()
 ---------------
 
+Available since: `1.52.0 <https://github.com/conan-io/conan/releases/tag/1.52.0>`_
+
 .. code-block:: python
 
     def to_apple_arch(conanfile):
@@ -422,6 +426,8 @@ understood by different Apple build tools (e.g. `armv8` -> `arm64`).
 
 XCRun()
 -------
+
+Available since: `1.53.0 <https://github.com/conan-io/conan/releases/tag/1.53.0>`_
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/microsoft.rst
+++ b/reference/conanfile/tools/microsoft.rst
@@ -317,7 +317,8 @@ Where:
   but this will be configurable with ``msbuild.build_type``.
 - ``platform`` is the architecture, a mapping from the ``settings.arch`` to the common 'x86', 'x64', 'ARM', 'ARM64'.
   This is configurable with ``msbuild.platform``.
-- ``targets`` is an optional argument, defaults to ``None``, and otherwise it is a list of targets to build
+- ``targets`` (since `1.52.0 <https://github.com/conan-io/conan/releases/tag/1.52.0>`_) is an optional argument,
+  defaults to ``None``, and otherwise it is a list of targets to build
 
 
 attributes
@@ -435,8 +436,8 @@ When the ``compiler`` is empty, it returns ``False``.
 Parameters:
 
 - **conanfile**: ConanFile instance.
-- **build_context**: (default=False). If this argument is ``True``, the method will check the compiler of the
-  ``build`` context, not the ``host`` one. 
+- **build_context** (since `1.52.0 <https://github.com/conan-io/conan/releases/tag/1.52.0>`_): (default=False). If this
+  argument is ``True``, the method will check the compiler of the ``build`` context, not the ``host`` one. 
 
 .. code-block:: python
 

--- a/reference/conanfile/tools/scm/git.rst
+++ b/reference/conanfile/tools/scm/git.rst
@@ -153,6 +153,8 @@ again from sources from the same commit. This is the behavior:
 run()
 -----
 
+Available since: `1.53.0 <https://github.com/conan-io/conan/releases/tag/1.53.0>`_
+
 .. code-block:: python
     
     def run(self, cmd)


### PR DESCRIPTION
- `rm_safe()` method in `conanfile.settings` & `conanfile.options` since 1.53.0
- `conan.tools.apple.is_apple_os()` function since 1.51.3
- `conan.tools.apple.to_apple_arch()` function since 1.52.0
- `conan.tools.apple.XCRun` class since 1.53.0
- `targets` optional argument of `conan.tools.microsoft.MSBuild.build()` method since 1.52.0
- `run()` method of `conan.tools.scm.Git` class since 1.53.0