### PR TITLE
Update attributes.rst

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -267,7 +267,7 @@ attribute:
             "compiler": {"Visual Studio": {"version": [11, 12]}},
             "arch": None}
 
-In this example we have just defined that this package only works in Windows, with VS 10 and 11.
+In this example we have just defined that this package only works in Windows, with VS 11 and 12.
 Any attempt to build it in other platforms with other settings will throw an error saying so.
 We have also defined that the runtime (the MD and MT flags of VS) is irrelevant for us
 (maybe we using a universal one?). Using None as a value means, *maintain the original values* in order


### PR DESCRIPTION
Update the English explanation to match the python example.

The python code block example (on line 267) shows the following:
`"compiler": {"Visual Studio": {"version": [11, 12]}},`

However the explanation of this code says:
> In this example we have just defined that this package only works in Windows, with VS 10 and 11.

Notice the version numbers do not match from the code example to the explanation. 
This proposed change will update the explanation to match the code example more closely. 
Alternatively we could update the code example to update the explanation.

Please let me know if there are any other changes I should make here to improve the documentation quality. 