### PR TITLE
v2 migration fix dead links + reference new blog post

### DIFF
--- a/migrating_to_2.0/commands.rst
+++ b/migrating_to_2.0/commands.rst
@@ -5,6 +5,7 @@ Commands
 There is no "compatible with 2.X" commands introduced in Conan 1.X.
 You will need to adapt to the new commands once you migrate to Conan 2.0
 
+For a comparison of 1.x and 2.0 commands see the `Conan 2.0 Cheat Sheet Blog Post <https://blog.conan.io/2023/06/07/New-Cheat-Sheet-For-Conan-2.html>`_.
 
 Changes to expect
 -----------------
@@ -72,9 +73,6 @@ The ``conan search`` will search, by default, in all the remotes (not in the loc
         zlib/1.2.8
 
 If you want to explore the local cache there is a command ``conan list recipes <pattern>``.
-
-
-.. _conan_v2_remote_login:
 
 conan remote login
 ^^^^^^^^^^^^^^^^^^
@@ -158,7 +156,7 @@ server-side, copying packages from one server repository to another repository.
 Removed "conan user"
 ^^^^^^^^^^^^^^^^^^^^
 
-This has been replaced with :ref:<conan_v2_remote_login>
+This has been replaced with the `remote login command <https://docs.conan.io/2/reference/commands/remote.html#conan-remote-login>`_
 
 Removed "conan config set"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,4 +168,4 @@ Custom commands
 ---------------
 
 You can build custom commands on top of the Conan Python API.
-WIP documentation.
+Refer to the `Conan 2.0 documenttion for custom commands <https://docs.conan.io/2/reference/extensions/custom_commands.html>`_.

--- a/migrating_to_2.0/commands.rst
+++ b/migrating_to_2.0/commands.rst
@@ -3,9 +3,10 @@ Commands
 ========
 
 There is no "compatible with 2.X" commands introduced in Conan 1.X.
-You will need to adapt to the new commands once you migrate to Conan 2.0
+You will need to adapt to the new commands once you migrate to Conan 2.0.
 
-For a comparison of 1.x and 2.0 commands see the `Conan 2.0 Cheat Sheet Blog Post <https://blog.conan.io/2023/06/07/New-Cheat-Sheet-For-Conan-2.html>`_.
+For a comparison of some 1.x versus 2.0 commands, see the
+`Conan 2.0 Cheat Sheet Blog Post <https://blog.conan.io/2023/06/07/New-Cheat-Sheet-For-Conan-2.html>`_.
 
 Changes to expect
 -----------------
@@ -156,7 +157,7 @@ server-side, copying packages from one server repository to another repository.
 Removed "conan user"
 ^^^^^^^^^^^^^^^^^^^^
 
-This has been replaced with the `remote login command <https://docs.conan.io/2/reference/commands/remote.html#conan-remote-login>`_
+This has been replaced with the `remote login command <https://docs.conan.io/2/reference/commands/remote.html#conan-remote-login>`_ in 2.0.
 
 Removed "conan config set"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -168,4 +169,4 @@ Custom commands
 ---------------
 
 You can build custom commands on top of the Conan Python API.
-Refer to the `Conan 2.0 documenttion for custom commands <https://docs.conan.io/2/reference/extensions/custom_commands.html>`_.
+Refer to the `Conan 2.0 documentation for custom commands <https://docs.conan.io/2/reference/extensions/custom_commands.html>`_.


### PR DESCRIPTION
I noticed there was a dead link trying to help someone 

![image](https://github.com/conan-io/docs/assets/16867443/2d551967-b37e-4e97-b72e-7cd16c727285)


I also put in some links for the "WIP documentation" and linked the blog post since that covered more commands and has extra information.