### PR TITLE
Added tutorial instructions for Powershell users

### DIFF
--- a/reference/tools/env/virtualbuildenv.rst
+++ b/reference/tools/env/virtualbuildenv.rst
@@ -3,7 +3,7 @@
 VirtualBuildEnv
 ===============
 
-VirtualBuildEnv is a generator that produces a *conanbuildenv* .bat or .sh script containing the environment variables
+VirtualBuildEnv is a generator that produces a *conanbuildenv* .bat, .ps1 or .sh script containing the environment variables
 of the build time context:
 
     - From the ``self.buildenv_info`` of the direct ``tool_requires`` in "build" context.
@@ -49,19 +49,23 @@ Generated files
 This generator (for example the invocation of ``conan install --tool-require=cmake/3.20.0@ -g VirtualBuildEnv``)
 will create the following files:
 
-- conanbuildenv-release-x86_64.(bat|sh): This file contains the actual definition of environment variables
+- conanbuildenv-release-x86_64.(bat|ps1|sh): This file contains the actual definition of environment variables
   like PATH, LD_LIBRARY_PATH, etc, and any other variable defined in the dependencies ``buildenv_info``
   corresponding to the ``build`` context, and to the current installed
   configuration. If a repeated call is done with other settings, a different file will be created.
   After the execution or sourcing of this file, a new deactivation script will be generated, capturing the current
   environment, so the environment can be restored when desired. The file will be named also following the
   current active configuration, like ``deactivate_conanbuildenv-release-x86_64.bat``.
-- conanbuild.(bat|sh): Accumulates the calls to one or more other scripts, in case there are multiple tools
+- conanbuild.(bat|ps1|sh): Accumulates the calls to one or more other scripts, in case there are multiple tools
   in the generate process that create files, to give one single convenient file for all. This only calls
   the latest specific configuration one, that is, if ``conan install`` is called first for Release build type,
-  and then for Debug, ``conanbuild.(bat|sh)`` script will call the Debug one.
-- deactivate_conanbuild.(bat|sh): Accumulates the deactivation calls defined in the above ``conanbuild.(bat|sh)``.
+  and then for Debug, ``conanbuild.(bat|ps1|sh)`` script will call the Debug one.
+- deactivate_conanbuild.(bat|ps1|sh): Accumulates the deactivation calls defined in the above ``conanbuild.(bat|ps1|sh)``.
   This file should only be called after the accumulated activate has been called first.
+
+.. note::
+
+    To create ``.ps1`` files it is necessary to use the conf: ``tools.env.virtualenv:Powershell``.
 
 
 Reference

--- a/reference/tools/env/virtualbuildenv.rst
+++ b/reference/tools/env/virtualbuildenv.rst
@@ -65,8 +65,7 @@ will create the following files:
 
 .. note::
 
-    To create ``.ps1`` files it is necessary to use the conf: ``tools.env.virtualenv:Powershell``.
-
+    To create ``.ps1`` files required for Powershell it is necessary to set to True the following conf: ``tools.env.virtualenv:powershell``.
 
 Reference
 ---------

--- a/reference/tools/env/virtualrunenv.rst
+++ b/reference/tools/env/virtualrunenv.rst
@@ -61,7 +61,7 @@ current active configuration, like ``deactivate_conanrunenv-release-x86_64.bat``
 
 .. note::
 
-    To create ``.ps1`` files it is necessary to use the conf: ``tools.env.virtualenv:Powershell``.
+    To create ``.ps1`` files required for Powershell it is necessary to set to True the following conf: ``tools.env.virtualenv:powershell``.
 
 Reference
 ---------

--- a/reference/tools/env/virtualrunenv.rst
+++ b/reference/tools/env/virtualrunenv.rst
@@ -3,7 +3,7 @@
 VirtualRunEnv
 =============
 
-``VirtualRunEnv`` is a generator that produces a launcher *conanrunenv* .bat or .sh script containing environment variables
+``VirtualRunEnv`` is a generator that produces a launcher *conanrunenv* .bat, .ps1 or .sh script containing environment variables
 of the run time environment.
 
 The launcher contains the runtime environment information, anything that is necessary in the environment to actually run
@@ -48,17 +48,20 @@ And it can also be fully instantiated in the conanfile ``generate()`` method:
 Generated files
 ---------------
 
-- conanrunenv-release-x86_64.(bat|sh): This file contains the actual definition of environment variables
+- conanrunenv-release-x86_64.(bat|ps1|sh): This file contains the actual definition of environment variables
   like PATH, LD_LIBRARY_PATH, etc, and ``runenv_info`` of dependencies corresponding to the ``host`` context,
   and to the current installed configuration. If a repeated call is done with other settings, a different file will be created.
-- conanrun.(bat|sh): Accumulates the calls to one or more other scripts to give one single convenient file
+- conanrun.(bat|ps1|sh): Accumulates the calls to one or more other scripts to give one single convenient file
   for all. This only calls the latest specific configuration one, that is, if ``conan install`` is called first for Release build type,
-  and then for Debug, ``conanrun.(bat|sh)`` script will call the Debug one.
+  and then for Debug, ``conanrun.(bat|ps1|sh)`` script will call the Debug one.
 
 After the execution of one of those files, a new deactivation script will be generated, capturing the current
 environment, so the environment can be restored when desired. The file will be named also following the
 current active configuration, like ``deactivate_conanrunenv-release-x86_64.bat``.
 
+.. note::
+
+    To create ``.ps1`` files it is necessary to use the conf: ``tools.env.virtualenv:Powershell``.
 
 Reference
 ---------

--- a/tutorial/consuming_packages/different_configurations.rst
+++ b/tutorial/consuming_packages/different_configurations.rst
@@ -45,6 +45,19 @@ folder:
 
     # The default profile can also be checked with the command "conan profile show"
 
+.. note::
+
+    **Using Powershell**
+
+    For Powershell users it is recommended to modify the profile so it is no longer needed to use the
+    ``--conf=tools.env.virtualenv:powershell=True`` command. Open your profile file an add:
+
+    .. code-block:: bash
+
+        [conf]
+        tools.env.virtualenv:powershell=True
+
+    This only modifies the chosen profile and further profiles created will require the same change.
 
 As you can see, the profile has different sections. The ``[settings]`` section is the one
 that has information about things like the operating system, architecture, compiler, and

--- a/tutorial/consuming_packages/different_configurations.rst
+++ b/tutorial/consuming_packages/different_configurations.rst
@@ -45,19 +45,6 @@ folder:
 
     # The default profile can also be checked with the command "conan profile show"
 
-.. note::
-
-    **Using Powershell**
-
-    For Powershell users it is recommended to modify the profile so it is no longer needed to use the
-    ``--conf=tools.env.virtualenv:powershell=True`` command. Open your profile file an add:
-
-    .. code-block:: bash
-
-        [conf]
-        tools.env.virtualenv:powershell=True
-
-    This only modifies the chosen profile and further profiles created will require the same change.
 
 As you can see, the profile has different sections. The ``[settings]`` section is the one
 that has information about things like the operating system, architecture, compiler, and

--- a/tutorial/consuming_packages/use_tools_as_conan_packages.rst
+++ b/tutorial/consuming_packages/use_tools_as_conan_packages.rst
@@ -89,23 +89,17 @@ files the folder *build*. To do that, just run:
 
 .. note::
 
-    **Using Powershell**
-
-    When using a Powershell terminal we need a different configuration to generate the corresponding files.
-    Adding :command:`--conf=tools.env.virtualenv:powershell=True` to the previous :command:`conan install` command
-    will generate ``.ps1`` files that you can run instead of the ``.bat`` files.
-
-    We recommend changing the profile so you don't need to run the command every time. Run :command:`conan config home`
-    to find your conan cache location, then edit the file in **.conan2/profiles/default** by adding:
+    **Powershell** users need to add ``--conf=tools.env.virtualenv:powershell=True`` to the previous command
+    to generate ``.ps1`` files instead of ``.bat`` files.
+    We recommend modifying the profile so you don't need to run the command every time.
+    Add to the profile used:
 
     .. code-block:: bash
 
         [conf]
         tools.env.virtualenv:powershell=True
 
-    Note that this only modifies the chosen profile and further profiles created will require the same change.
-    Check the :ref:`profiles page<reference_config_files_profiles>`
-    for more information.
+    For more information on how to set your profile check the :ref:`profiles page<reference_config_files_profiles>`.
 
 You can check the output:
 

--- a/tutorial/consuming_packages/use_tools_as_conan_packages.rst
+++ b/tutorial/consuming_packages/use_tools_as_conan_packages.rst
@@ -92,8 +92,18 @@ files the folder *build*. To do that, just run:
     **Using Powershell**
 
     When using a Powershell terminal we need a different configuration to generate the corresponding files.
-    Adding ``--conf=tools.env.virtualenv:powershell=True`` to the previous conan install command
+    Adding :command:`--conf=tools.env.virtualenv:powershell=True` to the previous :command:`conan install` command
     will generate ``.ps1`` files that you can run instead of the ``.bat`` files.
+
+    We recommend changing the profile so you don't need to run the command every time. Run :command:`conan config home`
+    to find your conan cache location, then edit the file in **.conan2/profiles/default** by adding:
+
+    .. code-block:: bash
+
+        [conf]
+        tools.env.virtualenv:powershell=True
+
+    Note that this only modifies the chosen profile and further profiles created will require the same change.
 
 You can check the output:
 

--- a/tutorial/consuming_packages/use_tools_as_conan_packages.rst
+++ b/tutorial/consuming_packages/use_tools_as_conan_packages.rst
@@ -91,15 +91,7 @@ files the folder *build*. To do that, just run:
 
     **Powershell** users need to add ``--conf=tools.env.virtualenv:powershell=True`` to the previous command
     to generate ``.ps1`` files instead of ``.bat`` files.
-    We recommend modifying the profile so you don't need to run the command every time.
-    Add to the profile used:
-
-    .. code-block:: bash
-
-        [conf]
-        tools.env.virtualenv:powershell=True
-
-    For more information on how to set your profile check the :ref:`profiles page<reference_config_files_profiles>`.
+    To avoid the need to add this line every time, we recommend configuring it in the ``[conf]`` section of your profile. For detailed information, please refer to the :ref:`profiles section<reference_config_files_profiles>`.
 
 You can check the output:
 

--- a/tutorial/consuming_packages/use_tools_as_conan_packages.rst
+++ b/tutorial/consuming_packages/use_tools_as_conan_packages.rst
@@ -87,6 +87,14 @@ files the folder *build*. To do that, just run:
 
     $ conan install . --output-folder=build --build=missing
 
+.. note::
+
+    **Using Powershell**
+
+    When using a Powershell terminal we need a different configuration to generate the corresponding files.
+    Adding ``--conf=tools.env.virtualenv:powershell=True`` to the previous conan install command
+    will generate ``.ps1`` files that you can run instead of the ``.bat`` files.
+
 You can check the output:
 
 .. code-block:: bash
@@ -142,6 +150,7 @@ have installed the new CMake version in the path.
 
     $ cd build
     $ conanbuild.bat
+    # conanbuild.ps1 if using Powershell
 
 .. code-block:: bash
     :caption: Linux, macOS

--- a/tutorial/consuming_packages/use_tools_as_conan_packages.rst
+++ b/tutorial/consuming_packages/use_tools_as_conan_packages.rst
@@ -104,6 +104,8 @@ files the folder *build*. To do that, just run:
         tools.env.virtualenv:powershell=True
 
     Note that this only modifies the chosen profile and further profiles created will require the same change.
+    Check the :ref:`profiles page<reference_config_files_profiles>`
+    for more information.
 
 You can check the output:
 


### PR DESCRIPTION
Added notes to help Powershell users in the beginning of the tutorial:
- The first time the conan virtual env is used, there's a note so powershell users can create the correct conanbuild file and run it.
- When the profile is introduced there's a note so users can add the powershell conf.


Possible alternatives: 
- Modifying the profile directly on the [first page](https://docs.conan.io/2/tutorial/consuming_packages/build_simple_cmake_project.html), adding another note after it talks about changing the compiler in the profile.
- Reducing the explanation around Powershell and including just some comments in the code blocks.

Let me know what you think and which solution fits best :)