### PR TITLE
Missing docs from beta10

### DIFF
--- a/reference/commands/cache.rst
+++ b/reference/commands/cache.rst
@@ -8,10 +8,8 @@ conan cache path
 
 .. code-block:: bash
 
-    $ conan cache path -h
-    usage: conan cache path [-h] [-v [V]] [--logger]
-                            [--folder {export_source,source,build}]
-                            reference
+    $ conan cache path --help
+    usage: conan cache path [-h] [-v [V]] [--logger] [--folder {export_source,source,build}] reference
 
     Shows the path in the Conan cache af a given reference
 
@@ -20,13 +18,12 @@ conan cache path
 
     optional arguments:
     -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more
-                            verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or
-                            -vverbose, -vv or -vdebug, -vvv or -vtrace
+    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
     --logger              Show the output with log format, with time, type and message.
-    --folder {exports,exports_sources,sources,build,package}
-                            Show the path to the specified element. The 'build' and 'package'
-                            requires a package reference. If not specified it shows 'exports' path
+    --folder {export_source,source,build}
+                            Show the path to the specified element. The 'build' requires a package reference. If not specified it shows
+                            'exports' path
 
 
 The ``conan cache path`` returns the path in the cache of a given reference. Depending on the reference, it
@@ -149,3 +146,27 @@ Again, the "build" folder will only exist if the package was built from source.
       package storage must be considered **read-only**. Do not modify, change, remove or add files from the cache.
     - If you are using this command to obtain the path to artifacts and then copying them, consider the usage of a ``deployer``
       instead. In the general case, extracting artifacts from the cache manually is discouraged.
+
+conan cache clean
+-----------------
+
+.. code-block:: bash
+
+    $ conan cache clean --help
+    usage: conan cache clean [-h] [-v [V]] [--logger] [-s] [-b] [-d] [-p PACKAGE_QUERY] pattern
+
+    Shows the path in the Conan cache af a given reference
+
+    positional arguments:
+    pattern               selection pattern for references to clean
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+    --logger              Show the output with log format, with time, type and message.
+    -s, --source          Clean source folders
+    -b, --build           Clean source folders
+    -d, --download        Clean download folders
+    -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
+                            Remove all packages (empty) or provide a query: os=Windows AND (arch=x86 OR compiler=gcc)

--- a/reference/commands/config.rst
+++ b/reference/commands/config.rst
@@ -203,11 +203,13 @@ Displays all the Conan built-in configurations. There are 2 groups:
     tools.apple:sdk_path: Path to the SDK to be used
     tools.build.cross_building:can_run: Bool value that indicates whether is possible to run a non-native app on the same architecture. It's used by 'can_run' tool
     tools.build:cflags: List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain
+    tools.build:compiler_executables: Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}
     tools.build:cxxflags: List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain
     tools.build:defines: List of extra definition flags used by different toolchains like CMakeToolchain and AutotoolsToolchain
+    tools.build:download_source: Force download of sources for every package
     tools.build:exelinkflags: List of extra flags used by CMakeToolchain for CMAKE_EXE_LINKER_FLAGS_INIT variable
     tools.build:jobs: Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)
-    tools.build:linker_scripts: List of linker scripts used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain
+    tools.build:linker_scripts: List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain
     tools.build:sharedlinkflags: List of extra flags used by CMakeToolchain for CMAKE_SHARED_LINKER_FLAGS_INIT variable
     tools.build:skip_test: Do not execute CMake.test() and Meson.test() when enabled
     tools.build:sysroot: Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)
@@ -235,10 +237,11 @@ Displays all the Conan built-in configurations. There are 2 groups:
     tools.intel:installation_path: Defines the Intel oneAPI installation root path
     tools.intel:setvars_args: Custom arguments to be passed onto the setvars.sh|bat script from Intel oneAPI
     tools.meson.mesontoolchain:backend: Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode
+    tools.meson.mesontoolchain:extra_machine_files: List of paths for any additional native/cross file references to be appended to the existing Conan ones
     tools.microsoft.bash:active: If Conan is already running inside bash terminal in Windows
     tools.microsoft.bash:path: The path to the shell to run when conanfile.win_bash==True
     tools.microsoft.bash:subsystem: The subsystem to be used when conanfile.win_bash==True. Possible values: msys2, msys, cygwin, wsl, sfu
-    tools.microsoft.msbuild:installation_path: VS install path, to avoid auto-detect via vswhere, like C:/Program Files (x86)/Microsoft Visual Studio/2019/Community
+    tools.microsoft.msbuild:installation_path: VS install path, to avoid auto-detect via vswhere, like C:/Program Files (x86)/Microsoft Visual Studio/2019/Community. Use empty string to disable
     tools.microsoft.msbuild:max_cpu_count: Argument for the /m when running msvc to build parallel projects
     tools.microsoft.msbuild:verbosity: Verbosity level for MSBuild: 'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'
     tools.microsoft.msbuild:vs_version: Defines the IDE version when using the new msvc compiler
@@ -248,7 +251,6 @@ Displays all the Conan built-in configurations. There are 2 groups:
     tools.system.package_manager:sudo: Use 'sudo' when invoking the package manager tools in Linux (False by default)
     tools.system.package_manager:sudo_askpass: Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)
     tools.system.package_manager:tool: Default package manager tool: 'apt-get', 'yum', 'dnf', 'brew', 'pacman', 'choco', 'zypper', 'pkg' or 'pkgutil'
-
 
 
 .. seealso::

--- a/reference/commands/editable.rst
+++ b/reference/commands/editable.rst
@@ -12,13 +12,62 @@ conan editable
 
     positional arguments:
     {add,list,remove}  sub-command help
-        add              Define the given <path> location as the package <reference>, so when this package is required, it is
-                        used from this <path> location instead of from the cache
+        add              Define the given <path> location as the package <reference>, so when this package is required, it is used from
+                        this <path> location instead of from the cache
         list             List packages in editable mode
         remove           Remove the "editable" mode for this reference.
 
     optional arguments:
     -h, --help         show this help message and exit
-    -v [V]             Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror,
-                        -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+    -v [V]             Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning,
+                        -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
     --logger           Show the output with log format, with time, type and message.
+
+conan editable add
+------------------
+
+.. code-block:: bash
+
+    $ conan editable add --help
+    usage: conan editable add [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL]
+                            [-of OUTPUT_FOLDER]
+                            path
+
+    Define the given <path> location as the package <reference>, so when this package is required, it is used from this <path> location
+    instead of from the cache
+
+    positional arguments:
+    path                  Path to the package folder in the user workspace
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+    --logger              Show the output with log format, with time, type and message.
+    --name NAME           Provide a package name if not specified in conanfile
+    --version VERSION     Provide a package version if not specified in conanfile
+    --user USER           Provide a user if not specified in conanfile
+    --channel CHANNEL     Provide a channel if not specified in conanfil
+    -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
+                            The root output folder for generated and build files
+
+conan editable remove
+---------------------
+
+.. code-block:: bash
+
+    $ conan editable remove --help
+    usage: conan editable remove [-h] [-v [V]] [--logger] [-r REFS] [path]
+
+    Remove the "editable" mode for this reference.
+
+    positional arguments:
+    path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+    --logger              Show the output with log format, with time, type and message.
+    -r REFS, --refs REFS  Directly provide reference patterns

--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -28,13 +28,6 @@ conan list
                             Remote names. Accepts wildcards
       -c, --cache           Search in the local cache
 
-.. warning::
-
-    The html formatter (--format=html) is not fully implemented yet, so it will create an empty html file
-    with no packages information. This is `a reported bug
-    <https://github.com/conan-io/conan/issues/13022>`_ that happens in Conan <= 2.0-beta9
-    and is planned to be solved in 2.0-beta10
-
 The ``conan list`` command can list recipes and packages from the local cache, from the
 specified remotes or from both. This command uses a *reference pattern* as input. The
 structure of this pattern is based on a complete Conan reference that looks like: 

--- a/reference/commands/remote.rst
+++ b/reference/commands/remote.rst
@@ -42,7 +42,7 @@ conan remote add
 .. code-block:: bash
 
     $ conan remote add --help
-    usage: conan remote add [-h] [-v [V]] [--logger] [--insecure] [--index INDEX] name url
+    usage: conan remote add [-h] [-v [V]] [--logger] [--insecure] [--index INDEX] [-f] name url
 
     Add a remote
 
@@ -52,10 +52,12 @@ conan remote add
 
     optional arguments:
     -h, --help     show this help message and exit
-    -v [V]         Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+    -v [V]         Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning,
+                    -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
     --logger       Show the output with log format, with time, type and message.
     --insecure     Allow insecure server connections when using SSL
-    --index INDEX  Insert the remote at a specific position in the remote list 
+    --index INDEX  Insert the remote at a specific position in the remote list
+    -f, --force    Force the definition of the remote even if duplicated
 
 
 conan remote disable

--- a/reference/conanfile/methods/layout.rst
+++ b/reference/conanfile/methods/layout.rst
@@ -42,6 +42,9 @@ self.folders
   ``conanfile.py`` is relative to the project root. This is particularly useful for
   :ref:`layouts with multiple subprojects<examples_conanfile_layout_multiple_subprojects>`
 
+- **self.folders.build_folder_vars** (Defaulted to ``None``): Use settings and options to
+  produce a different build folder and different CMake presets names.
+
 
 .. _layout_cpp_reference:
 

--- a/tutorial/developing_packages/editable_packages.rst
+++ b/tutorial/developing_packages/editable_packages.rst
@@ -58,7 +58,7 @@ the local working directory**:
 
 .. code-block:: bash
 
-    $ conan editable add say say/1.0
+    $ conan editable add say --name=say --version=1.0
     $ conan editable list
     say/1.0
         Path: /Users/.../examples2/tutorial/developing_packages/editable_packages/say/conanfile.py
@@ -184,7 +184,7 @@ In order to revert the editable mode just remove the link using:
 
 .. code-block:: bash
 
-    $ conan editable remove say/1.0
+    $ conan editable remove --refs=say/1.0
 
 It will remove the link (the local directory won't be affected) and all the packages consuming this
 requirement will get it from the cache again.

--- a/tutorial/developing_packages/package_layout.rst
+++ b/tutorial/developing_packages/package_layout.rst
@@ -260,7 +260,7 @@ package in editable mode and build it locally.
 .. code-block:: bash
 
     $ cd ../say
-    $ conan editable add . say/1.0
+    $ conan editable add . --name=say --version=1.0
     $ conan install . -s build_type=Release
     $ cmake --preset release
     $ cmake --build --preset release
@@ -316,7 +316,7 @@ defined by ``cpp.source`` and ``cpp.build``:
     [100%] Linking CXX executable hello
     [100%] Built target hello
 
-    $ conan editable remove say/1.0
+    $ conan editable remove --refs=say/1.0
 
 
 .. note:: 


### PR DESCRIPTION
Port part of: https://docs.conan.io/en/2.0/changelog.html#beta10-16-feb-2023

Still missing:

- Feature: Provide the ability for users to extend Conan generated CMakePresets. [#13090](https://github.com/conan-io/conan/pull/13090)
- Feature: Implement customizable CMakeToolchain.presets_prefix so presets name prepend this. [#13015](https://github.com/conan-io/conan/pull/13015)
- Feature: Add [system_tools] section to profiles to use your own installed tools instead of the packages declared in the requires. [#10166](https://github.com/conan-io/conan/pull/10166)
- Fix: Define CMakeToolchain.presets_prefix="conan" by default, to avoid conflict with other users presets. [#13015](https://github.com/conan-io/conan/pull/13015)