### PR TITLE
Add documentation for `conan new`

### DIFF
--- a/reference/commands.rst
+++ b/reference/commands.rst
@@ -46,6 +46,8 @@ and these :ref:`custom command examples <examples_extensions_custom_commands>`
    :maxdepth: 1
    :hidden:
 
+   commands/new
    commands/upload
 
+- :doc:`conan new <commands/new>`: Create a new recipe from a predefined template
 - :doc:`conan upload <commands/upload>`: Upload packages from the local cache to a specified remote

--- a/reference/commands/new.rst
+++ b/reference/commands/new.rst
@@ -14,18 +14,24 @@ conan new
     Create a new recipe (with conanfile.py and other files) from either a predefined or a user-defined template
 
     positional arguments:
-      template              Template name, either a predefined built-in or a user-provided one.
-                            Available built-in templates:
-                            basic, alias, cmake_lib, cmake_exe, meson_lib, meson_exe,
-                            msbuild_lib, msbuild_exe, bazel_lib, bazel_exe, autotools_lib, autotools_exe.
-                            E.g. 'conan new cmake_lib -d name=hello -d version=0.1'.
-                            You can define your own templates too by referencing an absolute path to your template,
-                            or a path relative to your conan home folder.
+      template              Template name, either a predefined built-in or a user-
+                            provided one. Available built-in templates: basic,
+                            cmake_lib, cmake_exe, meson_lib, meson_exe,
+                            msbuild_lib, msbuild_exe, bazel_lib, bazel_exe,
+                            autotools_lib, autotools_exe. E.g. 'conan new
+                            cmake_lib -d name=hello -d version=0.1'. You can
+                            define your own templates too by inputting an absolute
+                            path as your template, or a path relative to your
+                            conan home folder.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       -d DEFINE, --define DEFINE
                             Define a template argument as key=value
       -f, --force           Overwrite file if it already exists
@@ -39,16 +45,16 @@ Each template has some required and some [optional] user-defined variables used 
 
  * ``basic``: [name], [version], [description], [require, require...]
  * ``alias``: name, [version], target
- * ``cmake_lib``: name, version
- * ``cmake_exe``: name, version
- * ``autotools_lib``: name, version
- * ``autotools_exe``: name, version
- * ``bazel_lib``: name, version
- * ``bazel_exe``: name, version
- * ``meson_lib``: name, version
- * ``meson_exe``: name, version
- * ``msbuild_lib``: name, version
- * ``msbuild_exe``: name, version
+ * ``cmake_lib``: name, version, [require, require...]
+ * ``cmake_exe``: name, version, [require, require...]
+ * ``autotools_lib``: name, version, [require, require...]
+ * ``autotools_exe``: name, version, [require, require...]
+ * ``bazel_lib``: name, version, [require, require...]
+ * ``bazel_exe``: name, version, [require, require...]
+ * ``meson_lib``: name, version, [require, require...]
+ * ``meson_exe``: name, version, [require, require...]
+ * ``msbuild_lib``: name, version, [require, require...]
+ * ``msbuild_exe``: name, version, [require, require...]
 
 
 Examples

--- a/reference/commands/new.rst
+++ b/reference/commands/new.rst
@@ -1,0 +1,72 @@
+.. _reference_commands_new:
+
+conan new
+=========
+
+conan new
+---------
+
+.. code-block:: text
+
+    $ conan new --help
+    usage: conan new [-h] [-v [V]] [--logger] [-d DEFINE] [-f] template
+
+    Create a new recipe (with conanfile.py and other files) from either a predefined or a user-defined template
+
+    positional arguments:
+      template              Template name, either a predefined built-in or a user-provided one.
+                            Available built-in templates:
+                            basic, alias, cmake_lib, cmake_exe, meson_lib, meson_exe,
+                            msbuild_lib, msbuild_exe, bazel_lib, bazel_exe, autotools_lib, autotools_exe.
+                            E.g. 'conan new cmake_lib -d name=hello -d version=0.1'.
+                            You can define your own templates too by referencing an absolute path to your template,
+                            or a path relative to your conan home folder.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      -d DEFINE, --define DEFINE
+                            Define a template argument as key=value
+      -f, --force           Overwrite file if it already exists
+
+
+The ``conan new`` command creates a new recipe in the current working directory,
+plus extra example files such as *CMakeLists.txt* or the *test_package* folder (as necessary),
+to be used as a basis for your own project.
+
+Each template has some required and some [optional] user-defined variables used to customize the resulting files. These are:
+
+ * ``basic``: [name], [version], [description], [require, require...]
+ * ``alias``: name, [version], target
+ * ``cmake_lib``: name, version
+ * ``cmake_exe``: name, version
+ * ``autotools_lib``: name, version
+ * ``autotools_exe``: name, version
+ * ``bazel_lib``: name, version
+ * ``bazel_exe``: name, version
+ * ``meson_lib``: name, version
+ * ``meson_exe``: name, version
+ * ``msbuild_lib``: name, version
+ * ``msbuild_exe``: name, version
+
+
+Examples
+--------
+
+.. code-block:: bash
+
+    $ conan new basic
+
+
+Generates a basic *conanfile.py* that does not implement any custom functionality
+
+.. code-block:: bash
+
+    $ conan new basic -d name=mygame -d requires=math/1.0 -d requires=ai/1.3
+
+Generates a *conanfile.py* for ``mygame`` that depends on the packages ``math/1.0`` and ``ai/1.3``
+
+
+
+

--- a/reference/commands/new.rst
+++ b/reference/commands/new.rst
@@ -39,22 +39,88 @@ conan new
 
 The ``conan new`` command creates a new recipe in the current working directory,
 plus extra example files such as *CMakeLists.txt* or the *test_package* folder (as necessary),
-to be used as a basis for your own project.
+to either be used as a basis for your own project or aiding in the debugging process.
 
-Each template has some required and some [optional] user-defined variables used to customize the resulting files. These are:
+Note that each template has some required and some [optional] user-defined variables used to customize the resulting files.
 
- * ``basic``: [name], [version], [description], [require, require...]
- * ``alias``: name, [version], target
- * ``cmake_lib``: name, version, [require, require...]
- * ``cmake_exe``: name, version, [require, require...]
- * ``autotools_lib``: name, version, [require, require...]
- * ``autotools_exe``: name, version, [require, require...]
- * ``bazel_lib``: name, version, [require, require...]
- * ``bazel_exe``: name, version, [require, require...]
- * ``meson_lib``: name, version, [require, require...]
- * ``meson_exe``: name, version, [require, require...]
- * ``msbuild_lib``: name, version, [require, require...]
- * ``msbuild_exe``: name, version, [require, require...]
+The available templates are:
+
+- **basic**:
+  Creates a simple recipe with some example code and helpful comments,
+  and is a good starting point to avoid writing boilerplate code.
+
+  Its variables are: [name], [version], [description], [require, require...]
+
+- **alias**:
+  Creates the minimal recipe needed to define an alias to a target recipe
+
+  Its variables are: name, [version], target
+
+- **cmake_lib**:
+  Creates a cmake library target that defines a function called ``name``,
+  which will print some information about the compilation environment to stdout.
+  You can add requirements to this template in the form of
+
+  ``conan new cmake_lib -d name=ai -d version=1.0 -d requires=math/3.14 -d requires=magic/0.0``
+
+  This will add requirements for both ``math/3.14`` and ``magic/0.0`` to the `requirements()` method,
+  will add the necessary ``find_package``s in CMake, and add a call to ``math()`` and ``magic()``
+  inside the generated ``ai()`` function.
+
+  Its variables are: name, version, [require, require...]
+
+- **cmake_exe**:
+  Creates a cmake executable target that defines a function called ``name``,
+  which will print some information about the compilation environment to stdout.
+  You can add requirements to this template in the form of
+
+  ``conan new cmake_exe -d name=game -d version=1.0 -d requires=math/3.14 -d requires=ai/1.0``
+
+  This will add requirements for both ``math/3.14`` and ``ai/1.0`` to the `requirements()` method,
+  will add the necessary ``find_package``s in CMake, and add a call to ``math()`` and ``ai()``
+  inside the generated ``game()`` function.
+
+  Its variables are: name, version, [require, require...]
+
+- **autotools_lib**:
+  Creates an Autotools library.
+
+  Its variables are: name, version
+
+- **autotools_exe**:
+  Creates an Autotools executable
+
+  Its variables are: name, version
+
+- **bazel_lib**:
+  Creates a Bazel library.
+
+  Its variables are: name, version
+
+- **bazel_exe**:
+  Creates a Bazel executable
+
+  Its variables are: name, version
+
+- **meson_lib**:
+  Creates a Meson library.
+
+  Its variables are: name, version
+
+- **meson_exe**:
+  Creates a Meson executable
+
+  Its variables are: name, version
+
+- **msbuild_lib**:
+  Creates a MSBuild library.
+
+  Its variables are: name, version
+
+- **msbuild_exe**:
+  Creates a MSBuild executable
+
+  Its variables are: name, version
 
 
 Examples
@@ -74,5 +140,18 @@ Generates a basic *conanfile.py* that does not implement any custom functionalit
 Generates a *conanfile.py* for ``mygame`` that depends on the packages ``math/1.0`` and ``ai/1.3``
 
 
+.. code-block:: bash
+
+    $ conan new cmake_exe -d name=game -d version=1.0 -d requires=math/3.14 -d requires=ai/1.0
+
+Generates the necessary files for a CMake executable target.
+This will add requirements for both ``math/3.14`` and ``ai/1.0`` to the `requirements()` method,
+will add the necessary ``find_package`` in CMake, and add a call to ``math()`` and ``ai()``
+inside the generated ``game()`` function.
 
 
+Custom templates
+----------------
+
+There's also the possibility to create your own templates by passing a path to your template file,
+both as an absolute path, or relative to your Conan home folder.


### PR DESCRIPTION
For https://github.com/conan-io/conan/pull/12802 and https://github.com/conan-io/conan/pull/12830

Focuses in `conan new basic` as that's what I implemented in the first linked PR, but also updates the available definitions for the rest of the templates