### PR TITLE
Remove space in requirements options

### DIFF
--- a/reference/conanfile/attributes/binary_model.inc
+++ b/reference/conanfile/attributes/binary_model.inc
@@ -182,7 +182,7 @@ This attribute should be defined as a python dictionary.
                     "option2": "ANY"}
         default_options = {"build_tests": True,
                             "option1": 42,
-                            "z*: shared": True}
+                            "z*:shared": True}
 
 
 You can also assign default values for options of your requirements using "<reference_pattern>: option_name", being


### PR DESCRIPTION
With whitespace it fails silently in conan 2.0.4 (but fails with `option ' xxx' doesn't exist` in conan 1).