### PR TITLE
Fix name regex to be truly 50 characters only.

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -11,7 +11,7 @@ Attributes
 name
 ----
 This is a string, with a minimum of 2 and a maximum of 50 characters (though shorter names are recommended), that defines the package name. It will be the ``<pkgName>/version@user/channel`` of the package reference.
-It should match the following regex ``^[a-zA-Z0-9_][a-zA-Z0-9_\+\.-]{1,50}$``, so start with alphanumeric or underscore, then alphanumeric, underscore, +, ., - characters.
+It should match the following regex ``^[a-zA-Z0-9_][a-zA-Z0-9_\+\.-]{1,49}$``, so start with alphanumeric or underscore, then alphanumeric, underscore, +, ., - characters.
 
 The name is only necessary for ``export``-ing the recipe into the local cache (``export`` and ``create`` commands), if they are not defined in the command line.
 It might take its value from an environment variable, or even any python code that defines it (e.g. a function that reads an environment variable, or a file from disk).


### PR DESCRIPTION
## Abstract

The previous text of this help documentation provides a regex that actually allows a name of size 51 characters instead of what the rest of documentation claims is 50 characters. This new regex checks that it is appropriately 50 characters.