### PR TITLE
Add links to fnmatch where aplicable

### DIFF
--- a/mastering/policies.rst
+++ b/mastering/policies.rst
@@ -40,5 +40,5 @@ libraries.
 The ``always`` policy will retrieve the sources each time the package is installed, so it can be useful for providing a "latest" mechanism
 or ignoring the uploaded binary packages.
 
-The package pattern can be referred as a case-sensitive fnmatch pattern of the package name or the full package reference.
+The package pattern can be referred as a case-sensitive `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ pattern of the package name or the full package reference.
 e.g :command:`--build poco`, :command:`--build poc*`, :command:`--build zlib/*`, :command:`--build *@conan/stable` or :command:`--build zlib/1.2.11`.

--- a/reference/commands/consumer/install.rst
+++ b/reference/commands/consumer/install.rst
@@ -249,7 +249,8 @@ Possible values are:
 * :command:`--build=cascade`: Conan selects packages for the build where at least one of its
   dependencies is selected for the build. This is useful to rebuild packages that, directly or
   indirectly, depend on changed packages.
-* :command:`--build=[pattern]`: A fnmatch case-sensitive pattern of a package reference or only the package name.
+* :command:`--build=[pattern]`: A `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ case-sensitive pattern
+  of a package reference or only the package name.
   Conan will force the build of the packages whose reference matches the given
   **pattern**. Several patterns can be specified, chaining multiple options:
 
@@ -257,7 +258,8 @@ Possible values are:
    - e.g., :command:`--build=zlib` will match any package named ``zlib`` (same as ``zlib/*``).
    - e.g., :command:`--build=z*@conan/stable` will match any package starting with ``z`` with ``conan/stable`` as user/channel.
 
-* :command:`--build=![pattern]`: A fnmatch case-sensitive pattern of a package reference or only the package name.
+* :command:`--build=![pattern]`: A `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ case-sensitive pattern
+  of a package reference or only the package name.
   Conan will exclude the build of the packages whose reference matches the given
   **pattern**. Several patterns can be specified, chaining multiple options:
 

--- a/reference/conanfile/methods.rst
+++ b/reference/conanfile/methods.rst
@@ -151,8 +151,8 @@ The syntax of ``self.copy`` inside ``package()`` is as follows:
 Returns: A list with absolute paths of the files copied in the destination folder.
 
 Parameters:
-    - **pattern** (Required): A pattern following fnmatch syntax of the files you want to copy, from the build to the package folders.
-      Typically something like ``*.lib`` or ``*.h``.
+    - **pattern** (Required): A pattern following `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ syntax of the files
+      you want to copy, from the build to the package folders. Typically something like ``*.lib`` or ``*.h``.
     - **src** (Optional, Defaulted to ``""``): The folder where you want to search the files in the build folder. If you know that your
       libraries when you build your package will be in *build/lib*, you will typically use ``build/lib`` in this parameter. Leaving it empty
       means the root build folder in local cache.
@@ -935,14 +935,14 @@ The ``self.copy()`` method inside ``imports()`` supports the following arguments
     def copy(pattern, dst="", src="", root_package=None, folder=False, ignore_case=True, excludes=None, keep_path=True)
 
 Parameters:
-    - **pattern** (Required): An fnmatch file pattern of the files that should be copied.
+    - **pattern** (Required): An `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ file pattern of the files that should be copied.
     - **dst** (Optional, Defaulted to ``""``): Destination local folder, with reference to current directory, to which the files will be
       copied.
     - **src** (Optional, Defaulted to ``""``): Source folder in which those files will be searched. This folder will be stripped from the
       dst parameter. E.g., `lib/Debug/x86`. It accepts symbolic folder names like ``@bindirs`` and ``@libdirs`` which will map to the
       ``self.cpp_info.bindirs`` and ``self.cpp_info.libdirs`` of the source package, instead of a hardcoded name.
-    - **root_package** (Optional, Defaulted to *all packages in deps*): An fnmatch pattern of the package name ("OpenCV", "Boost") from
-      which files will be copied.
+    - **root_package** (Optional, Defaulted to *all packages in deps*): An `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_
+      pattern of the package name ("OpenCV", "Boost") from which files will be copied.
     - **folder** (Optional, Defaulted to ``False``): If enabled, it will copy the files from the local cache to a subfolder named as the
       package containing the files. Useful to avoid conflicting imports of files with the same name (e.g. License).
     - **ignore_case** (Optional, Defaulted to ``True``): If enabled, it will do a case-insensitive pattern matching.

--- a/reference/conanfile/tools/files/basic.rst
+++ b/reference/conanfile/tools/files/basic.rst
@@ -18,17 +18,20 @@ Available since: `1.46.0 <https://github.com/conan-io/conan/releases/tag/1.46.0>
     def copy(conanfile, pattern, src, dst, keep_path=True, excludes=None, ignore_case=True)
 
 
-Copy the files matching the ``pattern`` (fnmatch) at the ``src`` folder to a ``dst`` folder.
+Copy the files matching the ``pattern`` (`fnmatch <https://docs.python.org/3/library/fnmatch.html>`_)
+at the ``src`` folder to a ``dst`` folder.
 
 Parameters:
     - **conanfile**: Conanfile object.
-    - **pattern**: An fnmatch file pattern of the files that should be copied. It must not start with ``..`` relative path or an exception will be raised.
+    - **pattern**: An `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ file pattern of the files that should be copied.
+      It must not start with ``..`` relative path or an exception will be raised.
     - **src**: Source folder in which those files will be searched. This folder will be stripped from the
       dst parameter. E.g., `lib/Debug/x86`.
     - **dst**: Destination local folder. It must be different from ``src`` value or an exception will be raised.
     - **keep_path**: Means if you want to keep the relative path when you copy the files from the **src**
       folder to the **dst** one.
-    - **excludes**: A tuple/list of fnmatch patterns or even a single one to be excluded from the copy.
+    - **excludes**: A tuple/list of `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ patterns or even a single one
+      to be excluded from the copy.
     - **ignore_case**: If enabled, it will do a case-insensitive pattern matching.
 
 .. note::
@@ -158,7 +161,7 @@ Available since: `1.50.0 <https://github.com/conan-io/conan/releases/tag/1.50.0>
     def rm(conanfile, pattern, folder, recursive=False)
 
 
-Remove the files following the ``pattern`` (fnmatch) from the specified ``folder``.
+Remove the files following the ``pattern`` (`fnmatch <https://docs.python.org/3/library/fnmatch.html>`_) from the specified ``folder``.
 
 .. code-block:: python
 
@@ -169,7 +172,7 @@ Remove the files following the ``pattern`` (fnmatch) from the specified ``folder
 
 Parameters:
     - **conanfile**: Conanfile object.
-    - **pattern**: Pattern that the files to be removed have to match (fnmatch).
+    - **pattern**: Pattern that the files to be removed have to match (`fnmatch <https://docs.python.org/3/library/fnmatch.html>`_).
     - **folder**: Folder to search/remove the files.
     - **recursive**: If ``recursive`` is specified it will search in the subfolders.
 
@@ -307,8 +310,8 @@ Parameters:
     - **pattern**: Extract from the archive only paths matching the pattern. This should be a Unix
       shell-style wildcard. See `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ documentation for more details.
     - **strip_root**: When ``True`` and the ZIP file contains one folder containing all the contents,
-      it will strip the root folder moving all its contents to the root. E.g: *mylib-1.2.8/main.c* will be extracted as *main.c*. If the compressed
-      file contains more than one folder or only a file it will raise a ``ConanException``.
+      it will strip the root folder moving all its contents to the root. E.g: *mylib-1.2.8/main.c* will be extracted as *main.c*.
+      If the compressed file contains more than one folder or only a file it will raise a ``ConanException``.
 
 
 conan.tools.files.update_conandata()

--- a/reference/conanfile_txt.rst
+++ b/reference/conanfile_txt.rst
@@ -113,8 +113,8 @@ The ``[imports]`` section also support the same arguments as the equivalent ``im
     e.g: ``lib, * -> /home/jenkins/workspace/conan_test@2/g/install/lib @``
 
 
-- **root_package** (Optional, Defaulted to *all packages in deps*): fnmatch pattern of the package name ("OpenCV", "Boost") from which files
-  will be copied.
+- **root_package** (Optional, Defaulted to *all packages in deps*): `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_ pattern
+  of the package name ("OpenCV", "Boost") from which files will be copied.
 - **folder**: (Optional, Defaulted to ``False``). If enabled, it will copy the files from the local cache to a subfolder named as the
   package containing the files. Useful to avoid conflicting imports of files with the same name (e.g. License).
 - **ignore_case**: (Optional, Defaulted to ``False``). If enabled will do a case-insensitive pattern matching.


### PR DESCRIPTION
While @uilianries was showing me the conan-center-index review process I had a doubt about whether `conan.tools.files.copy` was recursive or not.

Having the link present everywhere it's mentioned makes it clearer that it's a documented functionality that you can go and check when in doubt