### PR TITLE
correct translated conanfile.py

### DIFF
--- a/tutorial/consuming_packages/the_flexibility_of_conanfile_py.rst
+++ b/tutorial/consuming_packages/the_flexibility_of_conanfile_py.rst
@@ -83,6 +83,8 @@ The equivalent of the *conanfile.txt* in form of Conan recipe could look like th
 
         def requirements(self):
             self.requires("zlib/1.2.11")
+
+        def build_requirements(self):
             self.tool_requires("cmake/3.19.8")
 
 


### PR DESCRIPTION
"tool_requires" function calls are meant to go into the "build_requirements" [method](https://docs.conan.io/2/reference/conanfile/methods/build_requirements.html)