### PR TITLE
Fix incorrect links in commands.rst

### DIFF
--- a/reference/commands.rst
+++ b/reference/commands.rst
@@ -29,8 +29,8 @@ and these :ref:`custom command examples <examples_extensions_custom_commands>`
 
 
 - :doc:`conan cache <commands/cache>`: Return the path of recipes and packages in the cache
-- :doc:`conan config <commands/cache>`: Manage Conan configuration (remotes, settings, plugins, etc)
-- :doc:`conan graph <commands/cache>`: Obtain information about the dependency graph without fetching binaries
+- :doc:`conan config <commands/config>`: Manage Conan configuration (remotes, settings, plugins, etc)
+- :doc:`conan graph <commands/graph>`: Obtain information about the dependency graph without fetching binaries
 - :doc:`conan inspect <commands/inspect>`: Inspect a conanfile.py to return the public fields
 - :doc:`conan install <commands/install>`: Install dependencies
 - :doc:`conan list <commands/list>`: List recipes, revisions and packages in the local cache or in remotes


### PR DESCRIPTION
Links for docs on `conan config` and `conan graph` currently point to `conan cache`.