### PR TITLE
Add docs for `--no-remotes` flag

### DIFF
--- a/reference/commands.rst
+++ b/reference/commands.rst
@@ -53,7 +53,7 @@ and these :ref:`custom command examples <examples_extensions_custom_commands>`
 
 
 - :doc:`conan create <commands/create>`: Create a package from a recipe
-- :doc:`conan export <commands/create>`: Export a recipe to the Conan package cache
+- :doc:`conan export <commands/export>`: Export a recipe to the Conan package cache
 - :doc:`conan test <commands/test>`: Test a package
 - :doc:`conan upload <commands/upload>`: Upload packages from the local cache to a specified remote
 

--- a/reference/commands.rst
+++ b/reference/commands.rst
@@ -46,6 +46,23 @@ and these :ref:`custom command examples <examples_extensions_custom_commands>`
    :maxdepth: 1
    :hidden:
 
+   commands/create
+   commands/export
+   commands/test
    commands/upload
 
+
+- :doc:`conan create <commands/create>`: Create a package from a recipe
+- :doc:`conan export <commands/create>`: Export a recipe to the Conan package cache
+- :doc:`conan test <commands/test>`: Test a package
 - :doc:`conan upload <commands/upload>`: Upload packages from the local cache to a specified remote
+
+
+.. toctree::
+   :caption: Development commands
+   :maxdepth: 1
+   :hidden:
+
+   commands/build
+
+- :doc:`conan build <commands/build>`: Install package and call its build method

--- a/reference/commands/build.rst
+++ b/reference/commands/build.rst
@@ -1,0 +1,72 @@
+conan build
+===========
+
+.. code-block:: text
+
+    $ conan build --help
+    usage: conan build [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [-of OUTPUT_FOLDER] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                       [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                       [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean]
+                       [path]
+
+    Install + calls the build() method
+
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
+                            The root output folder for generated and build files
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes
+                            precedence over the command line parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if
+                            a binary package is not found. Cannot be combined with other '--build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have
+                            at least one dependency being built from source. --build=[pattern] Build packages from source whose package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded
+                            packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. Default behavior: If you omit the '--build' option, the 'build_policy'
+                            attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+      -r REMOTE, --remote REMOTE
+                            Look in the specified remote or remotes server
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that
+                            satisfies the range. Also, if using revisions, it will update to the latest revision for the resolved version range.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+                            Apply the specified profile to the build machine
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
+
+
+The ``conan build`` command installs the recipe specified in ``path`` and calls its ``build`` method

--- a/reference/commands/build.rst
+++ b/reference/commands/build.rst
@@ -69,4 +69,4 @@ conan build
       --lockfile-clean      remove unused
 
 
-The ``conan build`` command installs the recipe specified in ``path`` and calls its ``build`` method
+The ``conan build`` command installs the recipe specified in ``path`` and calls its ``build`` method.

--- a/reference/commands/create.rst
+++ b/reference/commands/create.rst
@@ -3,51 +3,76 @@ conan create
 
 .. code-block:: text
 
-    $ conan create --help
-    usage: conan create [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean] [-b BUILD] [-r REMOTE | -nr] [-u]
-                        [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [--build-require]
-                        [-tf TEST_FOLDER]
-                        path
+    $ conan build --help
+    usage: conan build [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]
+                       [--user USER] [--channel CHANNEL] [-of OUTPUT_FOLDER] [-b BUILD]
+                       [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
+                       [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                       [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
+                       [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
+                       [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                       [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                       [--lockfile-clean]
+                       [path]
 
-    Create a package
+    Install + calls the build() method
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py)
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -f FORMAT, --format FORMAT
-                            Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       --name NAME           Provide a package name if not specified in conanfile
       --version VERSION     Provide a package version if not specified in conanfile
       --user USER           Provide a user if not specified in conanfile
       --channel CHANNEL     Provide a channel if not specified in conanfil
-      -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
-      --lockfile-out LOCKFILE_OUT
-                            Filename of the updated lockfile
-      --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
+                            The root output folder for generated and build files
       -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
-                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
-                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
-                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
-                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command line is
+                            allowed. For dependencies, the optional 'build_policy'
+                            attribute in their conanfile.py takes precedence over the
+                            command line parameter. Possible parameters: --build="*" Force
+                            build for all packages, do not use binary packages.
+                            --build=never Disallow build for all packages, use binary
+                            packages or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing Build
+                            packages from source whose binary package is not found.
+                            --build=cascade Build packages from source that have at least
+                            one dependency being built from source. --build=[pattern]
+                            Build packages from source whose package reference matches the
+                            pattern. The pattern uses 'fnmatch' style wildcards.
+                            --build=![pattern] Excluded packages, which will not be built
+                            from the source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards. Default behavior:
+                            If you omit the '--build' option, the 'build_policy' attribute
+                            in conanfile.py will be used if it exists, otherwise the
+                            behavior is like '--build=never'.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
-                            revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version and/or
+                            revision of the dependencies exists there, it will install
+                            those in the local cache. When using version ranges, it will
+                            install the latest version that satisfies the range. Also, if
+                            using revisions, it will update to the latest revision for the
+                            resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -55,20 +80,34 @@ conan create
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the defaults (build
+                            machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
-      --build-require       The provided reference is a build-require
-      -tf TEST_FOLDER, --test-folder TEST_FOLDER
-                            Alternative test folder name. By default it is "test_package". Use "None" to skip the test stage
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
 
 
 The ``conan create`` command creates a package from the recipe specified in ``path``.

--- a/reference/commands/create.rst
+++ b/reference/commands/create.rst
@@ -1,0 +1,74 @@
+conan create
+============
+
+.. code-block:: text
+
+    $ conan create --help
+    usage: conan create [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean] [-b BUILD] [-r REMOTE | -nr] [-u]
+                        [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [--build-require]
+                        [-tf TEST_FOLDER]
+                        path
+
+    Create a package
+
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py)
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
+                            Select the output format: json
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
+                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
+                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
+                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+      -r REMOTE, --remote REMOTE
+                            Look in the specified remote or remotes server
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
+                            revisions, it will update to the latest revision for the resolved version range.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+                            Apply the specified profile to the build machine
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+      --build-require       The provided reference is a build-require
+      -tf TEST_FOLDER, --test-folder TEST_FOLDER
+                            Alternative test folder name. By default it is "test_package". Use "None" to skip the test stage
+
+
+The ``conan create`` command creates a package from the recipe specified in ``path``.

--- a/reference/commands/export.rst
+++ b/reference/commands/export.rst
@@ -4,7 +4,11 @@ conan export
 .. code-block:: text
 
     $ conan export --help
-    usage: conan export [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [-r REMOTE | -nr] [-l LOCKFILE] [--lockfile-out LOCKFILE_OUT] [--lockfile-partial] [--build-require] path
+    usage: conan export [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
+                        [--version VERSION] [--user USER] [--channel CHANNEL]
+                        [-r REMOTE | -nr] [-l LOCKFILE] [--lockfile-out LOCKFILE_OUT]
+                        [--lockfile-partial] [--build-require]
+                        path
 
     Export recipe to the Conan package cache
 
@@ -15,7 +19,9 @@ conan export
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       --name NAME           Provide a package name if not specified in conanfile
       --version VERSION     Provide a package version if not specified in conanfile
@@ -28,7 +34,8 @@ conan export
                             Path to a lockfile.
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
       --build-require       The provided reference is a build-require
 
 

--- a/reference/commands/export.rst
+++ b/reference/commands/export.rst
@@ -1,0 +1,35 @@
+conan export
+============
+
+.. code-block:: text
+
+    $ conan export --help
+    usage: conan export [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [-r REMOTE | -nr] [-l LOCKFILE] [--lockfile-out LOCKFILE_OUT] [--lockfile-partial] [--build-require] path
+
+    Export recipe to the Conan package cache
+
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py)
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
+                            Select the output format: json
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      -r REMOTE, --remote REMOTE
+                            Look in the specified remote or remotes server
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --build-require       The provided reference is a build-require
+
+
+The ``conan export`` command exports the recipe specified in ``path`` to the Conan package cache.

--- a/reference/commands/graph/build_order.rst
+++ b/reference/commands/graph/build_order.rst
@@ -4,21 +4,34 @@ conan graph build-order
 .. code-block:: text
 
     $ conan graph build-order --help
-    usage: conan graph build-order [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                                   [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                                   [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean]
+    usage: conan graph build-order [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
+                                   [--version VERSION] [--user USER] [--channel CHANNEL]
+                                   [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
+                                   [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                                   [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                                   [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                                   [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                                   [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                                   [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+                                   [-l LOCKFILE] [--lockfile-partial]
+                                   [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                                   [--lockfile-clean]
                                    [path]
 
     Computes the build order of a dependency graph
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
 
     optional arguments:
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       --name NAME           Provide a package name if not specified in conanfile
       --version VERSION     Provide a package version if not specified in conanfile
@@ -28,22 +41,44 @@ conan graph build-order
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
-                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
-                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
-                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
-                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command line is
+                            allowed. For dependencies, the optional 'build_policy'
+                            attribute in their conanfile.py takes precedence over the
+                            command line parameter. Possible parameters: --build="*" Force
+                            build for all packages, do not use binary packages.
+                            --build=never Disallow build for all packages, use binary
+                            packages or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing Build
+                            packages from source whose binary package is not found.
+                            --build=cascade Build packages from source that have at least
+                            one dependency being built from source. --build=[pattern]
+                            Build packages from source whose package reference matches the
+                            pattern. The pattern uses 'fnmatch' style wildcards.
+                            --build=![pattern] Excluded packages, which will not be built
+                            from the source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards. Default behavior:
+                            If you omit the '--build' option, the 'build_policy' attribute
+                            in conanfile.py will be used if it exists, otherwise the
+                            behavior is like '--build=never'.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
-                            revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version and/or
+                            revision of the dependencies exists there, it will install
+                            those in the local cache. When using version ranges, it will
+                            install the latest version that satisfies the range. Also, if
+                            using revisions, it will update to the latest revision for the
+                            resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -51,24 +86,34 @@ conan graph build-order
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the defaults (build
+                            machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
                             Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
       --lockfile-clean      remove unused
 
 
-Computes the build order of the dependency graph for the recipe specified in ``path``.
+The ``conan graph build-order`` command compues build order of the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/graph/build_order.rst
+++ b/reference/commands/graph/build_order.rst
@@ -1,2 +1,74 @@
 conan graph build-order
 =======================
+
+.. code-block:: text
+
+    $ conan graph build-order --help
+    usage: conan graph build-order [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
+                                   [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                                   [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean]
+                                   [path]
+
+    Computes the build order of a dependency graph
+
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
+                            Select the output format: json
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --requires REQUIRES   Directly provide requires instead of a conanfile
+      --tool-requires TOOL_REQUIRES
+                            Directly provide tool-requires instead of a conanfile
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
+                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
+                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
+                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+      -r REMOTE, --remote REMOTE
+                            Look in the specified remote or remotes server
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
+                            revisions, it will update to the latest revision for the resolved version range.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+                            Apply the specified profile to the build machine
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
+
+
+Computes the build order of the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/graph/info.rst
+++ b/reference/commands/graph/info.rst
@@ -4,120 +4,120 @@ conan graph info
 .. code-block:: text
         
     $ conan graph info --help
-usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
-                        [--version VERSION] [--user USER] [--channel CHANNEL]
-                        [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
-                        [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
-                        [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
-                        [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
-                        [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
-                        [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
-                        [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
-                        [--lockfile-packages] [--lockfile-clean] [--check-updates]
-                        [--filter FILTER] [--package-filter PACKAGE_FILTER]
-                        [--deploy DEPLOY]
-                        [path]
+    usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
+                            [--version VERSION] [--user USER] [--channel CHANNEL]
+                            [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
+                            [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                            [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
+                            [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                            [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
+                            [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
+                            [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                            [--lockfile-packages] [--lockfile-clean] [--check-updates]
+                            [--filter FILTER] [--package-filter PACKAGE_FILTER]
+                            [--deploy DEPLOY]
+                            [path]
 
-Computes the dependency graph and shows information about it
+    Computes the dependency graph and shows information about it
 
-positional arguments:
-  path                  Path to a folder containing a recipe (conanfile.py or
-                        conanfile.txt) or to a recipe file. e.g.,
-                        ./my_project/conanfile.txt.
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -f FORMAT, --format FORMAT
-                        Select the output format: html, json, dot
-  -v [V]                Level of detail of the output. Valid options from less verbose
-                        to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                        -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-  --logger              Show the output with log format, with time, type and message.
-  --name NAME           Provide a package name if not specified in conanfile
-  --version VERSION     Provide a package version if not specified in conanfile
-  --user USER           Provide a user if not specified in conanfile
-  --channel CHANNEL     Provide a channel if not specified in conanfil
-  --requires REQUIRES   Directly provide requires instead of a conanfile
-  --tool-requires TOOL_REQUIRES
-                        Directly provide tool-requires instead of a conanfile
-  -b BUILD, --build BUILD
-                        Optional, specify which packages to build from source.
-                        Combining multiple '--build' options on one command line is
-                        allowed. For dependencies, the optional 'build_policy'
-                        attribute in their conanfile.py takes precedence over the
-                        command line parameter. Possible parameters: --build="*" Force
-                        build for all packages, do not use binary packages.
-                        --build=never Disallow build for all packages, use binary
-                        packages or fail if a binary package is not found. Cannot be
-                        combined with other '--build' options. --build=missing Build
-                        packages from source whose binary package is not found.
-                        --build=cascade Build packages from source that have at least
-                        one dependency being built from source. --build=[pattern]
-                        Build packages from source whose package reference matches the
-                        pattern. The pattern uses 'fnmatch' style wildcards.
-                        --build=![pattern] Excluded packages, which will not be built
-                        from the source, whose package reference matches the pattern.
-                        The pattern uses 'fnmatch' style wildcards. Default behavior:
-                        If you omit the '--build' option, the 'build_policy' attribute
-                        in conanfile.py will be used if it exists, otherwise the
-                        behavior is like '--build=never'.
-  -r REMOTE, --remote REMOTE
-                        Look in the specified remote or remotes server
-  -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-  -u, --update          Will check the remote and in case a newer version and/or
-                        revision of the dependencies exists there, it will install
-                        those in the local cache. When using version ranges, it will
-                        install the latest version that satisfies the range. Also, if
-                        using revisions, it will update to the latest revision for the
-                        resolved version range.
-  -o OPTIONS_HOST, --options OPTIONS_HOST
-                        Define options values (host machine), e.g.: -o
-                        Pkg:with_qt=true
-  -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                        Define options values (build machine), e.g.: -o:b
-                        Pkg:with_qt=true
-  -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                        Define options values (host machine), e.g.: -o:h
-                        Pkg:with_qt=true
-  -pr PROFILE_HOST, --profile PROFILE_HOST
-                        Apply the specified profile to the host machine
-  -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
-                        Apply the specified profile to the build machine
-  -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
-                        Apply the specified profile to the host machine
-  -s SETTINGS_HOST, --settings SETTINGS_HOST
-                        Settings to build the package, overwriting the defaults (host
-                        machine). e.g.: -s compiler=gcc
-  -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                        Settings to build the package, overwriting the defaults (build
-                        machine). e.g.: -s:b compiler=gcc
-  -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                        Settings to build the package, overwriting the defaults (host
-                        machine). e.g.: -s:h compiler=gcc
-  -c CONF_HOST, --conf CONF_HOST
-                        Configuration to build the package, overwriting the defaults
-                        (host machine). e.g.: -c
-                        tools.cmake.cmaketoolchain:generator=Xcode
-  -c:b CONF_BUILD, --conf:build CONF_BUILD
-                        Configuration to build the package, overwriting the defaults
-                        (build machine). e.g.: -c:b
-                        tools.cmake.cmaketoolchain:generator=Xcode
-  -c:h CONF_HOST, --conf:host CONF_HOST
-                        Configuration to build the package, overwriting the defaults
-                        (host machine). e.g.: -c:h
-                        tools.cmake.cmaketoolchain:generator=Xcode
-  -l LOCKFILE, --lockfile LOCKFILE
-                        Path to a lockfile.
-  --lockfile-partial    Do not raise an error if some dependency is not found in
-                        lockfile
-  --lockfile-out LOCKFILE_OUT
-                        Filename of the updated lockfile
-  --lockfile-packages   Lock package-id and package-revision information
-  --lockfile-clean      remove unused
-  --check-updates
-  --filter FILTER       Show only the specified fields
-  --package-filter PACKAGE_FILTER
-                        Print information only for packages that match the patterns
-  --deploy DEPLOY       Deploy using the provided deployer to the output folder
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
+                            Select the output format: html, json, dot
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --requires REQUIRES   Directly provide requires instead of a conanfile
+      --tool-requires TOOL_REQUIRES
+                            Directly provide tool-requires instead of a conanfile
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command line is
+                            allowed. For dependencies, the optional 'build_policy'
+                            attribute in their conanfile.py takes precedence over the
+                            command line parameter. Possible parameters: --build="*" Force
+                            build for all packages, do not use binary packages.
+                            --build=never Disallow build for all packages, use binary
+                            packages or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing Build
+                            packages from source whose binary package is not found.
+                            --build=cascade Build packages from source that have at least
+                            one dependency being built from source. --build=[pattern]
+                            Build packages from source whose package reference matches the
+                            pattern. The pattern uses 'fnmatch' style wildcards.
+                            --build=![pattern] Excluded packages, which will not be built
+                            from the source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards. Default behavior:
+                            If you omit the '--build' option, the 'build_policy' attribute
+                            in conanfile.py will be used if it exists, otherwise the
+                            behavior is like '--build=never'.
+      -r REMOTE, --remote REMOTE
+                            Look in the specified remote or remotes server
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -u, --update          Will check the remote and in case a newer version and/or
+                            revision of the dependencies exists there, it will install
+                            those in the local cache. When using version ranges, it will
+                            install the latest version that satisfies the range. Also, if
+                            using revisions, it will update to the latest revision for the
+                            resolved version range.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+                            Apply the specified profile to the build machine
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the defaults (build
+                            machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults
+                            (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
+      --check-updates
+      --filter FILTER       Show only the specified fields
+      --package-filter PACKAGE_FILTER
+                            Print information only for packages that match the patterns
+      --deploy DEPLOY       Deploy using the provided deployer to the output folder
 
 The ``conan graph info`` command shows information about the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/graph/info.rst
+++ b/reference/commands/graph/info.rst
@@ -4,9 +4,17 @@ conan graph info
 .. code-block:: text
         
     $ conan graph info --help
-    usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                            [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                            [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean] [--check-updates] [--filter FILTER] [--package-filter PACKAGE_FILTER] [--deploy DEPLOY]
+    usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION]
+                            [--user USER] [--channel CHANNEL] [--requires REQUIRES]
+                            [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u]
+                            [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                            [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
+                            [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                            [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+                            [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                            [--lockfile-packages] [--lockfile-clean]
+                            [--check-updates] [--filter FILTER] [--package-filter PACKAGE_FILTER]
+                            [--deploy DEPLOY]
                             [path]
 
     Computes the dependency graph and shows information about it
@@ -28,16 +36,29 @@ conan graph info
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
-                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
-                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
-                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
-                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command line is allowed.
+                            For dependencies, the optional 'build_policy' attribute in their conanfile.py
+                            takes precedence over the command line parameter.
+                            Possible parameters: --build="*" Force build for all packages, do not use binary packages.
+                            --build=never Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be combined with other '--build' options.
+                            --build=missing Build packages from source whose binary package is not found.
+                            --build=cascade Build packages from source that have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=![pattern] Excluded packages, which will not be built from the source,
+                            whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            Default behavior: If you omit the '--build' option, the 'build_policy' attribute
+                            in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
-                            revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version and/or revision
+                            of the dependencies exists there, it will install those in the local cache.
+                            When using version ranges, it will install the latest version that satisfies the range.
+                            Also, if using revisions, it will update to the latest revision for the resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD

--- a/reference/commands/graph/info.rst
+++ b/reference/commands/graph/info.rst
@@ -4,105 +4,120 @@ conan graph info
 .. code-block:: text
         
     $ conan graph info --help
-    usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION]
-                            [--user USER] [--channel CHANNEL] [--requires REQUIRES]
-                            [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u]
-                            [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
-                            [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
-                            [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
-                            [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
-                            [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
-                            [--lockfile-packages] [--lockfile-clean]
-                            [--check-updates] [--filter FILTER] [--package-filter PACKAGE_FILTER]
-                            [--deploy DEPLOY]
-                            [path]
+usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
+                        [--version VERSION] [--user USER] [--channel CHANNEL]
+                        [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
+                        [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                        [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
+                        [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                        [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
+                        [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
+                        [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                        [--lockfile-packages] [--lockfile-clean] [--check-updates]
+                        [--filter FILTER] [--package-filter PACKAGE_FILTER]
+                        [--deploy DEPLOY]
+                        [path]
 
-    Computes the dependency graph and shows information about it
+Computes the dependency graph and shows information about it
 
-    positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+positional arguments:
+  path                  Path to a folder containing a recipe (conanfile.py or
+                        conanfile.txt) or to a recipe file. e.g.,
+                        ./my_project/conanfile.txt.
 
-    optional arguments:
-      -h, --help            show this help message and exit
-      -f FORMAT, --format FORMAT
-                            Select the output format: html, json, dot
-      -v [V]                Level of detail of the output.Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
-      --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
-      --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfile
-      --requires REQUIRES   Directly provide requires instead of a conanfile
-      --tool-requires TOOL_REQUIRES
-                            Directly provide tool-requires instead of a conanfile
-      -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source.
-                            Combining multiple '--build' options on one command line is allowed.
-                            For dependencies, the optional 'build_policy' attribute in their conanfile.py
-                            takes precedence over the command line parameter.
-                            Possible parameters: --build="*" Force build for all packages, do not use binary packages.
-                            --build=never Disallow build for all packages, use binary packages
-                            or fail if a binary package is not found. Cannot be combined with other '--build' options.
-                            --build=missing Build packages from source whose binary package is not found.
-                            --build=cascade Build packages from source that have at least one dependency being built from source.
-                            --build=[pattern] Build packages from source whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards.
-                            --build=![pattern] Excluded packages, which will not be built from the source,
-                            whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards.
-                            Default behavior: If you omit the '--build' option, the 'build_policy' attribute
-                            in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
-      -r REMOTE, --remote REMOTE
-                            Look in the specified remote or remotes server
-      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision
-                            of the dependencies exists there, it will install those in the local cache.
-                            When using version ranges, it will install the latest version that satisfies the range.
-                            Also, if using revisions, it will update to the latest revision for the resolved version range.
-      -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine)
-                            e.g.: -o Pkg:with_qt=true
-      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine)
-                            e.g.: -o:b Pkg:with_qt=true
-      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine)
-                            e.g.: -o:h Pkg:with_qt=true
-      -pr PROFILE_HOST, --profile PROFILE_HOST
-                            Apply the specified profile to the host machine
-      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
-                            Apply the specified profile to the build machine
-      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
-                            Apply the specified profile to the host machine
-      -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine)
-                            e.g.: -s compiler=gcc
-      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine)
-                            e.g.: -s:b compiler=gcc
-      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine)
-                            e.g.: -s:h compiler=gcc
-      -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine)
-                            e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
-      -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine)
-                            e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
-      -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine)
-                            e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
-      -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
-      --lockfile-out LOCKFILE_OUT
-                            Filename of the updated lockfile
-      --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
-      --check-updates
-      --filter FILTER       Show only the specified fields
-      --package-filter PACKAGE_FILTER
-                            Print information only for packages that match the patterns
-      --deploy DEPLOY       Deploy using the provided deployer to the output folder
+optional arguments:
+  -h, --help            show this help message and exit
+  -f FORMAT, --format FORMAT
+                        Select the output format: html, json, dot
+  -v [V]                Level of detail of the output. Valid options from less verbose
+                        to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                        -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+  --logger              Show the output with log format, with time, type and message.
+  --name NAME           Provide a package name if not specified in conanfile
+  --version VERSION     Provide a package version if not specified in conanfile
+  --user USER           Provide a user if not specified in conanfile
+  --channel CHANNEL     Provide a channel if not specified in conanfil
+  --requires REQUIRES   Directly provide requires instead of a conanfile
+  --tool-requires TOOL_REQUIRES
+                        Directly provide tool-requires instead of a conanfile
+  -b BUILD, --build BUILD
+                        Optional, specify which packages to build from source.
+                        Combining multiple '--build' options on one command line is
+                        allowed. For dependencies, the optional 'build_policy'
+                        attribute in their conanfile.py takes precedence over the
+                        command line parameter. Possible parameters: --build="*" Force
+                        build for all packages, do not use binary packages.
+                        --build=never Disallow build for all packages, use binary
+                        packages or fail if a binary package is not found. Cannot be
+                        combined with other '--build' options. --build=missing Build
+                        packages from source whose binary package is not found.
+                        --build=cascade Build packages from source that have at least
+                        one dependency being built from source. --build=[pattern]
+                        Build packages from source whose package reference matches the
+                        pattern. The pattern uses 'fnmatch' style wildcards.
+                        --build=![pattern] Excluded packages, which will not be built
+                        from the source, whose package reference matches the pattern.
+                        The pattern uses 'fnmatch' style wildcards. Default behavior:
+                        If you omit the '--build' option, the 'build_policy' attribute
+                        in conanfile.py will be used if it exists, otherwise the
+                        behavior is like '--build=never'.
+  -r REMOTE, --remote REMOTE
+                        Look in the specified remote or remotes server
+  -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+  -u, --update          Will check the remote and in case a newer version and/or
+                        revision of the dependencies exists there, it will install
+                        those in the local cache. When using version ranges, it will
+                        install the latest version that satisfies the range. Also, if
+                        using revisions, it will update to the latest revision for the
+                        resolved version range.
+  -o OPTIONS_HOST, --options OPTIONS_HOST
+                        Define options values (host machine), e.g.: -o
+                        Pkg:with_qt=true
+  -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                        Define options values (build machine), e.g.: -o:b
+                        Pkg:with_qt=true
+  -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                        Define options values (host machine), e.g.: -o:h
+                        Pkg:with_qt=true
+  -pr PROFILE_HOST, --profile PROFILE_HOST
+                        Apply the specified profile to the host machine
+  -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+                        Apply the specified profile to the build machine
+  -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+                        Apply the specified profile to the host machine
+  -s SETTINGS_HOST, --settings SETTINGS_HOST
+                        Settings to build the package, overwriting the defaults (host
+                        machine). e.g.: -s compiler=gcc
+  -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                        Settings to build the package, overwriting the defaults (build
+                        machine). e.g.: -s:b compiler=gcc
+  -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                        Settings to build the package, overwriting the defaults (host
+                        machine). e.g.: -s:h compiler=gcc
+  -c CONF_HOST, --conf CONF_HOST
+                        Configuration to build the package, overwriting the defaults
+                        (host machine). e.g.: -c
+                        tools.cmake.cmaketoolchain:generator=Xcode
+  -c:b CONF_BUILD, --conf:build CONF_BUILD
+                        Configuration to build the package, overwriting the defaults
+                        (build machine). e.g.: -c:b
+                        tools.cmake.cmaketoolchain:generator=Xcode
+  -c:h CONF_HOST, --conf:host CONF_HOST
+                        Configuration to build the package, overwriting the defaults
+                        (host machine). e.g.: -c:h
+                        tools.cmake.cmaketoolchain:generator=Xcode
+  -l LOCKFILE, --lockfile LOCKFILE
+                        Path to a lockfile.
+  --lockfile-partial    Do not raise an error if some dependency is not found in
+                        lockfile
+  --lockfile-out LOCKFILE_OUT
+                        Filename of the updated lockfile
+  --lockfile-packages   Lock package-id and package-revision information
+  --lockfile-clean      remove unused
+  --check-updates
+  --filter FILTER       Show only the specified fields
+  --package-filter PACKAGE_FILTER
+                        Print information only for packages that match the patterns
+  --deploy DEPLOY       Deploy using the provided deployer to the output folder
 
 The ``conan graph info`` command shows information about the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/graph/info.rst
+++ b/reference/commands/graph/info.rst
@@ -26,12 +26,12 @@ conan graph info
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: html, json, dot
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output.Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       --name NAME           Provide a package name if not specified in conanfile
       --version VERSION     Provide a package version if not specified in conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       --requires REQUIRES   Directly provide requires instead of a conanfile
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
@@ -60,11 +60,14 @@ conan graph info
                             When using version ranges, it will install the latest version that satisfies the range.
                             Also, if using revisions, it will update to the latest revision for the resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine)
+                            e.g.: -o Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine)
+                            e.g.: -o:b Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine)
+                            e.g.: -o:h Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -72,17 +75,23 @@ conan graph info
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the defaults (host machine)
+                            e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the defaults (build machine)
+                            e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the defaults (host machine)
+                            e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults (host machine)
+                            e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults (build machine)
+                            e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults (host machine)
+                            e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
                             Path to a lockfile.
       --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
@@ -96,4 +105,4 @@ conan graph info
                             Print information only for packages that match the patterns
       --deploy DEPLOY       Deploy using the provided deployer to the output folder
 
-Shows information about the dependency graph for the recipe specified in ``path``.
+The ``conan graph info`` command shows information about the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -4,9 +4,17 @@ conan install
 .. code-block:: text
 
     $ conan install --help
-    usage: conan install [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                         [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                         [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean] [-g GENERATOR] [-of OUTPUT_FOLDER] [--deploy DEPLOY]
+    usage: conan install [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
+                         [--version VERSION] [--user USER] [--channel CHANNEL]
+                         [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD]
+                         [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
+                         [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                         [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
+                         [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
+                         [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                         [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                         [--lockfile-clean] [-g GENERATOR] [-of OUTPUT_FOLDER]
+                         [--deploy DEPLOY]
                          [path]
 
     Installs the requirements specified in a recipe (conanfile.py or conanfile.txt).
@@ -22,13 +30,17 @@ conan install
     generators.
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
 
     optional arguments:
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       --name NAME           Provide a package name if not specified in conanfile
       --version VERSION     Provide a package version if not specified in conanfile
@@ -38,22 +50,44 @@ conan install
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
-                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
-                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
-                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
-                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command line is
+                            allowed. For dependencies, the optional 'build_policy'
+                            attribute in their conanfile.py takes precedence over the
+                            command line parameter. Possible parameters: --build="*" Force
+                            build for all packages, do not use binary packages.
+                            --build=never Disallow build for all packages, use binary
+                            packages or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing Build
+                            packages from source whose binary package is not found.
+                            --build=cascade Build packages from source that have at least
+                            one dependency being built from source. --build=[pattern]
+                            Build packages from source whose package reference matches the
+                            pattern. The pattern uses 'fnmatch' style wildcards.
+                            --build=![pattern] Excluded packages, which will not be built
+                            from the source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards. Default behavior:
+                            If you omit the '--build' option, the 'build_policy' attribute
+                            in conanfile.py will be used if it exists, otherwise the
+                            behavior is like '--build=never'.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
-                            revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version and/or
+                            revision of the dependencies exists there, it will install
+                            those in the local cache. When using version ranges, it will
+                            install the latest version that satisfies the range. Also, if
+                            using revisions, it will update to the latest revision for the
+                            resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -61,20 +95,30 @@ conan install
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the defaults (build
+                            machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
                             Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information

--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -1,15 +1,13 @@
 conan install
 =============
 
-.. code-block:: bash
+.. code-block:: text
 
-    conan install -h
-    usage: conan install [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES]
-                        [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
-                        [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
-                        [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
-                        [--lockfile-packages] [--lockfile-clean] [-g GENERATOR] [-of OUTPUT_FOLDER] [--deploy DEPLOY]
-                        [path]
+    $ conan install --help
+    usage: conan install [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
+                         [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                         [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean] [-g GENERATOR] [-of OUTPUT_FOLDER] [--deploy DEPLOY]
+                         [path]
 
     Installs the requirements specified in a recipe (conanfile.py or conanfile.txt).
 
@@ -24,73 +22,68 @@ conan install
     generators.
 
     positional arguments:
-    path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v
-                            or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    --name NAME           Provide a package name if not specified in conanfile
-    --version VERSION     Provide a package version if not specified in conanfile
-    --user USER           Provide a user if not specified in conanfile
-    --channel CHANNEL     Provide a channel if not specified in conanfil
-    --requires REQUIRES   Directly provide requires instead of a conanfile
-    --tool-requires TOOL_REQUIRES
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --requires REQUIRES   Directly provide requires instead of a conanfile
+      --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
-    -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For
-                            dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line parameter. Possible
-                            parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use
-                            binary packages or fail if a binary package is not found. Cannot be combined with other '--build' options. --build=missing Build
-                            packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency
-                            being built from source. --build=[pattern] Build packages from source whose package reference matches the pattern. The pattern uses
-                            'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference
-                            matches the pattern. The pattern uses 'fnmatch' style wildcards. Default behavior: If you omit the '--build' option, the
-                            'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
-    -r REMOTE, --remote REMOTE
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
+                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
+                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
+                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+      -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
-    -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the
-                            local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using revisions, it
-                            will update to the latest revision for the resolved version range.
-    -o OPTIONS_HOST, --options OPTIONS_HOST
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
+                            revisions, it will update to the latest revision for the resolved version range.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o Pkg:with_qt=true
-    -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
                             Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
-    -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
                             Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
-    -pr PROFILE_HOST, --profile PROFILE_HOST
+      -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
-    -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
                             Apply the specified profile to the build machine
-    -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
-    -s SETTINGS_HOST, --settings SETTINGS_HOST
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
                             Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
-    -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
                             Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
-    -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                             Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
-    -c CONF_HOST, --conf CONF_HOST
+      -c CONF_HOST, --conf CONF_HOST
                             Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
-    -c:b CONF_BUILD, --conf:build CONF_BUILD
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
                             Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
-    -c:h CONF_HOST, --conf:host CONF_HOST
+      -c:h CONF_HOST, --conf:host CONF_HOST
                             Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
-    -l LOCKFILE, --lockfile LOCKFILE
+      -l LOCKFILE, --lockfile LOCKFILE
                             Path to a lockfile.
-    --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
-    --lockfile-out LOCKFILE_OUT
+      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
-    --lockfile-packages   Lock package-id and package-revision information
-    --lockfile-clean      remove unused
-    -g GENERATOR, --generator GENERATOR
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
+      -g GENERATOR, --generator GENERATOR
                             Generators to use
-    -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
+      -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                             The root output folder for generated and build files
-    --deploy DEPLOY       Deploy using the provided deployer to the output folder
+      --deploy DEPLOY       Deploy using the provided deployer to the output folder
 
 
 The ``conan install`` command is one of the main Conan commands, and it is used to resolve and install dependencies.

--- a/reference/commands/lock/create.rst
+++ b/reference/commands/lock/create.rst
@@ -1,2 +1,70 @@
 conan lock create
 =================
+
+.. code-block:: text
+    $ conan lock create --help
+    usage: conan lock create [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                             [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                             [--lockfile-packages] [--lockfile-clean]
+                             [path]
+
+    Create a lockfile from a conanfile or a reference
+
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --requires REQUIRES   Directly provide requires instead of a conanfile
+      --tool-requires TOOL_REQUIRES
+                            Directly provide tool-requires instead of a conanfile
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
+                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
+                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
+                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+      -r REMOTE, --remote REMOTE
+                            Look in the specified remote or remotes server
+      -nr, --no-remote      Do not use remote, resolve exclusively in the cache
+      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
+                            revisions, it will update to the latest revision for the resolved version range.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+                            Apply the specified profile to the build machine
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+                            Apply the specified profile to the host machine
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile.
+      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      remove unused
+
+The ``conan lock create`` command creates a lockfile for the recipe or reference specified in ``path``.

--- a/reference/commands/lock/create.rst
+++ b/reference/commands/lock/create.rst
@@ -2,20 +2,32 @@ conan lock create
 =================
 
 .. code-block:: text
+
     $ conan lock create --help
-    usage: conan lock create [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
-                             [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
-                             [--lockfile-packages] [--lockfile-clean]
+    usage: conan lock create [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]
+                             [--user USER] [--channel CHANNEL] [--requires REQUIRES]
+                             [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr]
+                             [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
+                             [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                             [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
+                             [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
+                             [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                             [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                             [--lockfile-clean]
                              [path]
 
     Create a lockfile from a conanfile or a reference
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       --name NAME           Provide a package name if not specified in conanfile
       --version VERSION     Provide a package version if not specified in conanfile
@@ -25,22 +37,44 @@ conan lock create
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
-                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
-                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
-                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
-                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command line is
+                            allowed. For dependencies, the optional 'build_policy'
+                            attribute in their conanfile.py takes precedence over the
+                            command line parameter. Possible parameters: --build="*" Force
+                            build for all packages, do not use binary packages.
+                            --build=never Disallow build for all packages, use binary
+                            packages or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing Build
+                            packages from source whose binary package is not found.
+                            --build=cascade Build packages from source that have at least
+                            one dependency being built from source. --build=[pattern]
+                            Build packages from source whose package reference matches the
+                            pattern. The pattern uses 'fnmatch' style wildcards.
+                            --build=![pattern] Excluded packages, which will not be built
+                            from the source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards. Default behavior:
+                            If you omit the '--build' option, the 'build_policy' attribute
+                            in conanfile.py will be used if it exists, otherwise the
+                            behavior is like '--build=never'.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
-                            revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version and/or
+                            revision of the dependencies exists there, it will install
+                            those in the local cache. When using version ranges, it will
+                            install the latest version that satisfies the range. Also, if
+                            using revisions, it will update to the latest revision for the
+                            resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -48,20 +82,30 @@ conan lock create
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the defaults (build
+                            machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
                             Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information

--- a/reference/commands/test.rst
+++ b/reference/commands/test.rst
@@ -1,38 +1,23 @@
-conan graph info
-================
+conan test
+===========
 
 .. code-block:: text
-        
-    $ conan graph info --help
-    usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                            [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                            [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean] [--check-updates] [--filter FILTER] [--package-filter PACKAGE_FILTER] [--deploy DEPLOY]
-                            [path]
 
-    Computes the dependency graph and shows information about it
+    $ conan test --help
+    usage: conan test [-h] [-v [V]] [--logger] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
+                      [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean]
+                      path reference
+
+    Test a package from a test_package folder
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+      path                  Path to a test_package folder containing a conanfile.py
+      reference             Provide a package reference to test
 
     optional arguments:
       -h, --help            show this help message and exit
-      -f FORMAT, --format FORMAT
-                            Select the output format: html, json, dot
       -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
-      --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
-      --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
-      --requires REQUIRES   Directly provide requires instead of a conanfile
-      --tool-requires TOOL_REQUIRES
-                            Directly provide tool-requires instead of a conanfile
-      -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes precedence over the command line
-                            parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if a binary package is not found. Cannot be combined with other '--
-                            build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have at least one dependency being built from source. --build=[pattern] Build packages from source whose
-                            package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style
-                            wildcards. Default behavior: If you omit the '--build' option, the 'build_policy' attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
@@ -69,10 +54,6 @@ conan graph info
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
       --lockfile-clean      remove unused
-      --check-updates
-      --filter FILTER       Show only the specified fields
-      --package-filter PACKAGE_FILTER
-                            Print information only for packages that match the patterns
-      --deploy DEPLOY       Deploy using the provided deployer to the output folder
 
-Shows information about the dependency graph for the recipe specified in ``path``.
+
+The ``conan test`` command uses the *test_package* folder specified in ``path`` to tests the package reference specified in ``reference``.

--- a/reference/commands/test.rst
+++ b/reference/commands/test.rst
@@ -4,8 +4,13 @@ conan test
 .. code-block:: text
 
     $ conan test --help
-    usage: conan test [-h] [-v [V]] [--logger] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
-                      [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean]
+    usage: conan test [-h] [-v [V]] [--logger] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                      [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
+                      [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                      [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
+                      [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
+                      [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                      [--lockfile-packages] [--lockfile-clean]
                       path reference
 
     Test a package from a test_package folder
@@ -16,19 +21,28 @@ conan test
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      -v [V]                Level of detail of the output. Valid options from less verbose
+                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
       --logger              Show the output with log format, with time, type and message.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that satisfies the range. Also, if using
-                            revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version and/or
+                            revision of the dependencies exists there, it will install
+                            those in the local cache. When using version ranges, it will
+                            install the latest version that satisfies the range. Also, if
+                            using revisions, it will update to the latest revision for the
+                            resolved version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -36,20 +50,30 @@ conan test
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the defaults (build
+                            machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the defaults (host
+                            machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the defaults
+                            (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
                             Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+      --lockfile-partial    Do not raise an error if some dependency is not found in
+                            lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information


### PR DESCRIPTION
For https://github.com/conan-io/conan/pull/12808

Some of the commands did not have docs yet. For those, I've added a basic file with only the result of calling `--help` in each of them and adding a short description afterwards.
