### PR TITLE
Add package_type to the migration guide

### DIFF
--- a/migrating_to_2.0/recipes.rst
+++ b/migrating_to_2.0/recipes.rst
@@ -488,10 +488,10 @@ other build systems, even a custom one, remember you should generate everything 
 If we are using that recipe for our project we can build it by typing:
 
 .. code-block:: bash
-    
+
     # This will generate the config files from the dependencies and the toolchain
     $ conan install .
-    
+
     # Windows
     $ cd build
     $ cmake .. -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake
@@ -997,3 +997,28 @@ the recipe for Conan 2.0:
   as default, the ``tools.system.package_manager:sudo`` configuration is ``False`` by default.
 * :ref:`systempackagetool` is initialized with ``default_mode='enabled'`` but for these new
   tools ``tools.system.package_manager:mode='check'`` is set by default.
+
+
+New package type attribute
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The new optional attribute ``package_type``, to help Conan package ID to choose a better default ``package_id_mode``.
+
+.. code-block:: python
+
+        from conan import ConanFile
+
+        class FoobarAppConanfile(ConanFile):
+            package_type = "application"
+
+
+The valid values are:
+
+    - **application**: The package is an application.
+    - **library**: The package is a generic library. It will try to determine the type of library (from shared-library, static-library, header-library) reading the self.options.shared (if declared) and the self.options.header_only
+    - **shared-library**: The package is a shared library only.
+    - **static-library**: The package is a static library only.
+    - **header-library**: The package is a header only library.
+    - **build-scripts**: The package only contains build scripts.
+    - **python-require**: The package is a python require.
+    - **unknown**: The type of the package is unknown.


### PR DESCRIPTION
The `package_type` attribute is getting popular in CCI: https://github.com/conan-io/conan-center-index/search?q=package_type  But it's not documented in Conan 1.x migration guide, so we need to point to Conan 2.x docs as reference.

closes #2790

Preview:

![Screenshot 2023-01-16 at 12-25-19 Migrating the recipes — conan 1 57 0 documentation](https://user-images.githubusercontent.com/4870173/212667592-0fd21cd6-d206-4ac9-97cf-d45e61e27e2e.png)
