### PR TITLE
Use Conan Center as remote for Conan 2.0 docs

### DIFF
--- a/examples/cross_build/android/android_studio.rst
+++ b/examples/cross_build/android/android_studio.rst
@@ -24,14 +24,6 @@ profile at ``os.api_level```
 Select a "C++ Standard" in the next window, again, remember the choice as later we should use the same in the profile at
 ``compiler.cppstd``.
 
-
-.. important::
-
-    In this example, we will retrieve Conan packages from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
 In the project generated with the wizard we have a folder ``cpp`` with a ``native-lib.cpp``. We are going to modify that
 file to use ``zlib`` and print a message with the used ``zlib`` version. Copy only the highlighted lines, it is important
 to keep the function name.

--- a/examples/tools/meson/mesontoolchain/build_simple_meson_project.rst
+++ b/examples/tools/meson/mesontoolchain/build_simple_meson_project.rst
@@ -11,14 +11,6 @@ that uses one of the most popular C++ libraries: `Zlib <https://zlib.net/>`__.
     This example is based on the main :ref:`Build a simple CMake project using Conan<consuming_packages_build_simple_cmake_project>`
     tutorial. So we highly recommend reading it before trying out this one.
 
-.. important::
-
-    We have to retrieve the Zlib Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 We'll use Meson as build system and pkg-config as helper tool in this case, so you should get them installed
 before going forward with this example.
 

--- a/tutorial/consuming_packages/build_simple_cmake_project.rst
+++ b/tutorial/consuming_packages/build_simple_cmake_project.rst
@@ -6,13 +6,6 @@ Build a simple CMake project using Conan
 Let's get started with an example: We are going to create a string compressor application
 that uses one of the most popular C++ libraries: `Zlib <https://zlib.net/>`__.
 
-.. important::
-
-    In this example, we will retrieve the Zlib Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
 We'll use CMake as build system in this case but keep in mind that Conan **works with any
 build system** and is not limited to using CMake. You can check more examples with other
 build systems in the :ref:`Read More

--- a/tutorial/consuming_packages/cross_building_with_conan.rst
+++ b/tutorial/consuming_packages/cross_building_with_conan.rst
@@ -3,14 +3,6 @@
 How to cross-compile your applications using Conan: host and build contexts
 ===========================================================================
 
-.. important::
-
-    In this example, we will retrieve Conan packages from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 Please, first clone the sources to recreate this project. You can find them in the
 `examples2.0 repository <https://github.com/conan-io/examples2>`_ on GitHub:
 

--- a/tutorial/consuming_packages/different_configurations.rst
+++ b/tutorial/consuming_packages/different_configurations.rst
@@ -3,14 +3,6 @@
 Building for multiple configurations: Release, Debug, Static and Shared
 =======================================================================
 
-.. important::
-
-    In this example, we will retrieve the CMake Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 Please, first clone the sources to recreate this project. You can find them in the
 `examples2.0 repository <https://github.com/conan-io/examples2>`_ in GitHub:
 

--- a/tutorial/consuming_packages/intro_to_versioning.rst
+++ b/tutorial/consuming_packages/intro_to_versioning.rst
@@ -1,14 +1,6 @@
 Introduction to versioning
 ==========================
 
-.. important::
-
-    In this example, we will retrieve Conan packages from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 So far we have been using requires with fixed versions like ``requires = "zlib/1.2.12"``.
 But sometimes dependencies evolve, new versions are released and consumers want to update to those versions as easy as possible.
 

--- a/tutorial/consuming_packages/the_flexibility_of_conanfile_py.rst
+++ b/tutorial/consuming_packages/the_flexibility_of_conanfile_py.rst
@@ -3,14 +3,6 @@
 Understanding the flexibility of using conanfile.py vs conanfile.txt
 ====================================================================
 
-.. important::
-
-    In this example, we will retrieve Conan packages from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 In the previous examples, we declared our dependencies (*Zlib* and *CMake*) in a
 *conanfile.txt* file. Let's have a look at that file:
 

--- a/tutorial/consuming_packages/use_tools_as_conan_packages.rst
+++ b/tutorial/consuming_packages/use_tools_as_conan_packages.rst
@@ -3,13 +3,6 @@
 Using build tools as Conan packages
 ===================================
 
-.. important::
-
-    In this example, we will retrieve the CMake Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
 In the previous example, we built our CMake project and used Conan to install and locate
 the **Zlib** library. Conan used the CMake version found in the system path to build this
 example. But, what happens if you don’t have CMake installed in your build environment or

--- a/tutorial/creating_packages/add_dependencies_to_packages.rst
+++ b/tutorial/creating_packages/add_dependencies_to_packages.rst
@@ -3,13 +3,6 @@
 Add dependencies to packages
 ============================
 
-.. important::
-
-    In this example, we will retrieve the *fmt* Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
 In the :ref:`previous tutorial section<tutorial_creating_packages>` we created a Conan
 package for a "Hello World" C++ library. We used the
 :ref:`conan.tools.scm.Git()<reference>` tool to retrieve the sources from a git

--- a/tutorial/creating_packages/build_packages.rst
+++ b/tutorial/creating_packages/build_packages.rst
@@ -1,15 +1,6 @@
 Build packages: the build() method
 ==================================
 
-.. important::
-
-    In this example, we retrieve the *fmt* and *gtest* Conan packages from a Conan
-    repository with packages compatible with Conan 2.0. To run this example successfully
-    you should add this remote to your Conan configuration (if did not already do it)
-    doing: ``conan remote add conanv2
-    https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 We already used a Conan recipe that has a ``build()`` method and learned how to use that
 to invoke a build system and build our packages. In this tutorial, we will modify that
 method and explain how you can use it to do things like:

--- a/tutorial/creating_packages/configure_options_settings.rst
+++ b/tutorial/creating_packages/configure_options_settings.rst
@@ -1,13 +1,6 @@
 Configure settings and options in recipes
 =========================================
 
-.. important::
-
-    In this example, we retrieve the *fmt* Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
 We already explained :ref:`Conan settings and options<settings_and_options_difference>`
 and how to use them to build your projects for different configurations like Debug,
 Release, with static or shared libraries, etc. In this section, we explain how to

--- a/tutorial/creating_packages/define_package_information.rst
+++ b/tutorial/creating_packages/define_package_information.rst
@@ -1,14 +1,6 @@
 Define information for consumers: the package_info() method
 ===========================================================
 
-.. important::
-
-    In this example, we retrieve the *fmt* Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 In the previous tutorial section, we explained how to store the headers and binaries of a
 library in a Conan package using the :ref:`package
 method<creating_packages_package_method>`. Consumers that depend on that package will

--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -107,14 +107,6 @@ do not affect the recipe and therefore the generated binary package is always th
 Header-only library with tests
 ------------------------------
 
-.. important::
-
-    In this example, we will retrieve the CMake Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 In the previous example, we saw why a recipe header-only library shouldn't declare the ``settings`` attribute,
 but sometimes the recipe needs them to build some executable, for example, for testing the library.
 Nonetheless, the binary package of the header-only library should still be unique, so we are going to review how to

--- a/tutorial/creating_packages/package_method.rst
+++ b/tutorial/creating_packages/package_method.rst
@@ -3,15 +3,6 @@
 Package files: the package() method
 ===================================
 
-.. important::
-
-    In this example, we retrieve the *fmt* Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add
-    this remote to your Conan configuration (if did not already do it) doing: ``conan
-    remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index
-    0``
-
-
 We already used the ``package()`` method in our `hello` package to invoke CMake's install
 step. In this tutorial, we will explain the use of the :ref:`CMake.install()
 <conan-cmake-build-helper>` in more detail and also how to modify this method to do things

--- a/tutorial/creating_packages/preparing_the_build.rst
+++ b/tutorial/creating_packages/preparing_the_build.rst
@@ -4,14 +4,6 @@
 Preparing the build
 ===================
 
-.. important::
-
-    In this example, we retrieve the *fmt* Conan package from a Conan repository with
-    packages compatible with Conan 2.0. To run this example successfully you should add this
-    remote to your Conan configuration (if did not already do it) doing:
-    ``conan remote add conanv2 https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 In the :ref:`previous tutorial section<creating_packages_add_dependencies_to_packages>`,
 we added the `fmt <https://conan.io/center/fmt>`__ requirement to our Conan package to
 provide colour output to our "Hello World" C++ library. In this section, we focus on the

--- a/tutorial/creating_packages/test_conan_packages.rst
+++ b/tutorial/creating_packages/test_conan_packages.rst
@@ -1,15 +1,6 @@
 Testing Conan packages
 ======================
 
-.. important::
-
-    In this example, we retrieve the *fmt* and *gtest* Conan packages from a Conan
-    repository with packages compatible with Conan 2.0. To run this example successfully
-    you should add this remote to your Conan configuration (if did not already do it)
-    doing: ``conan remote add conanv2
-    https://conanv2beta.jfrog.io/artifactory/api/conan/conan --index 0``
-
-
 In all the previous sections of the tutorial, we used the *test_package*. It was invoked
 automatically at the end of the ``conan create`` command after building our package
 verifying that the package is created correctly. Let's explain the *test_package* in more


### PR DESCRIPTION
This: https://github.com/conan-io/examples2/pull/60 is green, so we could use conancenter as remote in the conan 2.0 docs instead of the temporal free-tier instance