### PR TITLE
Set libdirs and bindirs as empty in header only packages

### DIFF
--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -171,7 +171,7 @@ We have the same header-only library that sums two numbers, but now we have this
 
         def package_info(self):
             # For header-only packages, libdirs and bindirs are not used
-            # so it's recommended to set those as empty.
+            # so it's necessary to set those as empty.
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
 

--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -44,6 +44,12 @@ This is a basic recipe for a header-only recipe:
             # This will also copy the "include" folder
             copy(self, "*.h", self.source_folder, self.package_folder)
 
+        def package_info(self):
+            # For header-only packages, libdirs and bindirs are not used
+            # so it's recommended to set those as empty.
+            self.cpp_info.bindirs = []
+            self.cpp_info.libdirs = []
+
 Our header-only library is this simple function that sums two numbers:
 
 
@@ -159,6 +165,12 @@ We have the same header-only library that sums two numbers, but now we have this
         def package(self):
             # This will also copy the "include" folder
             copy(self, "*.h", self.source_folder, self.package_folder)
+
+        def package_info(self):
+            # For header-only packages, libdirs and bindirs are not used
+            # so it's recommended to set those as empty.
+            self.cpp_info.bindirs = []
+            self.cpp_info.libdirs = []
 
         def package_id(self):
             self.info.clear()

--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -50,6 +50,9 @@ This is a basic recipe for a header-only recipe:
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
 
+Please, note that we are setting cpp_info.bindirs and cpp_info.libdirs to ``[]`` because
+we won't use them for header-only.
+
 Our header-only library is this simple function that sums two numbers:
 
 

--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -50,8 +50,8 @@ This is a basic recipe for a header-only recipe:
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
 
-Please, note that we are setting cpp_info.bindirs and cpp_info.libdirs to ``[]`` because
-we won't use them for header-only.
+Please, note that we are setting ``cpp_info.bindirs`` and ``cpp_info.libdirs`` to ``[]`` because
+header-only libraries don't have compiled libraries or binaries, but they default to ``["bin"]``, and ``["lib"]``, then it is necessary to change it.
 
 Our header-only library is this simple function that sums two numbers:
 

--- a/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/header_only_packages.rst
@@ -46,7 +46,7 @@ This is a basic recipe for a header-only recipe:
 
         def package_info(self):
             # For header-only packages, libdirs and bindirs are not used
-            # so it's recommended to set those as empty.
+            # so it's necessary to set those as empty.
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
 


### PR DESCRIPTION
Set libdirs and bindirs as empty in header only packages to align with the Conan Center Index recommendations.

Goes with: https://github.com/conan-io/examples2/pull/91