### PR TITLE
Update 2.0 docs to not use -s compiler.cppstd=gnu11 in some commands

### DIFF
--- a/tutorial/consuming_packages/build_simple_cmake_project.rst
+++ b/tutorial/consuming_packages/build_simple_cmake_project.rst
@@ -137,29 +137,39 @@ This will detect the operating system, build architecture and compiler settings 
 the environment. It will also set the build configuration as *Release* by default. The
 generated profile will be stored in the Conan home folder with name *default* and will be
 used by Conan in all commands by default unless another profile is specified via the command
-line. After executing the command you should see some output similar to this but for your
-configuration:
+line. An example of the output of this command for MacOS would be:
 
 .. code-block:: ini
 
     $ conan profile detect --force
-    CC and CXX: /usr/bin/gcc, /usr/bin/g++ 
-    Found gcc 10
-    gcc>=5, using the major as version
-    gcc C++ standard library: libstdc++11
+    Found apple-clang 14.0
+    apple-clang>=13, using the major as version
     Detected profile:
     [settings]
-    os=Linux
     arch=x86_64
-    compiler=gcc
-    compiler.version=10
-    compiler.libcxx=libstdc++11
-    compiler.cppstd=gnu14
     build_type=Release
-    [options]
-    [tool_requires]
-    [env]
-    ...
+    compiler=apple-clang
+    compiler.cppstd=gnu98
+    compiler.libcxx=libc++
+    compiler.version=14
+    os=Macos
+
+.. note:: **A note about the detected C++ standard by Conan**
+
+    Conan will always set the default C++ standard as the one that the detected compiler
+    version uses by default. In this case, for apple-clang 14, it sets
+    ``compiler.cppstd=gnu98`` but as we are going to use libraries through the tutorial that
+    require a higher C++ standard, we have to update our profile to use at least C++ 11. To do
+    that, you can edit the default profile file directly. First, get the location of the
+    default profile using:
+
+    .. code-block:: bash
+
+        $ conan profile path default
+        /Users/user/.conan2/profiles/default
+
+    Then open and edit the file and set ``compiler.cppstd`` to at least C++ 11, by setting
+    ``compiler.cppstd=gnu11`` or ``compiler.cppstd=11``
 
 We will use Conan to install **Zlib** and generate the files that CMake needs to
 find this library and build our project. We will generate those files in the folder

--- a/tutorial/consuming_packages/different_configurations.rst
+++ b/tutorial/consuming_packages/different_configurations.rst
@@ -43,9 +43,9 @@ folder:
     os=Macos
     arch=x86_64
     compiler=apple-clang
-    compiler.version=13.0
+    compiler.version=14.0
     compiler.libcxx=libc++
-    compiler.cppstd=gnu98
+    compiler.cppstd=gnu11
     build_type=Release
     [options]
     [tool_requires]
@@ -77,9 +77,9 @@ with that profile. One example of a *debug* profile could be:
     os=Macos
     arch=x86_64
     compiler=apple-clang
-    compiler.version=13.0
+    compiler.version=14.0
     compiler.libcxx=libc++
-    compiler.cppstd=gnu98
+    compiler.cppstd=gnu11
     build_type=Debug
 
 

--- a/tutorial/creating_packages/add_dependencies_to_packages.rst
+++ b/tutorial/creating_packages/add_dependencies_to_packages.rst
@@ -109,7 +109,7 @@ colour now:
 
 .. code-block:: bash
 
-    $ conan create . --build=missing -s compiler.cppstd=gnu11
+    $ conan create . --build=missing
     -------- Exporting the recipe ----------
     ...
     -------- Testing the package: Running test() ----------
@@ -123,10 +123,6 @@ colour now:
       hello/1.0: __clang_major__ 13
       hello/1.0: __clang_minor__ 1
       hello/1.0: __apple_build_version__ 13160021
-
-Note that we passed the ``-s compiler.cppstd=11`` argument to the :command:`conan
-create` command to override the C++ standard used in the default profile. You can set the
-C++ standard of your choice or leave the default one as long as it is higher than C++11.
 
 Read more
 ---------

--- a/tutorial/creating_packages/build_packages.rst
+++ b/tutorial/creating_packages/build_packages.rst
@@ -174,7 +174,7 @@ Now that we have gone through all the changes in the code, let's try them out:
 .. code-block:: bash
     :emphasize-lines: 6-23
 
-    $ conan create . -s compiler.cppstd=gnu11 --build=missing -tf=None
+    $ conan create . --build=missing -tf=None
     ...
     [ 25%] Building CXX object CMakeFiles/hello.dir/src/hello.cpp.o
     [ 50%] Linking CXX static library libhello.a
@@ -204,7 +204,7 @@ configuration in the commnand line to skip the test building and running:
 
 .. code-block:: bash
 
-    $ conan create . -s compiler.cppstd=gnu11 -c tools.build:skip_test=True -tf=None
+    $ conan create . -c tools.build:skip_test=True -tf=None
     ...
     [ 50%] Building CXX object CMakeFiles/hello.dir/src/hello.cpp.o
     [100%] Linking CXX static library libhello.a

--- a/tutorial/creating_packages/configure_options_settings.rst
+++ b/tutorial/creating_packages/configure_options_settings.rst
@@ -107,7 +107,7 @@ the generated binaries package IDs.
 .. code-block:: bash
     :emphasize-lines: 6,19,29,42
     
-    $ conan create . --build=missing -s compiler.cppstd=gnu11 -s build_type=Release -tf=None # -tf=None will skip buildiing the test_package
+    $ conan create . --build=missing -s build_type=Release -tf=None # -tf=None will skip buildiing the test_package
     ...
     [ 50%] Building CXX object CMakeFiles/hello.dir/src/hello.cpp.o
     [100%] Linking CXX static library libhello.a
@@ -130,7 +130,7 @@ the generated binaries package IDs.
     hello/1.0: Full package reference: hello/1.0#e6b11fb0cb64e3777f8d62f4543cd6b3:738feca714b7251063cc51448da0cf4811424e7c#3bd9faedc711cbb4fdf10b295268246e
     hello/1.0: Package folder /Users/user/.conan2/p/5c497cbb5421cbda/p
 
-    $ conan create . --build=missing -s compiler.cppstd=gnu11 -s build_type=Debug -tf=None # -tf=None will skip buildiing the test_package
+    $ conan create . --build=missing -s build_type=Debug -tf=None # -tf=None will skip buildiing the test_package
     ...
     [ 50%] Building CXX object CMakeFiles/hello.dir/src/hello.cpp.o
     [100%] Linking CXX static library libhello.a
@@ -197,7 +197,7 @@ package ID will be the same for the **hello/1.0** binary:
 
 .. code-block:: bash
     
-    $ conan conan create . --build=missing -s compiler.cppstd=gnu11 -o shared=True -o fPIC=True -tf=None
+    $ conan conan create . --build=missing -o shared=True -o fPIC=True -tf=None
     ...
     hello/1.0 package(): Packaged 1 '.h' file: hello.h
     hello/1.0 package(): Packaged 1 '.dylib' file: libhello.dylib
@@ -206,7 +206,7 @@ package ID will be the same for the **hello/1.0** binary:
     hello/1.0: Full package reference: hello/1.0#e6b11fb0cb64e3777f8d62f4543cd6b3:2a899fd0da3125064bf9328b8db681cd82899d56#f0d1385f4f90ae465341c15740552d7e
     hello/1.0: Package folder /Users/user/.conan2/p/8a55286c6595f662/p
 
-    $ conan conan create . --build=missing -s compiler.cppstd=gnu11 -o shared=True -o fPIC=False -tf=None
+    $ conan conan create . --build=missing -o shared=True -o fPIC=False -tf=None
     ...
     -------- Computing dependency graph --------
     Graph root

--- a/tutorial/creating_packages/create_your_first_package.rst
+++ b/tutorial/creating_packages/create_your_first_package.rst
@@ -262,9 +262,9 @@ we can see them with:
           arch=x86_64
           build_type=Release
           compiler=apple-clang
-          compiler.cppstd=gnu98
+          compiler.cppstd=gnu11
           compiler.libcxx=libc++
-          compiler.version=13
+          compiler.version=14
           os=Macos
         options:
           fPIC=True
@@ -274,9 +274,9 @@ we can see them with:
           arch=x86_64
           build_type=Debug
           compiler=apple-clang
-          compiler.cppstd=gnu98
+          compiler.cppstd=gnu11
           compiler.libcxx=libc++
-          compiler.version=13
+          compiler.version=14
           os=Macos
         options:
           fPIC=True
@@ -286,9 +286,9 @@ we can see them with:
           arch=x86_64
           build_type=Release
           compiler=apple-clang
-          compiler.cppstd=gnu98
+          compiler.cppstd=gnu11
           compiler.libcxx=libc++
-          compiler.version=13
+          compiler.version=14
           os=Macos
         options:
           fPIC=True

--- a/tutorial/creating_packages/package_method.rst
+++ b/tutorial/creating_packages/package_method.rst
@@ -70,7 +70,7 @@ packaging of files in the Conan local cache:
 .. code-block:: bash
     :emphasize-lines: 7-14
 
-    $ conan create . --build=missing -s compiler.cppstd=gnu11 -tf=None
+    $ conan create . --build=missing -tf=None
     ...
     hello/1.0: Build folder /Users/user/.conan2/p/tmp/b5857f2e70d1b2fd/b/build/Release
     hello/1.0: Generated conaninfo.txt
@@ -126,7 +126,7 @@ packaging of files in the Conan local cache:
 .. code-block:: bash
     :emphasize-lines: 7-13
 
-    $ conan create . --build=missing -s compiler.cppstd=gnu11 -tf=None
+    $ conan create . --build=missing -tf=None
     ...
     hello/1.0: Build folder /Users/user/.conan2/p/tmp/222db0532bba7cbc/b/build/Release
     hello/1.0: Generated conaninfo.txt

--- a/tutorial/creating_packages/preparing_the_build.rst
+++ b/tutorial/creating_packages/preparing_the_build.rst
@@ -163,7 +163,7 @@ on the value of the option.
 
 .. code-block:: bash
 
-    $ conan create . --build=missing -s compiler.cppstd=gnu11 -o with_fmt=True
+    $ conan create . --build=missing -o with_fmt=True
     -------- Exporting the recipe ----------
     ...
 


### PR DESCRIPTION
Explain at the beginning that we will use c++11 so that we don't have to write it several times in the tutorial...

Goes with: https://github.com/conan-io/examples2/pull/51