### PR TITLE
Fix zlib code examples.

### DIFF
--- a/examples/tools/meson/mesontoolchain/build_simple_meson_project.rst
+++ b/examples/tools/meson/mesontoolchain/build_simple_meson_project.rst
@@ -50,7 +50,7 @@ Let's have a look at the *main.c* file:
         char buffer_in [256] = {"Conan is a MIT-licensed, Open Source package manager for C and C++ development "
                                 "for C and C++ development, allowing development teams to easily and efficiently "
                                 "manage their packages and dependencies across platforms and build systems."};
-        char buffer_out [256] = {0};
+        unsigned char buffer_out [256] = {0};
 
         z_stream defstream;
         defstream.zalloc = Z_NULL;
@@ -65,8 +65,8 @@ Let's have a look at the *main.c* file:
         deflate(&defstream, Z_FINISH);
         deflateEnd(&defstream);
 
-        printf("Uncompressed size is: %lu\n", strlen(buffer_in));
-        printf("Compressed size is: %lu\n", strlen(buffer_out));
+        printf("Uncompressed size is: %zu\n", strlen(buffer_in));
+        printf("Compressed size is: %lu\n", defstream.total_out);
 
         printf("ZLIB VERSION: %s\n", zlibVersion());
 

--- a/tutorial/consuming_packages/build_simple_cmake_project.rst
+++ b/tutorial/consuming_packages/build_simple_cmake_project.rst
@@ -48,7 +48,7 @@ Let's have a look at the *main.c* file:
         char buffer_in [256] = {"Conan is a MIT-licensed, Open Source package manager for C and C++ development "
                                 "for C and C++ development, allowing development teams to easily and efficiently "
                                 "manage their packages and dependencies across platforms and build systems."};
-        char buffer_out [256] = {0};
+        unsigned char buffer_out [256] = {0};
 
         z_stream defstream;
         defstream.zalloc = Z_NULL;
@@ -63,8 +63,8 @@ Let's have a look at the *main.c* file:
         deflate(&defstream, Z_FINISH);
         deflateEnd(&defstream);
 
-        printf("Uncompressed size is: %lu\n", strlen(buffer_in));
-        printf("Compressed size is: %lu\n", strlen(buffer_out));
+        printf("Uncompressed size is: %zu\n", strlen(buffer_in));
+        printf("Compressed size is: %lu\n", defstream.total_out);
 
         printf("ZLIB VERSION: %s\n", zlibVersion());
 


### PR DESCRIPTION
- buffer_out will receive a binary stream, it should be unsigned char
- strlen shouldn't be used on a binary stream; the actual compression result is in z_stream.total_out [1]
- strlen() returns a size_t, so we should use "%zu" format specifier

[1] https://stackoverflow.com/questions/12840933/compressed-file-size-after-deflate