### PR TITLE
Update extend_own_cmake_presets.rst to specify correct directory

### DIFF
--- a/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets.rst
+++ b/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets.rst
@@ -14,7 +14,7 @@ Please, first of all, clone the sources to recreate this project. You can find t
 .. code-block:: bash
 
     $ git clone https://github.com/conan-io/examples2.git
-    $ cd examples2/examples/tools/cmake/cmake_toolchain/local_flow_cmake_presets
+    $ cd examples2/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets
 
 Please open the `conanfile.py` and check how it sets ``tc.user_presets_path =
 'ConanPresets.json'``. By modifying this attribute of `CMakeToolchain`, you can change the


### PR DESCRIPTION
The link to the sources for this part pointed to the `local_flow_cmake_presets` directory which isn't the correct one here.