### PR TITLE
Use absolute links for redirects in docs publishing

### DIFF
--- a/.ci/scripts/create_redirects.py
+++ b/.ci/scripts/create_redirects.py
@@ -3,10 +3,10 @@ from pathlib import Path
 import textwrap
 
 
-def create_redirects(path_html, old_slug, new_slug):
+def create_redirects(path_html, new_slug):
     """
-    Redirect every html page found in sources_path from being located under the old_slug
-    subfolder to the new location in new_slug. For example if old_slug=en/latest and new_slug=1
+    Redirect every html page found in sources_path to the new location in new_slug. For
+    example if new_slug=1 and sources are under <folder>/en/latest/...
 
     docs.conan.io/en/latest/index.html --> redirects to --> docs.conan.io/1/index.html
     """
@@ -18,7 +18,7 @@ def create_redirects(path_html, old_slug, new_slug):
         raise SystemExit(1)
 
 
-    def replace_html_files(sources_path: Path, old_slug: str, new_slug: str):
+    def replace_html_files(sources_path: Path, new_slug: str):
 
         redirect_template = textwrap.dedent("""
             <!DOCTYPE HTML>
@@ -26,6 +26,7 @@ def create_redirects(path_html, old_slug, new_slug):
                 <head>
                     <meta charset="UTF-8">
                     <meta http-equiv="refresh" content="1; url={destination}">
+                    <link rel="canonical" href="{destination}">
                 </head>
             </html>
         """)
@@ -33,13 +34,9 @@ def create_redirects(path_html, old_slug, new_slug):
         html_files = sources_path.glob('**/*.html')
 
         for html_file in html_files:
-            origin = Path(old_slug) / Path(html_file).relative_to(
-                sources_path).parent
-            destination = Path(new_slug) / Path(html_file).relative_to(
-                sources_path)
-            redirect = Path(os.path.relpath(destination, origin))
-            with html_file.open('w') as f:
-                f.write(redirect_template.format(destination=redirect))
+            destination = Path(new_slug) / Path(html_file).relative_to(sources_path)
+            print(html_file, destination)
+            with open(html_file, 'w') as f:
+                f.write(redirect_template.format(destination=f"https://docs.conan.io/{destination}"))
 
-
-    replace_html_files(path_html, old_slug, new_slug)
+    replace_html_files(path_html, new_slug)

--- a/.ci/scripts/prepare_gh_pages.py
+++ b/.ci/scripts/prepare_gh_pages.py
@@ -32,7 +32,7 @@ path_latest_v1 = Path(os.path.join(output_folder, latest_v1_folder))
 if path_latest_v1.exists():
     run(f"mkdir -p {output_folder}/en/latest")
     run(f"cp -R {output_folder}/{latest_v1_folder}/* {output_folder}/en/latest")
-    create_redirects(path_html=f"{output_folder}/en/latest", old_slug="en/latest", new_slug="1")
+    create_redirects(path_html=f"{output_folder}/en/latest", new_slug="1")
 
 # 2 folder is the same as the latest 2.X, copy the generated html files to 2 folder
 path_latest_v2 = Path(os.path.join(output_folder, latest_v2_version))


### PR DESCRIPTION
Closes: https://github.com/conan-io/docs/issues/3084

Now redirects are like this:

```html
<!DOCTYPE HTML>
<html lang="en-US">
    <head>
        <meta charset="UTF-8">
        <meta http-equiv="refresh" content="1; url=https://docs.conan.io/1/integrations/build_system/qmake.html">
        <link rel="canonical" href="https://docs.conan.io/1/integrations/build_system/qmake.html">
    </head>
</html>
```