### PR TITLE
remove legacy tools.files.download:download_cache conf

### DIFF
--- a/reference/commands/config.rst
+++ b/reference/commands/config.rst
@@ -237,7 +237,6 @@ Displays all the Conan built-in configurations. There are 2 groups:
     tools.cmake.cmaketoolchain:toolset_arch: Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain
     tools.cmake.cmaketoolchain:user_toolchain: Inject existing user toolchains at the beginning of conan_toolchain.cmake
     tools.env.virtualenv:powershell: If it is set to True it will generate powershell launchers if os=Windows
-    tools.files.download:download_cache: Define the cache folder to store downloads from files.download()/get()
     tools.files.download:retry: Number of retries in case of failure when downloading
     tools.files.download:retry_wait: Seconds to wait between download attempts
     tools.gnu:define_libcxx11_abi: Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11

--- a/reference/config_files/global_conf.rst
+++ b/reference/config_files/global_conf.rst
@@ -84,7 +84,6 @@ To list all the possible configurations available, run :command:`conan config li
     tools.cmake.cmaketoolchain:toolset_arch: Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain
     tools.cmake.cmaketoolchain:user_toolchain: Inject existing user toolchains at the beginning of conan_toolchain.cmake
     tools.env.virtualenv:powershell: If it is set to True it will generate powershell launchers if os=Windows
-    tools.files.download:download_cache: Define the cache folder to store downloads from files.download()/get()
     tools.files.download:retry: Number of retries in case of failure when downloading
     tools.files.download:retry_wait: Seconds to wait between download attempts
     tools.gnu:define_libcxx11_abi: Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11


### PR DESCRIPTION
For https://github.com/conan-io/docs/issues/3176, this conf was removed in 2.0.3 as buggy (required doubled profile definition, super confusing for users)