### PR TITLE
Bumps Shpinx to 1.8.6

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -143,16 +143,16 @@ import conan
 html_theme = "conan"
 html_theme_path = conan.get_html_theme_path()
 
+# for sphinx-sitemap, and for the canonical url
+# This helps with SEO by asking crawlers to prefer serving latest
+html_baseurl = "https://docs.conan.io/en/latest/"
 
 # Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
+# further. For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  "base_url": "https://docs.conan.io/en/latest/",
+  "base_url": html_baseurl,
 }
-
-# for sphinx-sitemap
-html_baseurl = html_theme_options['base_url']
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.7.9
+sphinx==1.8.6
 docutils<0.18
 sphinx-sitemap>=2.1.0
 sphinxcontrib-spelling


### PR DESCRIPTION
The changelog of 1.7.9 -> 1.8.6 does not look like it affects us much.
I've checked our extra dependencies, and all seem to support/be supported by this version.

The change is motivated because of the idea that having search engines return outdated documentation is not great. This can be somewhat alleviated by adding a `<link rel="canonical" href="https://docs.conan.io/en/latest/">` tag to the HTML doc, which will ask crawlers to prefer to serve results from `https://docs.conan.io/en/latest/`. Note that this is not a redirect for the users, nor mandatory for the crawlers to follow. It's interesting to point out that this is how both the official Python and Sphinx's docs do things.

For Sphinx to be able to generate that tag, we needed to be on 1.8.
After investigating, I found that 1.8.6 looks good on paper as an easy-to-do version bump.
In fact, we don't run into troubles with new errors until 3.0.0, and those look to be minor problems which could be addressed with little effort. The first version that fails to build is 4.0.0, but then gets subsequently fixed in 4.3.1. After that, 5.3.0 deprecated Python 3.6, but it's not a problem for us and otherwise works ok, and 6.3.1 (the latest version right now) also seems to build ok.

After talking with @czoido, we concluded that the best approach would be to update to 1.8.4 as that's the one that carries less risk, and then leave the major version upgrading to after 2.0.

This should not be an issue for the SEO, and in my opinion might even help it, but it's something we also want to take into account.
There's always more than can be done, such as ensuring our sitemap looks ok, as that's something that we also do differently than the aforementioned Python and Sphinx's docs, but that's something that needs further discussing with @memsharded and @prince-chrismc

If this gets merged, we would need to recompile every released version for the changes to take into effect. We can start small in some old version noone uses anymore, and once things look good (Which they should, everything looks good both locally and in the Docker container used for this task), go from there.