### PR TITLE
Added a virtual environment instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ How to build
 ============
 
 - Install python and [pip docs](https://pip.pypa.io/en/stable/installing/).
+- Create a virtual environment: `python -m venv env`
+- Activate the virtual environment: `source env/bin/activate`
 - Install the requirements (sphinx):
 
   `$ pip install -r requirements.txt`


### PR DESCRIPTION
When building the docs myself, I encounter the following issue:

```py
Defaulting to user installation because normal site-packages is not writeable
Collecting sphinx==1.8.6
  Downloading Sphinx-1.8.6-py2.py3-none-any.whl (3.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.1/3.1 MB 802.9 kB/s eta 0:00:00
Collecting docutils<0.18
  Downloading docutils-0.17.1-py2.py3-none-any.whl (575 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 575.5/575.5 kB 876.2 kB/s eta 0:00:00
Requirement already satisfied: sphinx-sitemap>=2.1.0 in /home/arshia/.local/lib/python3.10/site-packages (from -r requirements.txt (line 3)) (2.2.0)
Requirement already satisfied: sphinxcontrib-spelling in /home/arshia/.local/lib/python3.10/site-packages (from -r requirements.txt (line 4)) (4.2.1)
Requirement already satisfied: sphinx-notfound-page in /home/arshia/.local/lib/python3.10/site-packages (from -r requirements.txt (line 5)) (0.8)
Requirement already satisfied: jinja2<=3.0.3 in /home/arshia/.local/lib/python3.10/site-packages (from -r requirements.txt (line 6)) (3.0.3)
Requirement already satisfied: requests>=2.0.0 in /home/arshia/.local/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (2.25.1)
Requirement already satisfied: babel!=2.0,>=1.3 in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (2.11.0)
Requirement already satisfied: imagesize in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (1.4.1)
Requirement already satisfied: packaging in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (23.0)
Requirement already satisfied: sphinxcontrib-websupport in /home/arshia/.local/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (1.2.4)
Requirement already satisfied: alabaster<0.8,>=0.7 in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (0.7.13)
Requirement already satisfied: Pygments>=2.0 in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (2.14.0)
Requirement already satisfied: six>=1.5 in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (1.16.0)
Requirement already satisfied: setuptools in /home/arshia/.local/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (58.2.0)
Requirement already satisfied: snowballstemmer>=1.1 in /usr/lib/python3.10/site-packages (from sphinx==1.8.6->-r requirements.txt (line 1)) (2.2.0)
Requirement already satisfied: PyEnchant>=1.6.5 in /home/arshia/.local/lib/python3.10/site-packages (from sphinxcontrib-spelling->-r requirements.txt (line 4)) (3.2.2)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/lib/python3.10/site-packages (from jinja2<=3.0.3->-r requirements.txt (line 6)) (2.1.2)
Requirement already satisfied: pytz>=2015.7 in /home/arshia/.local/lib/python3.10/site-packages (from babel!=2.0,>=1.3->sphinx==1.8.6->-r requirements.txt (line 1)) (2021.3)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3.10/site-packages (from requests>=2.0.0->sphinx==1.8.6->-r requirements.txt (line 1)) (2022.12.7)
Requirement already satisfied: idna<3,>=2.5 in /home/arshia/.local/lib/python3.10/site-packages (from requests>=2.0.0->sphinx==1.8.6->-r requirements.txt (line 1)) (2.10)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/lib/python3.10/site-packages (from requests>=2.0.0->sphinx==1.8.6->-r requirements.txt (line 1)) (1.26.12)
Requirement already satisfied: chardet<5,>=3.0.2 in /home/arshia/.local/lib/python3.10/site-packages (from requests>=2.0.0->sphinx==1.8.6->-r requirements.txt (line 1)) (4.0.0)
Requirement already satisfied: sphinxcontrib-serializinghtml in /usr/lib/python3.10/site-packages (from sphinxcontrib-websupport->sphinx==1.8.6->-r requirements.txt (line 1)) (1.1.5)
Installing collected packages: docutils, sphinx
  Attempting uninstall: sphinx
    Found existing installation: Sphinx 5.1.1
    Uninstalling Sphinx-5.1.1:
      Successfully uninstalled Sphinx-5.1.1
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
sphinx-automodapi 0.14.1 requires sphinx>=2, but you have sphinx 1.8.6 which is incompatible.
Successfully installed docutils-0.17.1 sphinx-1.8.6
```

And the only way I found to fix it was to create a virtual environment and install the requirements there. This would help anyone facing issues like this.
I haven't installed these packages separately before, so this seems to be a conflict with some internal packages.