### PR TITLE
Dev deploys

### DIFF
--- a/examples/extensions.rst
+++ b/examples/extensions.rst
@@ -7,4 +7,5 @@ Conan extensions examples
    :maxdepth: 2
 
    extensions/commands/custom_commands
+   extensions/deployers/builtin_deployers
    extensions/deployers/custom_deployers

--- a/examples/extensions/commands/clean/custom_command_clean_revisions.rst
+++ b/examples/extensions/commands/clean/custom_command_clean_revisions.rst
@@ -3,12 +3,12 @@
 Custom command: Clean old recipe and package revisions
 ======================================================
 
-.. note:: 
+.. note::
 
     This is mostly an example command. The built-in ``conan remove *#!latest`` syntax,
     meaning "all revisions but the latest" would probably be enough for this use case,
     without needing this custom command.
-    
+
 
 Please, first of all, clone the sources to recreate this project. You can find them in the
 `examples2.0 repository <https://github.com/conan-io/examples2>`_ in GitHub:

--- a/examples/extensions/commands/clean/custom_command_clean_revisions.rst
+++ b/examples/extensions/commands/clean/custom_command_clean_revisions.rst
@@ -3,6 +3,13 @@
 Custom command: Clean old recipe and package revisions
 ======================================================
 
+.. note:: 
+
+    This is mostly an example command. The built-in ``conan remove *#!latest`` syntax,
+    meaning "all revisions but the latest" would probably be enough for this use case,
+    without needing this custom command.
+    
+
 Please, first of all, clone the sources to recreate this project. You can find them in the
 `examples2.0 repository <https://github.com/conan-io/examples2>`_ in GitHub:
 

--- a/examples/extensions/deployers/builtin_deployers.rst
+++ b/examples/extensions/deployers/builtin_deployers.rst
@@ -1,0 +1,10 @@
+.. _examples_extensions_builtin_deployers:
+
+
+Builtin deployers
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   dev/local_developer_deploy

--- a/examples/extensions/deployers/builtin_deployers.rst
+++ b/examples/extensions/deployers/builtin_deployers.rst
@@ -7,4 +7,4 @@ Builtin deployers
 .. toctree::
    :maxdepth: 2
 
-   dev/local_developer_deploy
+   dev/development_deploy

--- a/examples/extensions/deployers/dev/development_deploy.rst
+++ b/examples/extensions/deployers/dev/development_deploy.rst
@@ -1,9 +1,10 @@
-Conan agnostic relocatable development deploys
-==============================================
+.. _examples_extensions_builtin_deployers_relocatable:
+
+
+Conan independent relocatable development deploys
+=================================================
 
 With the ``full_deploy`` deployer it is possible to create a Conan-agnostic copy of dependencies that can be used by developers without even having Conan installed in their computers.
-
-As the generators like ``CMakeDeps`` and ``CMakeToolchain`` are able to generate files with relative paths to the binaries that have been copied by ``full_deploy`` to the user folder.
 
 Let's see it with an example. All the source code is in the
 `examples2.0 Github repository <https://github.com/conan-io/examples2>`_ 
@@ -46,7 +47,8 @@ This will create the following folders:
 
     ├──src
     ├──build
-    │   ├──generators 
+    │   ├──generators
+    |         └── ZLibConfig.cmake  
     ├──full_deploy
     │   ├──build
     │   │   └──cmake
@@ -67,13 +69,13 @@ This will create the following folders:
     │                       ├──lib
 
 
-This folder is fully self contained, it contains both the necessary tools (like ``cmake`` executable), the headers and compiled libraries of ``zlib`` and the necessary files like ``ZLibConfig.cmake`` in the ``build/generators`` folder, that point to the binaries inside ``full_deploy``, with a relative path. 
+This folder is fully self contained, it contains both the necessary tools (like ``cmake`` executable), the headers and compiled libraries of ``zlib`` and the necessary files like ``ZLibConfig.cmake`` in the ``build/generators`` folder, that point to the binaries inside ``full_deploy`` with a relative path. 
 
 The Conan cache can be removed, and even Conan uninstalled, then the folder could be moved elsewhere in the computer or copied to another computer, assuming it has the same configuration of OS, compiler, etc.
 
 .. code-block:: bash
 
-    $ cd .. 
+    $ cd ..
     $ cp -R relocatable_deploy /some/other/place
     $ cd /some/other/place
 

--- a/examples/extensions/deployers/dev/local_developer_deploy.rst
+++ b/examples/extensions/deployers/dev/local_developer_deploy.rst
@@ -1,0 +1,132 @@
+Conan agnostic relocatable development deploys
+==============================================
+
+With the ``full_deploy`` deployer it is possible to create a Conan-agnostic copy of dependencies that can be used by developers without even having Conan installed in their computers.
+
+As the generators like ``CMakeDeps`` and ``CMakeToolchain`` are able to generate files with relative paths to the binaries that have been copied by ``full_deploy`` to the user folder.
+
+Let's see it with an example. All the source code is in the
+`examples2.0 Github repository <https://github.com/conan-io/examples2>`_ 
+
+.. code-block:: bash
+
+    $ git clone https://github.com/conan-io/examples2.git
+    $ cd examples2/examples/extensions/deployers/relocatable_deploy
+
+In the folder we can find the following ``conanfile.txt``:
+
+.. code-block:: ini
+
+    [requires]
+    zlib/1.2.13
+
+    [tool_requires]
+    cmake/3.25.3
+
+    [generators]
+    CMakeDeps
+    CMakeToolchain
+
+    [layout]
+    cmake_layout
+
+The folder also contains a standard ``CMakeLists.txt`` and a ``main.cpp`` source file that can create
+an executable that links with ``zlib`` library.
+
+We can install the Debug and Release dependencies, and deploy a local copy of the packages with:
+
+.. code-block:: bash
+
+    $ conan install . --deploy=full_deploy --build=missing
+    $ conan install . --deploy=full_deploy -s build_type=Debug --build=missing
+
+This will create the following folders:
+
+.. code-block:: text
+
+    ├──src
+    ├──build
+    │   ├──generators 
+    ├──full_deploy
+    │   ├──build
+    │   │   └──cmake
+    │   │       └──3.25.3
+    │   │           └──x86_64
+    │   │               ├──bin
+    │   │
+    │   └──host
+    │       └──zlib
+    │           └──1.2.13
+    │               ├──Debug
+    │               │   └──x86_64
+    │               │       ├──include
+    │               │       ├──lib
+    │               └──Release
+    │                   └──x86_64
+    │                       ├──include
+    │                       ├──lib
+
+
+This folder is fully self contained, it contains both the necessary tools (like ``cmake`` executable), the headers and compiled libraries of ``zlib`` and the necessary files like ``ZLibConfig.cmake`` in the ``build/generators`` folder, that point to the binaries inside ``full_deploy``, with a relative path. 
+
+The Conan cache can be removed, and even Conan uninstalled, then the folder could be moved elsewhere in the computer or copied to another computer, assuming it has the same configuration of OS, compiler, etc.
+
+.. code-block:: bash
+
+    $ cd .. 
+    $ cp -R relocatable_deploy /some/other/place
+    $ cd /some/other/place
+
+And the files could be used by developers as:
+
+.. code-block:: bash
+    :caption: Windows
+
+    $ cd build
+    # Activate the environment to use CMake 3.25
+    $ generators\conanbuild.bat
+    $ cmake --version
+    cmake version 3.25.3
+    # Configure, should match the settings used at install
+    $ cmake .. -G \"Visual Studio 17 2022\" -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake
+    $ cmake --build . --config Release
+    $ Release\compressor.exe
+    ZLIB VERSION: 1.2.13
+
+
+The environment scripts in Linux and OSX are not relocatable, because they contain absolute paths and the ``sh`` shell `does not have any way to provide access to the current script directory for sourced files <https://stackoverflow.com/questions/29832037/how-to-get-script-directory-in-posix-sh/29835459#29835459>`_.
+
+This shouldn't be a big blocker, as a "search and replace" with `sed` in the generators folder can fix it:
+
+.. code-block:: bash
+    :caption: Linux
+
+    $ cd build/Release/generators
+    # Fix folders in Linux
+    $ sed -i 's,{old_folder},{new_folder},g' *
+    # Fix folders in MacOS
+    $ sed -i '' 's,{old_folder},{new_folder},g' *
+    $ source conanbuild.sh
+    $ cd ..
+    $ cmake --version
+    cmake version 3.25.3
+    $ cmake ../.. -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+    $ cmake --build .
+    $ ./compressor
+    ZLIB VERSION: 1.2.13
+
+
+.. note::
+
+    **Best practices**
+
+    The fact that this flow is possible doesn't mean that it is recommended for majority of cases.
+    It has some limitations:
+
+    - It is less efficient, requiring an extra copy of dependencies
+    - Only ``CMakeDeps`` and ``CMakeToolchain`` are relocatable at this moment. For other build system integrations, please create a ticket in Github
+    - Linux and OSX shell scripts are not relocatable and require a manual ``sed``
+    - The binary variability is limited to Release/Debug. The generated files are exclusively for the current configuration, changing any other setting (os, compiler, architecture) will require a different deploy
+
+    In the general case, normal usage of the cache is recommended. This "relocatable development deployment"
+    could be useful for distributing final products that looks like an SDK, to consumers of a project not using Conan.

--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -257,7 +257,7 @@ There are 2 built-in deployers:
 
 Some generators might have the capability of redefining the target "package folder". That means that if some other
 generator like ``CMakeDeps`` is used that is pointing to the packages, it will be pointing to the local deployed
-copy, and not to the original packages in the Conan cache.
+copy, and not to the original packages in the Conan cache. See the full example in :ref:`examples_extensions_builtin_deployers_relocatable`.
 
 It is also possible, and it is a powerful extension point, to write custom user deployers.
 Read more about custom deployers in :ref:`reference_extensions_deployers`.

--- a/reference/extensions/deployers.rst
+++ b/reference/extensions/deployers.rst
@@ -37,6 +37,7 @@ Then every dependency will end up in a folder such as:
 
 ``[OUTPUT_FOLDER]/full_deploy/host/dep/0.1/Release/x86_64``
 
+See a full example of the usage of ``full_deploy`` deployer in :ref:`examples_extensions_builtin_deployers_relocatable`.
 
 .. _reference_extensions_deployer_direct_deploy:
 


### PR DESCRIPTION
I think a better naming for the feature would be needed.

Current text in PR: **Conan independent relocatable development deploys**

Some better ideas?
- Creating Conan independent SDKs
- ?