### PR TITLE
- add note about 1.58

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -20,6 +20,7 @@ Check https://github.com/conan-io/conan for issues and more details about develo
 
     Conan 1.56 shouldn't break any existing 1.0 recipe or command line invocation. If it does, please submit 
     a report on GitHub. Read more about the :ref:`Conan stability commitment<stability>`.
+    Conan 1.58 should break any existing 1.0 recipe or command line invocation.
 
 1.58.0 (30-Jan-2023)
 --------------------


### PR DESCRIPTION
@czoido 

changelog only talks about conan 1.56 behavior, but it doesn't specify 1.58.