### PR TITLE
add note about `conan list --format=html`

### DIFF
--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -29,7 +29,7 @@ conan list
 .. warning::
 
     In some circumstances, `--format html` might produce semantically different results from `--format json`, like
-    showing a different amount of packages. Use it on your own risk.
+    showing a different amount of packages (there is a bug `GitHub issue #13022 <https://github.com/conan-io/conan/issues/13022>). Use it on your own risk.
 
 
 The ``conan list`` command can list recipes and packages from the local cache, from the

--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -28,9 +28,10 @@ conan list
 
 .. warning::
 
-    In some circumstances, `--format html` might produce semantically different results from `--format json`, like
-    showing a different amount of packages (there is a bug `GitHub issue #13022 <https://github.com/conan-io/conan/issues/13022>`_). Use it on your own risk.
-
+    The html formatter (--format=html) is not fully implemented yet, so it will create an empty html file
+    with no packages information. This is `a reported bug
+    <https://github.com/conan-io/conan/issues/13022>`_ that happens in Conan <= 2.0-beta9
+    and is planned to be solved in 2.0-beta10
 
 The ``conan list`` command can list recipes and packages from the local cache, from the
 specified remotes or from both. This command uses a *reference pattern* as input. The

--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -29,7 +29,7 @@ conan list
 .. warning::
 
     In some circumstances, `--format html` might produce semantically different results from `--format json`, like
-    showing a different amount of packages (there is a bug `GitHub issue #13022 <https://github.com/conan-io/conan/issues/13022>). Use it on your own risk.
+    showing a different amount of packages (there is a bug `GitHub issue #13022 <https://github.com/conan-io/conan/issues/13022>`_). Use it on your own risk.
 
 
 The ``conan list`` command can list recipes and packages from the local cache, from the

--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -26,6 +26,11 @@ conan list
                             Remote names. Accepts wildcards
       -c, --cache           Search in the local cache
 
+.. warning::
+
+    In some circumstances, `--format html` might produce semantically different results from `--format json`, like
+    showing a different amount of packages. Use it on your own risk.
+
 
 The ``conan list`` command can list recipes and packages from the local cache, from the
 specified remotes or from both. This command uses a *reference pattern* as input. The


### PR DESCRIPTION
related to: 
https://github.com/conan-io/conan/issues/13021
https://github.com/conan-io/conan/issues/13022

it needs some sort of disclaimer that `--format html` may work differently from `--format json` in some circumstances, e.g. showing a different amount of packages.