### PR TITLE
Fix wrong ref link in test method reference

### DIFF
--- a/reference/conanfile/methods/test.rst
+++ b/reference/conanfile/methods/test.rst
@@ -4,9 +4,12 @@
 test()
 ======
 
-The ``test()`` method is only used for **test_package/conanfile.py**. It will execute immediately after ``build()`` has been called, and its goal is to run some executable or tests on binaries to prove the package is correctly created. Note that it is intended to be used as a test of the package: the headers are found, the libraries are found, it is possible to link, etc. But it is **not intended** to run unit, integration or functional tests.
+The ``test()`` method is only used for **test_package/conanfile.py**.
+It will execute immediately after ``build()`` has been called, and its goal is to run some executable or tests on binaries to prove the package is correctly created.
+Note that it is intended to be used as a test of the package: the headers are found, the libraries are found,
+it is possible to link, etc. But it is **not intended** to run unit, integration or functional tests.
 
-It usually takes the form:
+It usually takes the form of:
 
 .. code:: python
 
@@ -18,4 +21,4 @@ It usually takes the form:
 
 .. seealso::
     
-    See :ref:` the "testing packages" tutorial<tutorial_creating_test>` for more information.
+    See :ref:`the "testing packages" tutorial<tutorial_creating_test>` for more information.


### PR DESCRIPTION
An extra space meant the link was not being properly generated