### PR TITLE
Typo fix: mixed up profiles

### DIFF
--- a/integrations/cross_platform/android.rst
+++ b/integrations/cross_platform/android.rst
@@ -74,7 +74,7 @@ Also, do not forget to use build context when cross building to Android:
 
 .. code-block:: bash
 
-  conan install conanfile.txt -pr:h=default -pr:b=android
+  conan install conanfile.txt -pr:b=default -pr:h=android
 
 Where ``android`` is one of the profiles listed above.
 


### PR DESCRIPTION
Host and build profiles were mixed up in the android example