### PR TITLE
Update commands help for v2

### DIFF
--- a/reference/commands/build.rst
+++ b/reference/commands/build.rst
@@ -5,45 +5,80 @@ conan build
 
 .. code-block:: text
 
-    $ conan build --help
-    usage: conan build [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [-of OUTPUT_FOLDER] [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
-                       [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                       [--lockfile-out LOCKFILE_OUT] [--lockfile-packages] [--lockfile-clean]
+    $ conan build -h
+    usage: conan build [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]
+                       [--user USER] [--channel CHANNEL] [-of OUTPUT_FOLDER]
+                       [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                       [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
+                       [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
+                       [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
+                       [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
+                       [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+                       [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                       [--lockfile-clean]
                        [path]
 
-    Install + calls the build() method
+    Install dependencies and call the build() method.
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g., ./my_project/conanfile.txt.
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                             The root output folder for generated and build files
       -b BUILD, --build BUILD
-                            Optional, specify which packages to build from source. Combining multiple '--build' options on one command line is allowed. For dependencies, the optional 'build_policy' attribute in their conanfile.py takes
-                            precedence over the command line parameter. Possible parameters: --build="*" Force build for all packages, do not use binary packages. --build=never Disallow build for all packages, use binary packages or fail if
-                            a binary package is not found. Cannot be combined with other '--build' options. --build=missing Build packages from source whose binary package is not found. --build=cascade Build packages from source that have
-                            at least one dependency being built from source. --build=[pattern] Build packages from source whose package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. --build=![pattern] Excluded
-                            packages, which will not be built from the source, whose package reference matches the pattern. The pattern uses 'fnmatch' style wildcards. Default behavior: If you omit the '--build' option, the 'build_policy'
-                            attribute in conanfile.py will be used if it exists, otherwise the behavior is like '--build=never'.
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or revision of the dependencies exists there, it will install those in the local cache. When using version ranges, it will install the latest version that
-                            satisfies the range. Also, if using revisions, it will update to the latest revision for the resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
       -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
       -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
       -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
       -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
@@ -51,24 +86,35 @@ conan build
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      --lockfile-clean      Remove unused entries from the lockfile
 
 
 The ``conan build`` command installs the recipe specified in ``path`` and calls its ``build`` method.

--- a/reference/commands/cache.rst
+++ b/reference/commands/cache.rst
@@ -9,7 +9,7 @@ Perform file operations in the local cache (of recipes and/or packages).
 conan cache path
 ----------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache path -h
     usage: conan cache path [-h] [-v [V]] [--logger]
@@ -39,7 +39,7 @@ could return the path of a recipe, or the path to a package binary.
 
 Let's say that we have created a package in our current cache with:
 
-.. code-block:: bash
+.. code-block:: text
     
     $ conan new cmake_lib -d name=pkg -d version=0.1
     $ conan create .
@@ -53,7 +53,7 @@ Let's say that we have created a package in our current cache with:
 
 And now we are interested in obtaining the path where our ``pkg/0.1`` recipe ``conanfile.py`` has been exported:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache path pkg/0.1
     <path to conan cache>/p/5cb229164ec1d245/e
@@ -65,7 +65,7 @@ By default, if the recipe revision is not specified, it means the "latest" revis
 also be made explicit by the literal ``#latest``, and also any recipe revision can be explicitly defined,
 these commands are equivalent to the above:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache path pkg/0.1#latest
     <path to conan cache>/p/5cb229164ec1d245/e
@@ -80,7 +80,7 @@ Together with the recipe folder, there are a two other folders that are common t
 produced with this recipe: the "export_source" folder and the "source" folder. Both can be
 obtained with:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache path pkg/0.1 --folder=export_source
     <path to conan cache>/p/5cb229164ec1d245/es
@@ -107,7 +107,7 @@ binary is retrieve from a server.
 
 It is also possible to obtain the folders of the binary packages providing the ``package_id``:
 
-.. code-block:: bash
+.. code-block:: text
 
     # Your package_id might be different, it depends on the platform
     # Check the "conan create" output to obtain yours
@@ -121,7 +121,7 @@ As above, by default it will resolve to the "latest" recipe revision and package
 The command above is equal to explicitly defining ``#latest`` or the exact revisions.
 All the commands below are equivalent to the above one:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache path pkg/0.1#latest:2401fa1d188d289bb25c37cfa3317e13e377a351
     <path to conan cache>/p/1cae77d6250c23b7/p
@@ -135,7 +135,7 @@ All the commands below are equivalent to the above one:
 
 It is possible to access the "build" folder with all the temporary build artifacts:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache path pkg/0.1:2401fa1d188d289bb25c37cfa3317e13e377a351 --folder=build
     <path to conan cache>/p/1cae77d6250c23b7/b
@@ -159,7 +159,7 @@ Again, the "build" folder will only exist if the package was built from source.
 conan cache clean
 -----------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan cache clean -h
     usage: conan cache clean [-h] [-v [V]] [--logger] [-s] [-b] [-d]

--- a/reference/commands/cache.rst
+++ b/reference/commands/cache.rst
@@ -3,6 +3,9 @@
 conan cache
 ===========
 
+Perform file operations in the local cache (of recipes and/or packages).
+
+
 conan cache path
 ----------------
 
@@ -13,20 +16,22 @@ conan cache path
                             [--folder {export_source,source,build}]
                             reference
 
-    Shows the path in the Conan cache af a given reference
+    Show the path to the Conan cache for a given reference.
 
     positional arguments:
-    reference             Recipe reference or Package reference
+      reference             Recipe reference or Package reference
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more
-                            verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or
-                            -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    --folder {exports,exports_sources,sources,build,package}
-                            Show the path to the specified element. The 'build' and 'package'
-                            requires a package reference. If not specified it shows 'exports' path
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --folder {export_source,source,build}
+                            Path to show. The 'build' requires a package
+                            reference. If not specified it shows 'exports' path
 
 
 The ``conan cache path`` returns the path in the cache of a given reference. Depending on the reference, it
@@ -149,3 +154,35 @@ Again, the "build" folder will only exist if the package was built from source.
       package storage must be considered **read-only**. Do not modify, change, remove or add files from the cache.
     - If you are using this command to obtain the path to artifacts and then copying them, consider the usage of a ``deployer``
       instead. In the general case, extracting artifacts from the cache manually is discouraged.
+
+
+conan cache clean
+-----------------
+
+.. code-block:: bash
+
+    $ conan cache clean -h
+    usage: conan cache clean [-h] [-v [V]] [--logger] [-s] [-b] [-d]
+                             [-p PACKAGE_QUERY]
+                             pattern
+
+    Remove non-critical folders from the cache, like source, build and/or download
+    (.tgz store) ones.
+
+    positional arguments:
+      pattern               Selection pattern for references to clean
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -s, --source          Clean source folders
+      -b, --build           Clean build folders
+      -d, --download        Clean download folders
+      -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
+                            Remove only the packages matching a specific query,
+                            e.g., os=Windows AND (arch=x86 OR compiler=gcc)

--- a/reference/commands/config.rst
+++ b/reference/commands/config.rst
@@ -1,22 +1,25 @@
 conan config
 ============
 
+Manage the Conan configuration in the Conan home.
+
+
 conan config home
 -----------------
 
 .. code-block:: bash
 
-    $  conan config home -h
+    $ conan config home --help
     usage: conan config home [-h] [-v [V]] [--logger]
 
-    Gets the Conan home folder
+    Show the Conan home folder.
 
     optional arguments:
-    -h, --help  show this help message and exit
-    -v [V]      Level of detail of the output. Valid options from less verbose to more verbose:
-                -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
-                -vvv or -vtrace
-    --logger    Show the output with log format, with time, type and message.
+      -h, --help  show this help message and exit
+      -v [V]      Level of detail of the output. Valid options from less verbose
+                  to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                  -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger    Show the output with log format, with time, type and message.
 
 
 The ``conan config home`` command returns the path of the Conan home folder.
@@ -34,31 +37,36 @@ conan config install
 .. code-block:: bash
 
     $ conan config install -h
-    usage: conan config install [-h] [-v [V]] [--logger] [--verify-ssl [VERIFY_SSL]]
-                                [-t {git,dir,file,url}] [-a ARGS] [-sf SOURCE_FOLDER]
-                                [-tf TARGET_FOLDER]
+    usage: conan config install [-h] [-v [V]] [--logger]
+                                [--verify-ssl [VERIFY_SSL]]
+                                [-t {git,dir,file,url}] [-a ARGS]
+                                [-sf SOURCE_FOLDER] [-tf TARGET_FOLDER]
                                 item
 
-    Installs the configuration (remotes, profiles, conf), from git, http or folder
+    Install the configuration (remotes, profiles, conf), from git, http or a
+    folder, into the Conan home folder.
 
     positional arguments:
-    item                  git repository, local file or folder or zip file (local or http) where
-                            the configuration is stored
+      item                  git repository, local file or folder or zip file
+                            (local or http) where the configuration is stored
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more
-                            verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or
-                            -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    --verify-ssl [VERIFY_SSL]
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --verify-ssl [VERIFY_SSL]
                             Verify SSL connection when downloading file
-    -t {git,dir,file,url}, --type {git,dir,file,url}
+      -t {git,dir,file,url}, --type {git,dir,file,url}
                             Type of remote config
-    -a ARGS, --args ARGS  String with extra arguments for "git clone"
-    -sf SOURCE_FOLDER, --source-folder SOURCE_FOLDER
-                            Install files only from a source subfolder from the specified origin
-    -tf TARGET_FOLDER, --target-folder TARGET_FOLDER
+      -a ARGS, --args ARGS  String with extra arguments for "git clone"
+      -sf SOURCE_FOLDER, --source-folder SOURCE_FOLDER
+                            Install files only from a source subfolder from the
+                            specified origin
+      -tf TARGET_FOLDER, --target-folder TARGET_FOLDER
                             Install to that path in the conan cache
 
 
@@ -149,16 +157,18 @@ conan config list
     $ conan config list -h
     usage: conan config list [-h] [-f FORMAT] [-v [V]] [--logger]
 
-    Prints all the Conan available configurations: core and tools.
+    Show all the Conan available configurations: core and tools.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more
-                            verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or
-                            -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 Displays all the Conan built-in configurations. There are 2 groups:

--- a/reference/commands/config.rst
+++ b/reference/commands/config.rst
@@ -7,7 +7,7 @@ Manage the Conan configuration in the Conan home.
 conan config home
 -----------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan config home --help
     usage: conan config home [-h] [-v [V]] [--logger]
@@ -24,7 +24,7 @@ conan config home
 
 The ``conan config home`` command returns the path of the Conan home folder.
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan config home
 
@@ -34,7 +34,7 @@ The ``conan config home`` command returns the path of the Conan home folder.
 conan config install
 --------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan config install -h
     usage: conan config install [-h] [-v [V]] [--logger]
@@ -96,7 +96,7 @@ All the configuration files can be shared and installed this way:
 
 - Install the configuration from a URL:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install http://url/to/some/config.zip
 
@@ -104,14 +104,14 @@ All the configuration files can be shared and installed this way:
 - Install the configuration from a URL, but only getting the files inside a *origin* folder
   inside the zip file, and putting them inside a *target* folder in the local cache:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install http://url/to/some/config.zip -sf=origin -tf=target
 
 - Install configuration from 2 different zip files from 2 different urls, using different source
   and target folders for each one, then update all:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install http://url/to/some/config.zip -sf=origin -tf=target
       $ conan config install http://url/to/some/config.zip -sf=origin2 -tf=target2
@@ -119,19 +119,19 @@ All the configuration files can be shared and installed this way:
 
 - Install the configuration from a Git repository with submodules:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install http://github.com/user/conan_config/.git --args "--recursive"
 
   You can also force the git download by using :command:`--type git` (in case it is not deduced from the URL automatically):
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install http://github.com/user/conan_config/.git --type git
 
 - Install from a URL skipping SSL verification:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install http://url/to/some/config.zip --verify-ssl=False
 
@@ -139,20 +139,20 @@ All the configuration files can be shared and installed this way:
 
 - Install a specific file from a local path:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install my_settings/settings.yml
 
 - Install the configuration from a local path:
 
-  .. code-block:: bash
+  .. code-block:: text
 
       $ conan config install /path/to/some/config.zip
 
 
 conan config list
 -----------------
-.. code-block:: bash
+.. code-block:: text
 
     $ conan config list -h
     usage: conan config list [-h] [-f FORMAT] [-v [V]] [--logger]
@@ -178,7 +178,7 @@ Displays all the Conan built-in configurations. There are 2 groups:
   recipes and tools used within recipes, like ``CMakeToolchain``
 
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan config list
     core.cache:storage_path: Absolute path where the packages and database are stored

--- a/reference/commands/create.rst
+++ b/reference/commands/create.rst
@@ -3,67 +3,79 @@ conan create
 
 .. code-block:: text
 
-    $ conan build --help
-    usage: conan build [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]
-                       [--user USER] [--channel CHANNEL] [-of OUTPUT_FOLDER] [-b BUILD]
-                       [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                       [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
-                       [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
-                       [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
-                       [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                       [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
-                       [--lockfile-clean]
-                       [path]
+    $ conan create -h
+    usage: conan create [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
+                        [--version VERSION] [--user USER] [--channel CHANNEL]
+                        [-l LOCKFILE] [--lockfile-partial]
+                        [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                        [--lockfile-clean] [-b BUILD] [-r REMOTE | -nr] [-u]
+                        [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                        [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                        [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                        [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
+                        [-c:b CONF_BUILD] [-c:h CONF_HOST] [--build-require]
+                        [-tf TEST_FOLDER]
+                        path
 
-    Install + calls the build() method
+    Create a package.
 
     positional arguments:
-      path                  Path to a folder containing a recipe (conanfile.py or
-                            conanfile.txt) or to a recipe file. e.g.,
-                            ./my_project/conanfile.txt.
+      path                  Path to a folder containing a recipe (conanfile.py)
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -f FORMAT, --format FORMAT
+                            Select the output format: json
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
-      -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
-                            The root output folder for generated and build files
+      --channel CHANNEL     Provide a channel if not specified in conanfile
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the updated lockfile
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      Remove unused entries from the lockfile
       -b BUILD, --build BUILD
                             Optional, specify which packages to build from source.
-                            Combining multiple '--build' options on one command line is
-                            allowed. For dependencies, the optional 'build_policy'
-                            attribute in their conanfile.py takes precedence over the
-                            command line parameter. Possible parameters: --build="*" Force
-                            build for all packages, do not use binary packages.
-                            --build=never Disallow build for all packages, use binary
-                            packages or fail if a binary package is not found. Cannot be
-                            combined with other '--build' options. --build=missing Build
-                            packages from source whose binary package is not found.
-                            --build=cascade Build packages from source that have at least
-                            one dependency being built from source. --build=[pattern]
-                            Build packages from source whose package reference matches the
-                            pattern. The pattern uses 'fnmatch' style wildcards.
-                            --build=![pattern] Excluded packages, which will not be built
-                            from the source, whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards. Default behavior:
-                            If you omit the '--build' option, the 'build_policy' attribute
-                            in conanfile.py will be used if it exists, otherwise the
-                            behavior is like '--build=never'.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or
-                            revision of the dependencies exists there, it will install
-                            those in the local cache. When using version ranges, it will
-                            install the latest version that satisfies the range. Also, if
-                            using revisions, it will update to the latest revision for the
-                            resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o
                             Pkg:with_qt=true
@@ -80,34 +92,30 @@ conan create
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build
-                            machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults
-                            (build machine). e.g.: -c:b
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c:h
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode
-      -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
-      --lockfile-out LOCKFILE_OUT
-                            Filename of the updated lockfile
-      --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      --build-require       Whether the provided reference is a build-require
+      -tf TEST_FOLDER, --test-folder TEST_FOLDER
+                            Alternative test folder name. By default it is
+                            "test_package". Use "" to skip the test stage
 
 
 The ``conan create`` command creates a package from the recipe specified in ``path``.

--- a/reference/commands/download.rst
+++ b/reference/commands/download.rst
@@ -3,7 +3,7 @@
 conan download
 ==============
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan download -h
     usage: conan download [-h] [-v [V]] [--logger] [--only-recipe]

--- a/reference/commands/download.rst
+++ b/reference/commands/download.rst
@@ -5,27 +5,34 @@ conan download
 
 .. code-block:: bash
 
-    $ conan download --help
-    usage: conan download [-h] [-v [V]] [--logger] [--only-recipe] [-p PACKAGE_QUERY] -r REMOTE reference
+    $ conan download -h
+    usage: conan download [-h] [-v [V]] [--logger] [--only-recipe]
+                          [-p PACKAGE_QUERY] -r REMOTE
+                          reference
 
-    Download (without install) a single conan package from a remote server.
+    Download (without installing) a single conan package from a remote server.
 
     It downloads just the package, but not its transitive dependencies, and it will not call
     any generate, generators or deployers.
-    It can download multiple packages if patterns are used, and also queries over the package
-    binaries can be provided.
+    It can download multiple packages if patterns are used, and also works with queries over
+    the package binaries.
 
     positional arguments:
-    reference             Recipe reference or package reference, can contain * as wildcard at any reference field. If
-                            revision is not specified, it is assumed latest one.
+      reference             Recipe reference or package reference, can contain *
+                            as wildcard at any reference field. If revision is not
+                            specified, it is assumed latest one.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror,
-                            -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    --only-recipe         Download only the recipe/s, not the binary packages.
-    -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
-                            Only upload packages matching a specific query. e.g: os=Windows AND (arch=x86 OR compiler=gcc)
-    -r REMOTE, --remote REMOTE
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --only-recipe         Download only the recipe/s, not the binary packages.
+      -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
+                            Only upload packages matching a specific query. e.g:
+                            os=Windows AND (arch=x86 OR compiler=gcc)
+      -r REMOTE, --remote REMOTE
                             Download from this specific remote

--- a/reference/commands/editable.rst
+++ b/reference/commands/editable.rst
@@ -8,7 +8,7 @@ Allow working with a package that resides in user folder.
 conan editable add
 ------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan editable add -h
     usage: conan editable add [-h] [-v [V]] [--logger] [--name NAME]
@@ -42,7 +42,7 @@ conan editable add
 conan editable remove
 ---------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan editable remove -h
     usage: conan editable remove [-h] [-v [V]] [--logger] [-r REFS] [path]

--- a/reference/commands/editable.rst
+++ b/reference/commands/editable.rst
@@ -3,22 +3,63 @@
 conan editable
 ==============
 
+Allow working with a package that resides in user folder.
+
+conan editable add
+------------------
+
 .. code-block:: bash
 
-    $ conan editable --help
-    usage: conan editable [-h] [-v [V]] [--logger] {add,list,remove} ...
+    $ conan editable add -h
+    usage: conan editable add [-h] [-v [V]] [--logger] [--name NAME]
+                              [--version VERSION] [--user USER]
+                              [--channel CHANNEL] [-of OUTPUT_FOLDER]
+                              path
 
-    Allows working with a package in user folder
+    Define the given <path> location as the package <reference>, so when this
+    package is required, it is used from this <path> location instead of the
+    cache.
 
     positional arguments:
-    {add,list,remove}  sub-command help
-        add              Define the given <path> location as the package <reference>, so when this package is required, it is
-                        used from this <path> location instead of from the cache
-        list             List packages in editable mode
-        remove           Remove the "editable" mode for this reference.
+      path                  Path to the package folder in the user workspace
 
     optional arguments:
-    -h, --help         show this help message and exit
-    -v [V]             Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror,
-                        -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger           Show the output with log format, with time, type and message.
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfile
+      -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
+                            The root output folder for generated and build files
+
+conan editable remove
+---------------------
+
+.. code-block:: bash
+
+    $ conan editable remove -h
+    usage: conan editable remove [-h] [-v [V]] [--logger] [-r REFS] [path]
+
+    Remove the "editable" mode for this reference.
+
+    positional arguments:
+      path                  Path to a folder containing a recipe (conanfile.py or
+                            conanfile.txt) or to a recipe file. e.g.,
+                            ./my_project/conanfile.txt.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -r REFS, --refs REFS  Directly provide reference patterns

--- a/reference/commands/export-pkg.rst
+++ b/reference/commands/export-pkg.rst
@@ -3,7 +3,7 @@
 conan export-pkg
 ================
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan export-pkg -h
     usage: conan export-pkg [-h] [-f FORMAT] [-v [V]] [--logger]

--- a/reference/commands/export-pkg.rst
+++ b/reference/commands/export-pkg.rst
@@ -5,63 +5,89 @@ conan export-pkg
 
 .. code-block:: bash
 
-    $ conan export-pkg --help
-    usage: conan export-pkg [-h] [-f FORMAT] [-v [V]] [--logger] [-of OUTPUT_FOLDER] [--name NAME] [--version VERSION]
-                            [--user USER] [--channel CHANNEL] [-l LOCKFILE] [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
-                            [--lockfile-packages] [--lockfile-clean] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
-                            [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
-                            [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+    $ conan export-pkg -h
+    usage: conan export-pkg [-h] [-f FORMAT] [-v [V]] [--logger]
+                            [-of OUTPUT_FOLDER] [--build-require]
+                            [-tf TEST_FOLDER] [--name NAME] [--version VERSION]
+                            [--user USER] [--channel CHANNEL] [-l LOCKFILE]
+                            [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                            [--lockfile-packages] [--lockfile-clean]
+                            [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
+                            [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
+                            [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
+                            [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
+                            [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
+                            [-c:h CONF_HOST]
                             path
 
-    Create a package directly from pre-compiled binaries
+    Create a package directly from pre-compiled binaries.
 
     positional arguments:
-    path                  Path to a folder containing a recipe (conanfile.py)
+      path                  Path to a folder containing a recipe (conanfile.py)
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror,
-                            -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                             The root output folder for generated and build files
-    --name NAME           Provide a package name if not specified in conanfile
-    --version VERSION     Provide a package version if not specified in conanfile
-    --user USER           Provide a user if not specified in conanfile
-    --channel CHANNEL     Provide a channel if not specified in conanfil
-    -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile. Use --lockfile="" to avoid automatic use of existing 'conan.lock' file
-    --lockfile-partial    Do not raise an error if some dependency is not found in lockfile
-    --lockfile-out LOCKFILE_OUT
+      --build-require       Whether the provided reference is a build-require
+      -tf TEST_FOLDER, --test-folder TEST_FOLDER
+                            Alternative test folder name. By default it is
+                            "test_package". Use "" to skip the test stage
+      --name NAME           Provide a package name if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
+      --user USER           Provide a user if not specified in conanfile
+      --channel CHANNEL     Provide a channel if not specified in conanfile
+      -l LOCKFILE, --lockfile LOCKFILE
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
+      --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
-    --lockfile-packages   Lock package-id and package-revision information
-    --lockfile-clean      remove unused
-    -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
-    -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
-    -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
-    -pr PROFILE_HOST, --profile PROFILE_HOST
+      --lockfile-packages   Lock package-id and package-revision information
+      --lockfile-clean      Remove unused entries from the lockfile
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
-    -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
                             Apply the specified profile to the build machine
-    -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
-    -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
-    -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
-    -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
-    -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
-    -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
-    -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode

--- a/reference/commands/export.rst
+++ b/reference/commands/export.rst
@@ -3,14 +3,15 @@ conan export
 
 .. code-block:: text
 
-    $ conan export --help
+    $ conan export -h
     usage: conan export [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
                         [--version VERSION] [--user USER] [--channel CHANNEL]
-                        [-r REMOTE | -nr] [-l LOCKFILE] [--lockfile-out LOCKFILE_OUT]
-                        [--lockfile-partial] [--build-require]
+                        [-r REMOTE | -nr] [-l LOCKFILE]
+                        [--lockfile-out LOCKFILE_OUT] [--lockfile-partial]
+                        [--build-require]
                         path
 
-    Export recipe to the Conan package cache
+    Export a recipe to the Conan package cache.
 
     positional arguments:
       path                  Path to a folder containing a recipe (conanfile.py)
@@ -19,14 +20,17 @@ conan export
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
@@ -34,9 +38,9 @@ conan export
                             Path to a lockfile.
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
-      --build-require       The provided reference is a build-require
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
+      --build-require       Whether the provided reference is a build-require
 
 
 The ``conan export`` command exports the recipe specified in ``path`` to the Conan package cache.

--- a/reference/commands/graph/build_order.rst
+++ b/reference/commands/graph/build_order.rst
@@ -3,22 +3,24 @@ conan graph build-order
 
 .. code-block:: text
 
-    $ conan graph build-order --help
-    usage: conan graph build-order [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
-                                   [--version VERSION] [--user USER] [--channel CHANNEL]
-                                   [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
-                                   [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+    $ conan graph build-order -h
+    usage: conan graph build-order [-h] [-f FORMAT] [-v [V]] [--logger]
+                                   [--name NAME] [--version VERSION] [--user USER]
+                                   [--channel CHANNEL] [--requires REQUIRES]
+                                   [--tool-requires TOOL_REQUIRES] [-b BUILD]
+                                   [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
                                    [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
                                    [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
                                    [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                                    [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
-                                   [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
-                                   [-l LOCKFILE] [--lockfile-partial]
-                                   [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
-                                   [--lockfile-clean]
+                                   [-c CONF_HOST] [-c:b CONF_BUILD]
+                                   [-c:h CONF_HOST] [-l LOCKFILE]
+                                   [--lockfile-partial]
+                                   [--lockfile-out LOCKFILE_OUT]
+                                   [--lockfile-packages] [--lockfile-clean]
                                    [path]
 
-    Computes the build order of a dependency graph
+    Compute the build order of a dependency graph.
 
     positional arguments:
       path                  Path to a folder containing a recipe (conanfile.py or
@@ -29,47 +31,50 @@ conan graph build-order
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       --requires REQUIRES   Directly provide requires instead of a conanfile
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
                             Optional, specify which packages to build from source.
-                            Combining multiple '--build' options on one command line is
-                            allowed. For dependencies, the optional 'build_policy'
-                            attribute in their conanfile.py takes precedence over the
-                            command line parameter. Possible parameters: --build="*" Force
-                            build for all packages, do not use binary packages.
-                            --build=never Disallow build for all packages, use binary
-                            packages or fail if a binary package is not found. Cannot be
-                            combined with other '--build' options. --build=missing Build
-                            packages from source whose binary package is not found.
-                            --build=cascade Build packages from source that have at least
-                            one dependency being built from source. --build=[pattern]
-                            Build packages from source whose package reference matches the
-                            pattern. The pattern uses 'fnmatch' style wildcards.
-                            --build=![pattern] Excluded packages, which will not be built
-                            from the source, whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards. Default behavior:
-                            If you omit the '--build' option, the 'build_policy' attribute
-                            in conanfile.py will be used if it exists, otherwise the
-                            behavior is like '--build=never'.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or
-                            revision of the dependencies exists there, it will install
-                            those in the local cache. When using version ranges, it will
-                            install the latest version that satisfies the range. Also, if
-                            using revisions, it will update to the latest revision for the
-                            resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o
                             Pkg:with_qt=true
@@ -86,34 +91,35 @@ conan graph build-order
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build
-                            machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults
-                            (build machine). e.g.: -c:b
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c:h
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      --lockfile-clean      Remove unused entries from the lockfile
 
 
-The ``conan graph build-order`` command compues build order of the dependency graph for the recipe specified in ``path``.
+The ``conan graph build-order`` command computes build order of the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/graph/build_order_merge.rst
+++ b/reference/commands/graph/build_order_merge.rst
@@ -1,2 +1,23 @@
 conan graph build-order-merge     
 =============================
+
+
+.. code-block:: text
+
+    $ conan graph build-order-merge -h
+    usage: conan graph build-order-merge [-h] [-f FORMAT] [-v [V]] [--logger]
+                                         [--file [FILE]]
+
+    Merge more than 1 build-order file.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
+                            Select the output format: json
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --file [FILE]         Files to be merged

--- a/reference/commands/graph/info.rst
+++ b/reference/commands/graph/info.rst
@@ -3,22 +3,23 @@ conan graph info
 
 .. code-block:: text
         
-    $ conan graph info --help
+    $ conan graph info -h
     usage: conan graph info [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
                             [--version VERSION] [--user USER] [--channel CHANNEL]
                             [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
                             [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
-                            [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
-                            [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
-                            [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
-                            [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
-                            [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
-                            [--lockfile-packages] [--lockfile-clean] [--check-updates]
-                            [--filter FILTER] [--package-filter PACKAGE_FILTER]
-                            [--deploy DEPLOY]
+                            [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                            [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                            [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                            [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                            [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+                            [-l LOCKFILE] [--lockfile-partial]
+                            [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
+                            [--lockfile-clean] [--check-updates] [--filter FILTER]
+                            [--package-filter PACKAGE_FILTER] [--deploy DEPLOY]
                             [path]
 
-    Computes the dependency graph and shows information about it
+    Compute the dependency graph and shows information about it.
 
     positional arguments:
       path                  Path to a folder containing a recipe (conanfile.py or
@@ -29,47 +30,50 @@ conan graph info
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: html, json, dot
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       --requires REQUIRES   Directly provide requires instead of a conanfile
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
                             Optional, specify which packages to build from source.
-                            Combining multiple '--build' options on one command line is
-                            allowed. For dependencies, the optional 'build_policy'
-                            attribute in their conanfile.py takes precedence over the
-                            command line parameter. Possible parameters: --build="*" Force
-                            build for all packages, do not use binary packages.
-                            --build=never Disallow build for all packages, use binary
-                            packages or fail if a binary package is not found. Cannot be
-                            combined with other '--build' options. --build=missing Build
-                            packages from source whose binary package is not found.
-                            --build=cascade Build packages from source that have at least
-                            one dependency being built from source. --build=[pattern]
-                            Build packages from source whose package reference matches the
-                            pattern. The pattern uses 'fnmatch' style wildcards.
-                            --build=![pattern] Excluded packages, which will not be built
-                            from the source, whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards. Default behavior:
-                            If you omit the '--build' option, the 'build_policy' attribute
-                            in conanfile.py will be used if it exists, otherwise the
-                            behavior is like '--build=never'.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or
-                            revision of the dependencies exists there, it will install
-                            those in the local cache. When using version ranges, it will
-                            install the latest version that satisfies the range. Also, if
-                            using revisions, it will update to the latest revision for the
-                            resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o
                             Pkg:with_qt=true
@@ -86,38 +90,41 @@ conan graph info
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build
-                            machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults
-                            (build machine). e.g.: -c:b
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c:h
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
-      --check-updates
+      --lockfile-clean      Remove unused entries from the lockfile
+      --check-updates       Check if there are recipe updates
       --filter FILTER       Show only the specified fields
       --package-filter PACKAGE_FILTER
-                            Print information only for packages that match the patterns
-      --deploy DEPLOY       Deploy using the provided deployer to the output folder
+                            Print information only for packages that match the
+                            patterns
+      --deploy DEPLOY       Deploy using the provided deployer to the output
+                            folder
 
 The ``conan graph info`` command shows information about the dependency graph for the recipe specified in ``path``.

--- a/reference/commands/inspect.rst
+++ b/reference/commands/inspect.rst
@@ -5,18 +5,21 @@ conan inspect
 
 .. code-block:: bash
 
-    $ conan inspect --help
+    $ conan inspect -h
     usage: conan inspect [-h] [-f FORMAT] [-v [V]] [--logger] path
 
-    Inspect a conanfile.py to return the public fields
+    Inspect a conanfile.py to return its public fields.
 
     positional arguments:
-    path                  Path to a folder containing a recipe (conanfile.py)
+      path                  Path to a folder containing a recipe (conanfile.py)
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or
-                            -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.

--- a/reference/commands/inspect.rst
+++ b/reference/commands/inspect.rst
@@ -3,7 +3,7 @@
 conan inspect
 =============
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan inspect -h
     usage: conan inspect [-h] [-f FORMAT] [-v [V]] [--logger] path

--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -159,7 +159,7 @@ Conanfile path or --requires
 The ``conan install`` command can use 2 different origins for information. The first one is using a local ``conanfile.py`` 
 or ``conanfile.txt``, containing definitions of the dependencies and generators to be used.
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan install .  # there is a conanfile.txt or a conanfile.py in the cwd
     $ conan install conanfile.py  # also works, direct reference file
@@ -174,7 +174,7 @@ name, located in the repository root, so users can do a straightforward ``git cl
 The other possibility is to not have a ``conanfile`` at all, and define the requirements to be installed directly in the
 command line:
 
-.. code-block:: bash
+.. code-block:: text
 
     # Install the zlib/1.2.13 library
     $ conan install --requires=zlib/1.2.13
@@ -204,7 +204,7 @@ By default the arguments refer to the "host" context, so ``--settings:host, -s:h
 Multiple definitions of profiles can be passed as arguments, and they will compound from left to right (right has the
 highest priority)
 
-.. code-block:: bash
+.. code-block:: text
 
     # The values of myprofile3 will have higher priority
     $ conan install . -pr=myprofile1 -pr=myprofile2 -pr=myprofile3
@@ -213,7 +213,7 @@ If values for any of ``settings``, ``options`` and ``conf`` are provided in the 
 is composed with the other provided ``-pr`` (or the "default" one if not specified) profiles, with higher priority,
 not matter what the order of arguments is.
 
-.. code-block:: bash
+.. code-block:: text
 
     # the final "host" profile will always be build_type=Debug, even if "myprofile"
     # says "build_type=Release"
@@ -225,7 +225,7 @@ Generators and deployers
 
 The ``-g`` argument allows to define in the command line the different built-in generators to be used:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan install --requires=zlib/1.2.13 -g CMakeDeps -g CMakeToolchain
 
@@ -236,7 +236,7 @@ Generators are intended to create files for the build systems to locate the depe
 main use case is to copy files from the Conan cache to user space, and performing any other custom operations over the dependency graph,
 like collecting licenses, generating reports, deploying binaries to the system, etc. The syntax for deployers is:
 
-.. code-block:: bash
+.. code-block:: text
 
     # does a full copy of the dependencies binaries to the current user folder
     $ conan install . --deploy=full_deploy
@@ -279,7 +279,7 @@ only in the case that they are not defined in the recipe:
                 
     
 
-.. code-block:: bash
+.. code-block:: text
 
     # If we don't specify ``--version``, it will be None and it will fail
     $ conan install . --version=3.24
@@ -306,7 +306,7 @@ Let's say that we already have a ``conan.lock`` input lockfile, but we just adde
 to a new dependency. We could resolve the dependencies, locking all the previously locked versions, while allowing
 to resolve the new one, which was not previously present in the lockfile, and store it in a new location, or overwrite the existing lockfile:
 
-.. code-block:: bash
+.. code-block:: text
 
     # --lockfile=conan.lock is the default, not necessary
     $ conan install . --lockfile=conan.lock --lockfile-partial --lockfile-out=conan.lock 

--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -5,21 +5,22 @@ conan install
 
 .. code-block:: text
 
-    $ conan install --help
+    $ conan install -h
     usage: conan install [-h] [-f FORMAT] [-v [V]] [--logger] [--name NAME]
                          [--version VERSION] [--user USER] [--channel CHANNEL]
-                         [--requires REQUIRES] [--tool-requires TOOL_REQUIRES] [-b BUILD]
-                         [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                         [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
-                         [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
-                         [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
-                         [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
-                         [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
-                         [--lockfile-clean] [-g GENERATOR] [-of OUTPUT_FOLDER]
-                         [--deploy DEPLOY]
+                         [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
+                         [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                         [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                         [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                         [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                         [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
+                         [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
+                         [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
+                         [--lockfile-packages] [--lockfile-clean] [-g GENERATOR]
+                         [-of OUTPUT_FOLDER] [--deploy DEPLOY]
                          [path]
 
-    Installs the requirements specified in a recipe (conanfile.py or conanfile.txt).
+    Install the requirements specified in a recipe (conanfile.py or conanfile.txt).
 
     It can also be used to install a concrete package specifying a
     reference. If any requirement is not found in the local cache, it will
@@ -40,47 +41,50 @@ conan install
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       --requires REQUIRES   Directly provide requires instead of a conanfile
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
                             Optional, specify which packages to build from source.
-                            Combining multiple '--build' options on one command line is
-                            allowed. For dependencies, the optional 'build_policy'
-                            attribute in their conanfile.py takes precedence over the
-                            command line parameter. Possible parameters: --build="*" Force
-                            build for all packages, do not use binary packages.
-                            --build=never Disallow build for all packages, use binary
-                            packages or fail if a binary package is not found. Cannot be
-                            combined with other '--build' options. --build=missing Build
-                            packages from source whose binary package is not found.
-                            --build=cascade Build packages from source that have at least
-                            one dependency being built from source. --build=[pattern]
-                            Build packages from source whose package reference matches the
-                            pattern. The pattern uses 'fnmatch' style wildcards.
-                            --build=![pattern] Excluded packages, which will not be built
-                            from the source, whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards. Default behavior:
-                            If you omit the '--build' option, the 'build_policy' attribute
-                            in conanfile.py will be used if it exists, otherwise the
-                            behavior is like '--build=never'.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or
-                            revision of the dependencies exists there, it will install
-                            those in the local cache. When using version ranges, it will
-                            install the latest version that satisfies the range. Also, if
-                            using revisions, it will update to the latest revision for the
-                            resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o
                             Pkg:with_qt=true
@@ -97,39 +101,41 @@ conan install
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build
-                            machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults
-                            (build machine). e.g.: -c:b
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c:h
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      --lockfile-clean      Remove unused entries from the lockfile
       -g GENERATOR, --generator GENERATOR
                             Generators to use
       -of OUTPUT_FOLDER, --output-folder OUTPUT_FOLDER
                             The root output folder for generated and build files
-      --deploy DEPLOY       Deploy using the provided deployer to the output folder
+      --deploy DEPLOY       Deploy using the provided deployer to the output
+                            folder
 
 
 The ``conan install`` command is one of the main Conan commands, and it is used to resolve and install dependencies.
@@ -302,7 +308,7 @@ to resolve the new one, which was not previously present in the lockfile, and st
 
 .. code-block:: bash
 
-    # --locfile=conan.lock is the default, not necessary
+    # --lockfile=conan.lock is the default, not necessary
     $ conan install . --lockfile=conan.lock --lockfile-partial --lockfile-out=conan.lock 
 
 The ``--lockfile-packages`` argument allows to create lockfiles that also lock down to the package revision, but 

--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -6,26 +6,33 @@ conan list
 .. code-block:: bash
 
     $ conan list -h
-    usage: conan list [-h] [-f FORMAT] [-v [V]] [--logger] [-p PACKAGE_QUERY] [-r REMOTE] [-c] reference
+    usage: conan list [-h] [-f FORMAT] [-v [V]] [--logger] [-p PACKAGE_QUERY]
+                      [-r REMOTE] [-c]
+                      reference
 
-    Lists existing recipes, revisions or packages in the cache or in remotes given a complete
-    reference or a pattern.
+    List existing recipes, revisions, or packages in the cache (by default) or the remotes.
 
     positional arguments:
-      reference             Recipe reference or package reference. Both can contain * as wildcard at any reference field. If revision is not specified, it is assumed latest
-                            one.
+      reference             Recipe reference or package reference. Both can
+                            contain * as wildcard at any reference field. If
+                            revision is not specified, it is assumed latest one.
 
     optional arguments:
       -h, --help            show this help message and exit
       -f FORMAT, --format FORMAT
                             Select the output format: json, html
-      -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose,
-                            -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
-                            Only list packages matching a specific query. e.g: os=Windows AND (arch=x86 OR compiler=gcc)
+                            List only the packages matching a specific query, e.g,
+                            os=Windows AND (arch=x86 OR compiler=gcc)
       -r REMOTE, --remote REMOTE
-                            Remote names. Accepts wildcards
+                            Remote names. Accepts wildcards ('*' means all the
+                            remotes available)
       -c, --cache           Search in the local cache
 
 .. warning::

--- a/reference/commands/list.rst
+++ b/reference/commands/list.rst
@@ -3,7 +3,7 @@
 conan list
 ==========
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan list -h
     usage: conan list [-h] [-f FORMAT] [-v [V]] [--logger] [-p PACKAGE_QUERY]
@@ -63,7 +63,7 @@ Let's see some examples on how to use this pattern:
 Listing recipe references
 -------------------------
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list all references on local cache*
 
     $ conan list *
@@ -80,7 +80,7 @@ Listing recipe references
         zlib/1.2.11
 
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list all versions of a reference*
 
     $ conan list zlib
@@ -93,7 +93,7 @@ Listing recipe references
 As we commented, you can also use the ``*`` wildcard inside the reference you want to
 search.
 
-.. code-block:: bash
+.. code-block:: text
     :caption: *list all versions of a reference, equivalent to the previous one*
 
     $ conan list zlib/*
@@ -104,7 +104,7 @@ search.
 
 Use the pattern for searching only references matching a specific channel:
 
-.. code-block:: bash
+.. code-block:: text
     :caption: *list references with 'stable' channel*
 
     $ conan list */*@*/stable
@@ -120,7 +120,7 @@ Listing recipe revisions
 The shortest way of listing the latest recipe revision for a recipe is using the
 ``name/version@user/channel`` as the pattern:
 
-.. code-block:: bash
+.. code-block:: text
     :caption: *list latest recipe revision*
 
     $ conan list zlib/1.2.11
@@ -133,7 +133,7 @@ The shortest way of listing the latest recipe revision for a recipe is using the
 This is equivalent to specify explicitly that you want to list the latest recipe revision
 using the ``#latest`` placeholder:
 
-.. code-block:: bash
+.. code-block:: text
     :caption: *list latest recipe revision*
 
     $ conan list zlib/1.2.11#latest
@@ -145,7 +145,7 @@ using the ``#latest`` placeholder:
 
 To list all recipe revisions use the ``*`` wildcard:
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list all recipe revisions*
 
     $ conan list zlib/1.2.11#*
@@ -166,7 +166,7 @@ Listing package IDs
 The shortest way of listing all the package IDs belonging to the latest recipe revision is
 using ``name/version@user/channel:*`` as the pattern:
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list all package IDs for latest recipe revision*
 
     $ conan list zlib/1.2.11:*
@@ -208,7 +208,7 @@ using ``name/version@user/channel:*`` as the pattern:
 To list all the package IDs for all the recipe revisions use the ``*`` wildcard in the
 revision ``#`` part:
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list all the package IDs for all the recipe revisions*
 
     $ conan list zlib/1.2.11#*:*
@@ -249,7 +249,7 @@ Listing package revisions
 The shortest way of listing the latest package revision for a specific recipe revision and
 package ID is using the pattern ``name/version@user/channel#rrev:pkgid``
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list latest package revision for a specific recipe revision and package ID*
 
     $ conan list zlib/1.2.11#8b23adc7acd6f1d6e220338a78e3a19e:fdb823f07bc228621617c6397210a5c6c4c8807b
@@ -266,7 +266,7 @@ package ID is using the pattern ``name/version@user/channel#rrev:pkgid``
 
 To list all the package revisions for for the latest recipe revision:
 
-.. code-block:: bash
+.. code-block:: text
   :caption: *list all the package revisions for all package-ids the latest recipe revision*
 
     $ conan list zlib/1.2.11:*#*
@@ -306,7 +306,7 @@ The ``conan list ... --format=json`` will return a json output in ``stdout`` (ca
 with the following structure:
 
 
-.. code-block:: bash
+.. code-block:: text
 
   $ conan list zlib/1.2.11:*#* --format=json
   {

--- a/reference/commands/lock/add.rst
+++ b/reference/commands/lock/add.rst
@@ -1,7 +1,7 @@
 conan lock add
 ==============
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan lock add -h
     usage: conan lock add [-h] [-v [V]] [--logger] [--requires REQUIRES]

--- a/reference/commands/lock/add.rst
+++ b/reference/commands/lock/add.rst
@@ -1,2 +1,33 @@
 conan lock add
 ==============
+
+.. code-block:: bash
+
+    $ conan lock add -h
+    usage: conan lock add [-h] [-v [V]] [--logger] [--requires REQUIRES]
+                          [--build-requires BUILD_REQUIRES]
+                          [--python-requires PYTHON_REQUIRES]
+                          [--lockfile-out LOCKFILE_OUT] [--lockfile LOCKFILE]
+
+    Add requires, build-requires or python-requires to an existing or new
+    lockfile. The resulting lockfile will be ordered, newer versions/revisions
+    first. References can be supplied with and without revisions like "--
+    requires=pkg/version", but they must be package references, including at least
+    the version, and they cannot contain a version range.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --requires REQUIRES   Add references to lockfile.
+      --build-requires BUILD_REQUIRES
+                            Add build-requires to lockfile
+      --python-requires PYTHON_REQUIRES
+                            Add python-requires to lockfile
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the created lockfile
+      --lockfile LOCKFILE   Filename of the input lockfile

--- a/reference/commands/lock/create.rst
+++ b/reference/commands/lock/create.rst
@@ -3,20 +3,22 @@ conan lock create
 
 .. code-block:: text
 
-    $ conan lock create --help
-    usage: conan lock create [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]
-                             [--user USER] [--channel CHANNEL] [--requires REQUIRES]
-                             [--tool-requires TOOL_REQUIRES] [-b BUILD] [-r REMOTE | -nr]
-                             [-u] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD]
-                             [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
-                             [-pr:h PROFILE_HOST] [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD]
-                             [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD]
-                             [-c:h CONF_HOST] [-l LOCKFILE] [--lockfile-partial]
+    $ conan lock create -h
+    usage: conan lock create [-h] [-v [V]] [--logger] [--name NAME]
+                             [--version VERSION] [--user USER] [--channel CHANNEL]
+                             [--requires REQUIRES] [--tool-requires TOOL_REQUIRES]
+                             [-b BUILD] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
+                             [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                             [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                             [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                             [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                             [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+                             [-l LOCKFILE] [--lockfile-partial]
                              [--lockfile-out LOCKFILE_OUT] [--lockfile-packages]
                              [--lockfile-clean]
                              [path]
 
-    Create a lockfile from a conanfile or a reference
+    Create a lockfile from a conanfile or a reference.
 
     positional arguments:
       path                  Path to a folder containing a recipe (conanfile.py or
@@ -25,47 +27,50 @@ conan lock create
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
       --name NAME           Provide a package name if not specified in conanfile
-      --version VERSION     Provide a package version if not specified in conanfile
+      --version VERSION     Provide a package version if not specified in
+                            conanfile
       --user USER           Provide a user if not specified in conanfile
-      --channel CHANNEL     Provide a channel if not specified in conanfil
+      --channel CHANNEL     Provide a channel if not specified in conanfile
       --requires REQUIRES   Directly provide requires instead of a conanfile
       --tool-requires TOOL_REQUIRES
                             Directly provide tool-requires instead of a conanfile
       -b BUILD, --build BUILD
                             Optional, specify which packages to build from source.
-                            Combining multiple '--build' options on one command line is
-                            allowed. For dependencies, the optional 'build_policy'
-                            attribute in their conanfile.py takes precedence over the
-                            command line parameter. Possible parameters: --build="*" Force
-                            build for all packages, do not use binary packages.
-                            --build=never Disallow build for all packages, use binary
-                            packages or fail if a binary package is not found. Cannot be
-                            combined with other '--build' options. --build=missing Build
-                            packages from source whose binary package is not found.
-                            --build=cascade Build packages from source that have at least
-                            one dependency being built from source. --build=[pattern]
-                            Build packages from source whose package reference matches the
-                            pattern. The pattern uses 'fnmatch' style wildcards.
-                            --build=![pattern] Excluded packages, which will not be built
-                            from the source, whose package reference matches the pattern.
-                            The pattern uses 'fnmatch' style wildcards. Default behavior:
-                            If you omit the '--build' option, the 'build_policy' attribute
-                            in conanfile.py will be used if it exists, otherwise the
-                            behavior is like '--build=never'.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or
-                            revision of the dependencies exists there, it will install
-                            those in the local cache. When using version ranges, it will
-                            install the latest version that satisfies the range. Also, if
-                            using revisions, it will update to the latest revision for the
-                            resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o
                             Pkg:with_qt=true
@@ -82,33 +87,34 @@ conan lock create
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build
-                            machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults
-                            (build machine). e.g.: -c:b
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c:h
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      --lockfile-clean      Remove unused entries from the lockfile
 
 The ``conan lock create`` command creates a lockfile for the recipe or reference specified in ``path``.

--- a/reference/commands/lock/merge.rst
+++ b/reference/commands/lock/merge.rst
@@ -1,2 +1,22 @@
 conan lock merge
 ================
+
+.. code-block:: text
+
+    $ conan lock merge -h
+    usage: conan lock merge [-h] [-v [V]] [--logger] [--lockfile LOCKFILE]
+                            [--lockfile-out LOCKFILE_OUT]
+
+    Merge 2 or more lockfiles.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      --lockfile LOCKFILE   Path to lockfile to be merged
+      --lockfile-out LOCKFILE_OUT
+                            Filename of the created lockfile

--- a/reference/commands/new.rst
+++ b/reference/commands/new.rst
@@ -3,15 +3,17 @@
 conan new
 =========
 
+Create a new recipe (with a conanfile.py and other associated files) from either a predefined or a user-defined template.
+
 conan new
 ---------
 
 .. code-block:: text
 
-    $ conan new --help
+    $ conan new -h
     usage: conan new [-h] [-v [V]] [--logger] [-d DEFINE] [-f] template
 
-    Create a new recipe (with conanfile.py and other files) from either a predefined or a user-defined template
+    Create a new example recipe and source files from a template.
 
     positional arguments:
       template              Template name, either a predefined built-in or a user-
@@ -33,7 +35,8 @@ conan new
       --logger              Show the output with log format, with time, type and
                             message.
       -d DEFINE, --define DEFINE
-                            Define a template argument as key=value
+                            Define a template argument as key=value, e.g., -d
+                            name=mypkg
       -f, --force           Overwrite file if it already exists
 
 
@@ -85,42 +88,42 @@ The available templates are:
 - **autotools_lib**:
   Creates an Autotools library.
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **autotools_exe**:
   Creates an Autotools executable
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **bazel_lib**:
   Creates a Bazel library.
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **bazel_exe**:
   Creates a Bazel executable
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **meson_lib**:
   Creates a Meson library.
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **meson_exe**:
   Creates a Meson executable
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **msbuild_lib**:
   Creates a MSBuild library.
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 - **msbuild_exe**:
   Creates a MSBuild executable
 
-  Its variables are: name, version
+  Its variables are: ``name``, ``version``
 
 
 Examples
@@ -145,7 +148,7 @@ Generates a *conanfile.py* for ``mygame`` that depends on the packages ``math/1.
     $ conan new cmake_exe -d name=game -d version=1.0 -d requires=math/3.14 -d requires=ai/1.0
 
 Generates the necessary files for a CMake executable target.
-This will add requirements for both ``math/3.14`` and ``ai/1.0`` to the `requirements()` method,
+This will add requirements for both ``math/3.14`` and ``ai/1.0`` to the ``requirements()`` method,
 will add the necessary ``find_package`` in CMake, and add a call to ``math()`` and ``ai()``
 inside the generated ``game()`` function.
 
@@ -153,5 +156,7 @@ inside the generated ``game()`` function.
 Custom templates
 ----------------
 
-There's also the possibility to create your own templates by passing a path to your template file,
-both as an absolute path, or relative to your Conan home folder.
+There's also the possibility to create your own templates by passing a path to your template directory,
+both as an absolute path, or relative to your Conan home folder. This directory should contain Jinja2 templates,
+which will produce your desired template structure. You can use custom variables that will be needed to be passed
+as ``name`` and ```version`` does, or use your custom variables.

--- a/reference/commands/new.rst
+++ b/reference/commands/new.rst
@@ -129,21 +129,21 @@ The available templates are:
 Examples
 --------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan new basic
 
 
 Generates a basic *conanfile.py* that does not implement any custom functionality
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan new basic -d name=mygame -d requires=math/1.0 -d requires=ai/1.3
 
 Generates a *conanfile.py* for ``mygame`` that depends on the packages ``math/1.0`` and ``ai/1.3``
 
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan new cmake_exe -d name=game -d version=1.0 -d requires=math/3.14 -d requires=ai/1.0
 

--- a/reference/commands/profile.rst
+++ b/reference/commands/profile.rst
@@ -14,7 +14,7 @@ conan profile detect
     $ conan profile detect -h
     usage: conan profile detect [-h] [-v [V]] [--logger] [--name NAME] [-f]
 
-    Generate a default profile using auto-detected values.
+    Generate a profile using auto-detected values.
 
     optional arguments:
       -h, --help   show this help message and exit

--- a/reference/commands/profile.rst
+++ b/reference/commands/profile.rst
@@ -3,26 +3,7 @@
 conan profile
 =============
 
-.. code-block:: bash
-
-    $ conan profile --help              
-    usage: conan profile [-h] [-v [V]] [--logger] {detect,list,path,show} ...
-
-    Manages profiles
-
-    positional arguments:
-    {detect,list,path,show}
-                            sub-command help
-        detect              Detect default profile
-        list                List all profiles in the cache
-        path                Show profile path location
-        show                Show profiles
-
-    optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or
-                            -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+Manage profiles
 
 
 conan profile detect
@@ -30,18 +11,19 @@ conan profile detect
 
 .. code-block:: bash
 
-    $ conan profile detect --help
+    $ conan profile detect -h
     usage: conan profile detect [-h] [-v [V]] [--logger] [--name NAME] [-f]
 
-    Detect default profile
+    Generate a default profile using auto-detected values.
 
     optional arguments:
-    -h, --help   show this help message and exit
-    -v [V]       Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
-                -vvv or -vtrace
-    --logger     Show the output with log format, with time, type and message.
-    --name NAME  Profile name, 'default' if not specified
-    -f, --force  Overwrite if exists
+      -h, --help   show this help message and exit
+      -v [V]       Level of detail of the output. Valid options from less verbose
+                   to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                   -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger     Show the output with log format, with time, type and message.
+      --name NAME  Profile name, 'default' if not specified
+      -f, --force  Overwrite if exists
 
 
 conan profile list
@@ -49,18 +31,21 @@ conan profile list
 
 .. code-block:: bash
 
-    $ conan profile list --help  
+    $ conan profile list -h
     usage: conan profile list [-h] [-f FORMAT] [-v [V]] [--logger]
 
-    List all profiles in the cache
+    List all profiles in the cache.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or
-                            -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 conan profile path
@@ -68,45 +53,64 @@ conan profile path
 
 .. code-block:: bash
 
-    $ conan profile path --help
-    usage: conan profile path [-h] [-v [V]] [--logger] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
-                            [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
-                            name
+    $ conan profile path -h
+    usage: conan profile path [-h] [-v [V]] [--logger] [-o OPTIONS_HOST]
+                              [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                              [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                              [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                              [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                              [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+                              name
 
-    Show profile path location
+    Show profile path location.
 
     positional arguments:
-    name                  Profile name
+      name                  Profile name
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or
-                            -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
-    -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
-    -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
-    -pr PROFILE_HOST, --profile PROFILE_HOST
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
-    -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
                             Apply the specified profile to the build machine
-    -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
-    -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
-    -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
-    -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
-    -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
-    -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
-    -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcod
 
 
 conan profile show
@@ -114,38 +118,57 @@ conan profile show
 
 .. code-block:: bash
 
-    $ conan profile show --help
-    usage: conan profile show [-h] [-v [V]] [--logger] [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST]
-                            [-s SETTINGS_HOST] [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
+    $ conan profile show -h
+    usage: conan profile show [-h] [-v [V]] [--logger] [-o OPTIONS_HOST]
+                              [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                              [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                              [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+                              [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
+                              [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
 
-    Show profiles
+    Show aggregated profiles from the passed arguments.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or
-                            -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    -o OPTIONS_HOST, --options OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o Pkg:with_qt=true
-    -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
-                            Define options values (build machine), e.g.: -o:b Pkg:with_qt=true
-    -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
-                            Define options values (host machine), e.g.: -o:h Pkg:with_qt=true
-    -pr PROFILE_HOST, --profile PROFILE_HOST
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -o OPTIONS_HOST, --options OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o
+                            Pkg:with_qt=true
+      -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
+                            Define options values (build machine), e.g.: -o:b
+                            Pkg:with_qt=true
+      -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
+                            Define options values (host machine), e.g.: -o:h
+                            Pkg:with_qt=true
+      -pr PROFILE_HOST, --profile PROFILE_HOST
                             Apply the specified profile to the host machine
-    -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
+      -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
                             Apply the specified profile to the build machine
-    -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
+      -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
-    -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s compiler=gcc
-    -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build machine). e.g.: -s:b compiler=gcc
-    -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host machine). e.g.: -s:h compiler=gcc
-    -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c tools.cmake.cmaketoolchain:generator=Xcode
-    -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults (build machine). e.g.: -c:b tools.cmake.cmaketoolchain:generator=Xcode
-    -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults (host machine). e.g.: -c:h tools.cmake.cmaketoolchain:generator=Xcode
+      -s SETTINGS_HOST, --settings SETTINGS_HOST
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
+      -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
+      -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
+      -c CONF_HOST, --conf CONF_HOST
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:b CONF_BUILD, --conf:build CONF_BUILD
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
+                            tools.cmake.cmaketoolchain:generator=Xcode
+      -c:h CONF_HOST, --conf:host CONF_HOST
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
+                            tools.cmake.cmaketoolchain:generator=Xcode

--- a/reference/commands/profile.rst
+++ b/reference/commands/profile.rst
@@ -9,7 +9,7 @@ Manage profiles
 conan profile detect
 --------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan profile detect -h
     usage: conan profile detect [-h] [-v [V]] [--logger] [--name NAME] [-f]
@@ -29,7 +29,7 @@ conan profile detect
 conan profile list
 ------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan profile list -h
     usage: conan profile list [-h] [-f FORMAT] [-v [V]] [--logger]
@@ -51,7 +51,7 @@ conan profile list
 conan profile path
 ------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan profile path -h
     usage: conan profile path [-h] [-v [V]] [--logger] [-o OPTIONS_HOST]
@@ -116,7 +116,7 @@ conan profile path
 conan profile show
 ------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan profile show -h
     usage: conan profile show [-h] [-v [V]] [--logger] [-o OPTIONS_HOST]

--- a/reference/commands/remote.rst
+++ b/reference/commands/remote.rst
@@ -5,8 +5,7 @@ conan remote
 
 Use this command to add, edit and remove Conan repositories from the Conan remote
 registry and also manage authentication to those remotes. For more information on how to
-work with Conan repositories, please check the :ref:`dedicated section
-<conan_repositories>`.
+work with Conan repositories, please check the :ref:`dedicated section <conan_repositories>`.
 
 .. code-block:: bash
 
@@ -235,7 +234,7 @@ conan remote rename
 
 .. code-block:: bash
 
-     $ conan remote rename -h
+    $ conan remote rename -h
     usage: conan remote rename [-h] [-v [V]] [--logger] remote new_name
 
     Rename a remote.
@@ -304,7 +303,7 @@ conan remote update
                      -vtrace
       --logger       Show the output with log format, with time, type and message.
       --url URL      New url for the remote
-      --secure       Don't allow insecure server connections when using SSL
+      --secure       Do not allow insecure server connections when using SSL
       --insecure     Allow insecure server connections when using SSL
       --index INDEX  Insert the remote at a specific position in the remote list
 

--- a/reference/commands/remote.rst
+++ b/reference/commands/remote.rst
@@ -7,7 +7,7 @@ Use this command to add, edit and remove Conan repositories from the Conan remot
 registry and also manage authentication to those remotes. For more information on how to
 work with Conan repositories, please check the :ref:`dedicated section <conan_repositories>`.
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote -h
     usage: conan remote [-h] [-v [V]] [--logger]
@@ -46,7 +46,7 @@ work with Conan repositories, please check the :ref:`dedicated section <conan_re
 conan remote add
 ----------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote add -h
     usage: conan remote add [-h] [-i [INSERT]] [-f] remote url [verify_ssl]
@@ -65,7 +65,7 @@ conan remote add
 conan remote disable
 --------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote disable -h
     usage: conan remote disable [-h] [-v [V]] [--logger] remote
@@ -87,7 +87,7 @@ conan remote disable
 conan remote enable
 -------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote enable -h
     usage: conan remote enable [-h] [-v [V]] [--logger] remote
@@ -109,7 +109,7 @@ conan remote enable
 conan remote list
 -----------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote list -h
     usage: conan remote list [-h] [-f FORMAT] [-v [V]] [--logger]
@@ -131,7 +131,7 @@ conan remote list
 conan remote list-users
 -----------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote list-users -h
     usage: conan remote list-users [-h] [-f FORMAT] [-v [V]] [--logger]
@@ -153,7 +153,7 @@ conan remote list-users
 conan remote login
 ------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote login -h
     usage: conan remote login [-h] [-f FORMAT] [-v [V]] [--logger] [-p [PASSWORD]]
@@ -185,7 +185,7 @@ conan remote login
 conan remote logout
 -------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote logout -h
     usage: conan remote logout [-h] [-f FORMAT] [-v [V]] [--logger] remote
@@ -211,7 +211,7 @@ conan remote logout
 conan remote remove
 -------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote remove -h
     usage: conan remote remove [-h] [-v [V]] [--logger] remote
@@ -232,7 +232,7 @@ conan remote remove
 conan remote rename
 -------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote rename -h
     usage: conan remote rename [-h] [-v [V]] [--logger] remote new_name
@@ -254,7 +254,7 @@ conan remote rename
 conan remote set-user
 ---------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote set-user -h
     usage: conan remote set-user [-h] [-f FORMAT] [-v [V]] [--logger]
@@ -283,7 +283,7 @@ conan remote set-user
 conan remote update
 -------------------
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remote update -h
     usage: conan remote update [-h] [-v [V]] [--logger] [--url URL] [--secure]
@@ -303,7 +303,7 @@ conan remote update
                      -vtrace
       --logger       Show the output with log format, with time, type and message.
       --url URL      New url for the remote
-      --secure       Do not allow insecure server connections when using SSL
+      --secure       Don't allow insecure server connections when using SSL
       --insecure     Allow insecure server connections when using SSL
       --index INDEX  Insert the remote at a specific position in the remote list
 

--- a/reference/commands/remote.rst
+++ b/reference/commands/remote.rst
@@ -10,30 +10,38 @@ work with Conan repositories, please check the :ref:`dedicated section
 
 .. code-block:: bash
 
-    $ conan remote --help
-    usage: conan remote [-h] [-v [V]] [--logger] {add,disable,enable,list,list-users,login,logout,remove,rename,set-user,update} ...
+    $ conan remote -h
+    usage: conan remote [-h] [-v [V]] [--logger]
+                        {add,disable,enable,list,list-users,login,logout,remove,rename,set-user,update}
+                        ...
 
-    Manages the remote list and the users authenticated on them.
+    Manage the remote list and the users authenticated on them.
 
     positional arguments:
-    {add,disable,enable,list,list-users,login,logout,remove,rename,set-user,update}
+      {add,disable,enable,list,list-users,login,logout,remove,rename,set-user,update}
                             sub-command help
-        add                 Add a remote
-        disable             Disable all the remotes matching a pattern
-        enable              Enable all the remotes matching a pattern
-        list                List current remotes
-        list-users          List the users logged into the remotes
-        login               Login into the specified remotes
-        logout              Clear the existing credentials for the specified remotes
-        remove              Remove a remote
-        rename              Rename a remote
-        set-user            Associates a username with a remote without performing the authentication
-        update              Update the remote
+        add                 Add a remote.
+        disable             Disable all the remotes matching a pattern.
+        enable              Enable all the remotes matching a pattern.
+        list                List current remotes.
+        list-users          List the users logged into all the remotes.
+        login               Login into the specified remotes matching a pattern.
+        logout              Clear the existing credentials for the specified
+                            remotes matching a pattern.
+        remove              Remove a remote.
+        rename              Rename a remote.
+        set-user            Associate a username with a remote matching a pattern
+                            without performing the authentication.
+        update              Update a remote.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 conan remote add
@@ -41,40 +49,40 @@ conan remote add
 
 .. code-block:: bash
 
-    $ conan remote add --help
-    usage: conan remote add [-h] [-v [V]] [--logger] [--insecure] [--index INDEX] name url
-
-    Add a remote
+    $ conan remote add -h
+    usage: conan remote add [-h] [-i [INSERT]] [-f] remote url [verify_ssl]
 
     positional arguments:
-    name           Name of the remote to add
-    url            Url of the remote
+      remote                Name of the remote
+      url                   URL of the remote
+      verify_ssl            Verify SSL certificate. Defaulted to True
 
     optional arguments:
-    -h, --help     show this help message and exit
-    -v [V]         Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger       Show the output with log format, with time, type and message.
-    --insecure     Allow insecure server connections when using SSL
-    --index INDEX  Insert the remote at a specific position in the remote list 
-
+      -h, --help            show this help message and exit
+      -i [INSERT], --insert [INSERT]
+                            insert remote at specific index
+      -f, --force           Force addition, will update if existing
 
 conan remote disable
 --------------------
 
 .. code-block:: bash
 
-    $ conan remote disable --help
+    $ conan remote disable -h
     usage: conan remote disable [-h] [-v [V]] [--logger] remote
 
-    Disable all the remotes matching a pattern
+    Disable all the remotes matching a pattern.
 
     positional arguments:
-    remote      Pattern of the remote/s to disable. The pattern uses 'fnmatch' style wildcards.
+      remote      Pattern of the remote/s to disable. The pattern uses 'fnmatch'
+                  style wildcards.
 
     optional arguments:
-    -h, --help  show this help message and exit
-    -v [V]      Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger    Show the output with log format, with time, type and message.
+      -h, --help  show this help message and exit
+      -v [V]      Level of detail of the output. Valid options from less verbose
+                  to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                  -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger    Show the output with log format, with time, type and message.
 
 
 conan remote enable
@@ -82,18 +90,21 @@ conan remote enable
 
 .. code-block:: bash
 
-    $ conan remote enable --help 
+    $ conan remote enable -h
     usage: conan remote enable [-h] [-v [V]] [--logger] remote
 
-    Enable all the remotes matching a pattern
+    Enable all the remotes matching a pattern.
 
     positional arguments:
-    remote      Pattern of the remote/s to enable. The pattern uses 'fnmatch' style wildcards.
+      remote      Pattern of the remote/s to enable. The pattern uses 'fnmatch'
+                  style wildcards.
 
     optional arguments:
-    -h, --help  show this help message and exit
-    -v [V]      Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger    Show the output with log format, with time, type and message.
+      -h, --help  show this help message and exit
+      -v [V]      Level of detail of the output. Valid options from less verbose
+                  to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                  -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger    Show the output with log format, with time, type and message.
 
 
 conan remote list
@@ -101,17 +112,21 @@ conan remote list
 
 .. code-block:: bash
 
-    $ conan remote list --help  
+    $ conan remote list -h
     usage: conan remote list [-h] [-f FORMAT] [-v [V]] [--logger]
 
-    List current remotes
+    List current remotes.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 conan remote list-users
@@ -119,17 +134,21 @@ conan remote list-users
 
 .. code-block:: bash
 
-    $ conan remote list-users --help
+    $ conan remote list-users -h
     usage: conan remote list-users [-h] [-f FORMAT] [-v [V]] [--logger]
 
-    List the users logged into the remotes
+    List the users logged into all the remotes.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 conan remote login
@@ -137,23 +156,31 @@ conan remote login
 
 .. code-block:: bash
 
-    $ conan remote login --help     
-    usage: conan remote login [-h] [-f FORMAT] [-v [V]] [--logger] [-p [PASSWORD]] remote username
+    $ conan remote login -h
+    usage: conan remote login [-h] [-f FORMAT] [-v [V]] [--logger] [-p [PASSWORD]]
+                              remote username
 
-    Login into the specified remotes
+    Login into the specified remotes matching a pattern.
 
     positional arguments:
-    remote                Pattern or name of the remote to login into. The pattern uses 'fnmatch' style wildcards.
-    username              Username
+      remote                Pattern or name of the remote to login into. The
+                            pattern uses 'fnmatch' style wildcards.
+      username              Username
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    -p [PASSWORD], --password [PASSWORD]
-                            User password. Use double quotes if password with spacing, and escape quotes if existing. If empty, the password is requested interactively (not exposed)
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -p [PASSWORD], --password [PASSWORD]
+                            User password. Use double quotes if password with
+                            spacing, and escape quotes if existing. If empty, the
+                            password is requested interactively (not exposed)
 
 
 conan remote logout
@@ -161,20 +188,25 @@ conan remote logout
 
 .. code-block:: bash
 
-    $ conan remote logout --help
+    $ conan remote logout -h
     usage: conan remote logout [-h] [-f FORMAT] [-v [V]] [--logger] remote
 
-    Clear the existing credentials for the specified remotes
+    Clear the existing credentials for the specified remotes matching a pattern.
 
     positional arguments:
-    remote                Pattern or name of the remote to logout. The pattern uses 'fnmatch' style wildcards.
+      remote                Pattern or name of the remote to logout. The pattern
+                            uses 'fnmatch' style wildcards.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 conan remote remove
@@ -182,18 +214,20 @@ conan remote remove
 
 .. code-block:: bash
 
-    $ conan remote remove --help
+    $ conan remote remove -h
     usage: conan remote remove [-h] [-v [V]] [--logger] remote
 
-    Remove a remote
+    Remove a remote.
 
     positional arguments:
-    remote      Name of the remote to remove. Accepts 'fnmatch' style wildcards.
+      remote      Name of the remote to remove. Accepts 'fnmatch' style wildcards.
 
     optional arguments:
-    -h, --help  show this help message and exit
-    -v [V]      Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger    Show the output with log format, with time, type and message.
+      -h, --help  show this help message and exit
+      -v [V]      Level of detail of the output. Valid options from less verbose
+                  to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                  -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger    Show the output with log format, with time, type and message.
 
 
 conan remote rename
@@ -201,19 +235,21 @@ conan remote rename
 
 .. code-block:: bash
 
-    $ conan remote rename --help
+     $ conan remote rename -h
     usage: conan remote rename [-h] [-v [V]] [--logger] remote new_name
 
-    Rename a remote
+    Rename a remote.
 
     positional arguments:
-    remote      Current name of the remote
-    new_name    New name for the remote
+      remote      Current name of the remote
+      new_name    New name for the remote
 
     optional arguments:
-    -h, --help  show this help message and exit
-    -v [V]      Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger    Show the output with log format, with time, type and message.
+      -h, --help  show this help message and exit
+      -v [V]      Level of detail of the output. Valid options from less verbose
+                  to more verbose: -vquiet, -verror, -vwarning, -vnotice,
+                  -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
+      --logger    Show the output with log format, with time, type and message.
 
 
 conan remote set-user
@@ -221,21 +257,28 @@ conan remote set-user
 
 .. code-block:: bash
 
-    $ conan remote set-user --help
-    usage: conan remote set-user [-h] [-f FORMAT] [-v [V]] [--logger] remote username
+    $ conan remote set-user -h
+    usage: conan remote set-user [-h] [-f FORMAT] [-v [V]] [--logger]
+                                 remote username
 
-    Associates a username with a remote without performing the authentication
+    Associate a username with a remote matching a pattern without performing the
+    authentication.
 
     positional arguments:
-    remote                Pattern or name of the remote. The pattern uses 'fnmatch' style wildcards.
-    username              Username
+      remote                Pattern or name of the remote. The pattern uses
+                            'fnmatch' style wildcards.
+      username              Username
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f FORMAT, --format FORMAT
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
                             Select the output format: json
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
 
 
 conan remote update
@@ -243,22 +286,27 @@ conan remote update
 
 .. code-block:: bash
 
-    $ conan remote update --help  
-    usage: conan remote update [-h] [-v [V]] [--logger] [--url URL] [--secure] [--insecure] [--index INDEX] remote
+    $ conan remote update -h
+    usage: conan remote update [-h] [-v [V]] [--logger] [--url URL] [--secure]
+                               [--insecure] [--index INDEX]
+                               remote
 
-    Update the remote
+    Update a remote.
 
     positional arguments:
-    remote         Name of the remote to update
+      remote         Name of the remote to update
 
     optional arguments:
-    -h, --help     show this help message and exit
-    -v [V]         Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger       Show the output with log format, with time, type and message.
-    --url URL      New url for the remote
-    --secure       Don\'t allow insecure server connections when using SSL
-    --insecure     Allow insecure server connections when using SSL
-    --index INDEX  Insert the remote at a specific position in the remote list
+      -h, --help     show this help message and exit
+      -v [V]         Level of detail of the output. Valid options from less
+                     verbose to more verbose: -vquiet, -verror, -vwarning,
+                     -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or
+                     -vtrace
+      --logger       Show the output with log format, with time, type and message.
+      --url URL      New url for the remote
+      --secure       Don't allow insecure server connections when using SSL
+      --insecure     Allow insecure server connections when using SSL
+      --index INDEX  Insert the remote at a specific position in the remote list
 
 Read more
 ---------

--- a/reference/commands/remote.rst
+++ b/reference/commands/remote.rst
@@ -308,6 +308,7 @@ conan remote update
       --insecure     Allow insecure server connections when using SSL
       --index INDEX  Insert the remote at a specific position in the remote list
 
+
 Read more
 ---------
 

--- a/reference/commands/remove.rst
+++ b/reference/commands/remove.rst
@@ -1,7 +1,7 @@
 conan remove
 ============
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remove -h
     usage: conan remove [-h] [-v [V]] [--logger] [-c] [-p PACKAGE_QUERY]
@@ -43,7 +43,7 @@ remove a complete package, or just remove the binaries, leaving still the recipe
 To remove recipes and their associated package binaries from the local cache:
 
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remove "*"
     # Removes everything from the cache
@@ -66,7 +66,7 @@ To remove recipes and their associated package binaries from the local cache:
 To remove only package binaries, but leaving the recipes, it is necessary to specify the
 pattern including the ``:`` separator of the ``package_id``:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remove zlib/1.2.11:*
     # Removes all the zlib/1.2.11 package binaries from all the recipe revisions
@@ -90,7 +90,7 @@ pattern including the ``:`` separator of the ``package_id``:
 All the above commands, by default operate in the Conan cache.
 To remove artifacts from a server, use the ``-r=myremote`` argument:
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan remove zlib/1.2.11:* -r=myremote
     # Removes all the zlib/1.2.11 package binaries from all the recipe revisions in 

--- a/reference/commands/remove.rst
+++ b/reference/commands/remove.rst
@@ -4,28 +4,36 @@ conan remove
 .. code-block:: bash
 
     $ conan remove -h
-    usage: conan remove [-h] [-v [V]] [--logger] [-f] [-p PACKAGE_QUERY] [-r REMOTE] reference
+    usage: conan remove [-h] [-v [V]] [--logger] [-c] [-p PACKAGE_QUERY]
+                        [-r REMOTE]
+                        reference
 
-    Removes recipes or packages from local cache or a remote.
+    Remove recipes or packages from local cache or a remote.
+
     - If no remote is specified (-r), the removal will be done in the local conan cache.
     - If a recipe reference is specified, it will remove the recipe and all the packages, unless -p
-    is specified, in that case, only the packages matching the specified query (and not the recipe)
-    will be removed.
+      is specified, in that case, only the packages matching the specified query (and not the recipe)
+      will be removed.
     - If a package reference is specified, it will remove only the package.
 
     positional arguments:
-    reference             Recipe reference or package reference, can contain * aswildcard at any reference field. e.g: lib/*
+      reference             Recipe reference or package reference, can contain *
+                            aswildcard at any reference field. e.g: lib/*
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v
-                            or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    -f, --force           Remove without requesting a confirmation
-    -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
-                            Remove all packages (empty) or provide a query: os=Windows AND (arch=x86 OR compiler=gcc)
-    -r REMOTE, --remote REMOTE
-                            Will remove from the specified remote    
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -c, --confirm         Remove without requesting a confirmation
+      -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
+                            Remove all packages (empty) or provide a query:
+                            os=Windows AND (arch=x86 OR compiler=gcc)
+      -r REMOTE, --remote REMOTE
+                            Will remove from the specified remote
 
 
 The ``conan remove`` command removes recipes and packages from the local cache or from a

--- a/reference/commands/search.rst
+++ b/reference/commands/search.rst
@@ -8,20 +8,28 @@ This command is equivalent to ``conan list recipes <query> -r=*``, and is provid
 
 .. code-block:: bash
 
-    conan search -h
-    usage: conan search [-h] [-f {cli,json}] [-r REMOTE] query
+    $ conan search -h
+    usage: conan search [-h] [-f FORMAT] [-v [V]] [--logger] [-r REMOTE] reference
 
-    Searches for package recipes in a remote or remotes
+    Search for package recipes in all the remotes (by default), or a remote.
 
     positional arguments:
-    query                 Search query to find package recipe reference, e.g., 'boost', 'lib*'
+      reference             Recipe reference to search for.It can contain * as
+                            wildcard at any reference field.
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -f {cli,json}, --format {cli,json}
-                            Select the output format: cli, json. 'cli' is the default output.
-    -r REMOTE, --remote REMOTE
-                            Remote names. Accepts wildcards. If not specified it searches in all remotes
+      -h, --help            show this help message and exit
+      -f FORMAT, --format FORMAT
+                            Select the output format: json
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -r REMOTE, --remote REMOTE
+                            Remote names. Accepts wildcards. If not specified it
+                            searches in all the remotes
 
 
 

--- a/reference/commands/search.rst
+++ b/reference/commands/search.rst
@@ -6,7 +6,7 @@ conan search
 Search existing recipes in remotes.
 This command is equivalent to ``conan list recipes <query> -r=*``, and is provided for simpler UX.
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan search -h
     usage: conan search [-h] [-f FORMAT] [-v [V]] [--logger] [-r REMOTE] reference
@@ -33,7 +33,7 @@ This command is equivalent to ``conan list recipes <query> -r=*``, and is provid
 
 
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan search zlib
     conancenter:

--- a/reference/commands/source.rst
+++ b/reference/commands/source.rst
@@ -5,21 +5,27 @@ conan source
 
 .. code-block:: bash
 
-    $ conan source --help
-    usage: conan source [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION] [--user USER] [--channel CHANNEL] [path]
+    $ conan source -h
+    usage: conan source [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]
+                        [--user USER] [--channel CHANNEL]
+                        [path]
 
-    Calls the source() method
+    Call the source() method.
 
     positional arguments:
-    path               Path to a folder containing a recipe (conanfile.py or conanfile.txt) or to a recipe file. e.g.,
-                        ./my_project/conanfile.txt.
+      path               Path to a folder containing a recipe (conanfile.py or
+                         conanfile.txt) or to a recipe file. e.g.,
+                         ./my_project/conanfile.txt.
 
     optional arguments:
-    -h, --help         show this help message and exit
-    -v [V]             Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror,
-                        -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger           Show the output with log format, with time, type and message.
-    --name NAME        Provide a package name if not specified in conanfile
-    --version VERSION  Provide a package version if not specified in conanfile
-    --user USER        Provide a user if not specified in conanfile
-    --channel CHANNEL  Provide a channel if not specified in conanfile
+      -h, --help         show this help message and exit
+      -v [V]             Level of detail of the output. Valid options from less
+                         verbose to more verbose: -vquiet, -verror, -vwarning,
+                         -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv
+                         or -vtrace
+      --logger           Show the output with log format, with time, type and
+                         message.
+      --name NAME        Provide a package name if not specified in conanfile
+      --version VERSION  Provide a package version if not specified in conanfile
+      --user USER        Provide a user if not specified in conanfile
+      --channel CHANNEL  Provide a channel if not specified in conanfile

--- a/reference/commands/source.rst
+++ b/reference/commands/source.rst
@@ -3,7 +3,7 @@
 conan source
 ============
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan source -h
     usage: conan source [-h] [-v [V]] [--logger] [--name NAME] [--version VERSION]

--- a/reference/commands/test.rst
+++ b/reference/commands/test.rst
@@ -5,37 +5,62 @@ conan test
 
 .. code-block:: text
 
-    $ conan test --help
-    usage: conan test [-h] [-v [V]] [--logger] [-r REMOTE | -nr] [-u] [-o OPTIONS_HOST]
-                      [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST] [-pr PROFILE_HOST]
-                      [-pr:b PROFILE_BUILD] [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
+    $ conan test -h
+    usage: conan test [-h] [-v [V]] [--logger] [-b BUILD] [-r REMOTE | -nr] [-u]
+                      [-o OPTIONS_HOST] [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
+                      [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
+                      [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                       [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST] [-c CONF_HOST]
                       [-c:b CONF_BUILD] [-c:h CONF_HOST] [-l LOCKFILE]
                       [--lockfile-partial] [--lockfile-out LOCKFILE_OUT]
                       [--lockfile-packages] [--lockfile-clean]
                       path reference
 
-    Test a package from a test_package folder
+    Test a package from a test_package folder.
 
     positional arguments:
-      path                  Path to a test_package folder containing a conanfile.py
+      path                  Path to a test_package folder containing a
+                            conanfile.py
       reference             Provide a package reference to test
 
     optional arguments:
       -h, --help            show this help message and exit
-      -v [V]                Level of detail of the output. Valid options from less verbose
-                            to more verbose: -vquiet, -verror, -vwarning, -vnotice,
-                            -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-      --logger              Show the output with log format, with time, type and message.
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -b BUILD, --build BUILD
+                            Optional, specify which packages to build from source.
+                            Combining multiple '--build' options on one command
+                            line is allowed. Possible values: --build="*" Force
+                            build from source for all packages. --build=never
+                            Disallow build for all packages, use binary packages
+                            or fail if a binary package is not found. Cannot be
+                            combined with other '--build' options. --build=missing
+                            Build packages from source whose binary package is not
+                            found. --build=cascade Build packages from source that
+                            have at least one dependency being built from source.
+                            --build=[pattern] Build packages from source whose
+                            package reference matches the pattern. The pattern
+                            uses 'fnmatch' style wildcards. --build=![pattern]
+                            Excluded packages, which will not be built from the
+                            source, whose package reference matches the pattern.
+                            The pattern uses 'fnmatch' style wildcards.
+                            --build=missing:[pattern] Build from source if a
+                            compatible binary does not exist, only for packages
+                            matching pattern.
       -r REMOTE, --remote REMOTE
                             Look in the specified remote or remotes server
       -nr, --no-remote      Do not use remote, resolve exclusively in the cache
-      -u, --update          Will check the remote and in case a newer version and/or
-                            revision of the dependencies exists there, it will install
-                            those in the local cache. When using version ranges, it will
-                            install the latest version that satisfies the range. Also, if
-                            using revisions, it will update to the latest revision for the
-                            resolved version range.
+      -u, --update          Will check the remote and in case a newer version
+                            and/or revision of the dependencies exists there, it
+                            will install those in the local cache. When using
+                            version ranges, it will install the latest version
+                            that satisfies the range. Also, if using revisions, it
+                            will update to the latest revision for the resolved
+                            version range.
       -o OPTIONS_HOST, --options OPTIONS_HOST
                             Define options values (host machine), e.g.: -o
                             Pkg:with_qt=true
@@ -52,34 +77,35 @@ conan test
       -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                             Apply the specified profile to the host machine
       -s SETTINGS_HOST, --settings SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s compiler=gcc
       -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
-                            Settings to build the package, overwriting the defaults (build
-                            machine). e.g.: -s:b compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (build machine). e.g.: -s:b compiler=gcc
       -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
-                            Settings to build the package, overwriting the defaults (host
-                            machine). e.g.: -s:h compiler=gcc
+                            Settings to build the package, overwriting the
+                            defaults (host machine). e.g.: -s:h compiler=gcc
       -c CONF_HOST, --conf CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:b CONF_BUILD, --conf:build CONF_BUILD
-                            Configuration to build the package, overwriting the defaults
-                            (build machine). e.g.: -c:b
+                            Configuration to build the package, overwriting the
+                            defaults (build machine). e.g.: -c:b
                             tools.cmake.cmaketoolchain:generator=Xcode
       -c:h CONF_HOST, --conf:host CONF_HOST
-                            Configuration to build the package, overwriting the defaults
-                            (host machine). e.g.: -c:h
+                            Configuration to build the package, overwriting the
+                            defaults (host machine). e.g.: -c:h
                             tools.cmake.cmaketoolchain:generator=Xcode
       -l LOCKFILE, --lockfile LOCKFILE
-                            Path to a lockfile.
-      --lockfile-partial    Do not raise an error if some dependency is not found in
-                            lockfile
+                            Path to a lockfile. Use --lockfile="" to avoid
+                            automatic use of existing 'conan.lock' file
+      --lockfile-partial    Do not raise an error if some dependency is not found
+                            in lockfile
       --lockfile-out LOCKFILE_OUT
                             Filename of the updated lockfile
       --lockfile-packages   Lock package-id and package-revision information
-      --lockfile-clean      remove unused
+      --lockfile-clean      Remove unused entries from the lockfile
 
 
 The ``conan test`` command uses the *test_package* folder specified in ``path`` to tests the package reference specified in ``reference``.

--- a/reference/commands/upload.rst
+++ b/reference/commands/upload.rst
@@ -7,7 +7,7 @@ Use this command to upload recipes and binaries to Conan repositories. For more
 information on how to work with Conan repositories, please check the :ref:`dedicated
 section <conan_repositories>`.
 
-.. code-block:: bash
+.. code-block:: text
 
     $ conan upload -h
     usage: conan upload [-h] [-v [V]] [--logger] [-p PACKAGE_QUERY] -r REMOTE

--- a/reference/commands/upload.rst
+++ b/reference/commands/upload.rst
@@ -9,30 +9,42 @@ section <conan_repositories>`.
 
 .. code-block:: bash
 
-    $ conan upload --help 
-    usage: conan upload [-h] [-v [V]] [--logger] [-p PACKAGE_QUERY] -r REMOTE [--only-recipe] [--force] [--check] [-c] reference
+    $ conan upload -h
+    usage: conan upload [-h] [-v [V]] [--logger] [-p PACKAGE_QUERY] -r REMOTE
+                        [--only-recipe] [--force] [--check] [-c]
+                        reference
 
-    Uploads a recipe and binary packages to a remote.
+    Upload packages to a remote.
+
     By default, all the matching references are uploaded (all revisions).
     By default, if a recipe reference is specified, it will upload all the revisions for all the
     binary packages, unless --only-recipe is specified. You can use the "latest" placeholder at the
     "reference" argument to specify the latest revision of the recipe or the package.
 
     positional arguments:
-    reference             Recipe reference or package reference, can contain * as wildcard at any reference field. If no revision is specified, it is assumed to be the latest
+      reference             Recipe reference or package reference, can contain *
+                            as wildcard at any reference field. If no revision is
+                            specified, it is assumed to be the latest
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -v [V]                Level of detail of the output. Valid options from less verbose to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug, -vvv or -vtrace
-    --logger              Show the output with log format, with time, type and message.
-    -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
-                            Only upload packages matching a specific query. e.g: os=Windows AND (arch=x86 OR compiler=gcc)
-    -r REMOTE, --remote REMOTE
+      -h, --help            show this help message and exit
+      -v [V]                Level of detail of the output. Valid options from less
+                            verbose to more verbose: -vquiet, -verror, -vwarning,
+                            -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
+                            -vvv or -vtrace
+      --logger              Show the output with log format, with time, type and
+                            message.
+      -p PACKAGE_QUERY, --package-query PACKAGE_QUERY
+                            Only upload packages matching a specific query. e.g:
+                            os=Windows AND (arch=x86 OR compiler=gcc)
+      -r REMOTE, --remote REMOTE
                             Upload to this specific remote
-    --only-recipe         Upload only the recipe/s, not the binary packages.
-    --force               Force the upload of the artifacts even if the revision already exists in the server
-    --check               Perform an integrity check, using the manifests, before upload
-    -c, --confirm         Upload all matching recipes without confirmation
+      --only-recipe         Upload only the recipe/s, not the binary packages.
+      --force               Force the upload of the artifacts even if the revision
+                            already exists in the server
+      --check               Perform an integrity check, using the manifests,
+                            before upload
+      -c, --confirm         Upload all matching recipes without confirmation
 
 Read more
 ---------


### PR DESCRIPTION
This includes changes from https://github.com/conan-io/conan/pull/13179

Also fixes some of the typos in the commands reference (Although I plan to improve the actual wording tomorrow, so stay tuned for that)

The most contentious thing this PR does is to get all --help output from an 80-char terminal window. I've done this so that the user does not need to scroll to see the whole output, which could happen for long lines. I've put forth the idea to remove the max-width limit on the content of the docs so that the pages could fill the whole screen and then we wouldn't need to squeeze the output like this, but meanwhile, I think that this reads ok, but I open to using a different one if anyone feels too strongly against this :)