### PR TITLE
cmake: Add mentioning of tools.cmake:install strip

### DIFF
--- a/reference/tools/cmake/cmake.rst
+++ b/reference/tools/cmake/cmake.rst
@@ -64,3 +64,5 @@ The ``CMake()`` build helper is affected by these ``[conf]`` variables:
   ``MSBuild``
 
 - ``tools.cmake:cmake_program`` specify the location of the CMake executable, instead of using the one found in the ``PATH``.
+
+- ``tools.cmake:install_strip`` will pass ``--strip`` to the ``cmake --install`` call if set to ``True``.


### PR DESCRIPTION
I noticed there was no mentioning of this configuration in the docs. This commit fixes that.

Implemented on https://github.com/conan-io/conan/commit/cc02d498c456f0fe6c90eb88494047357b537540