### PR TITLE
Update Python version policy

### DIFF
--- a/introduction.rst
+++ b/introduction.rst
@@ -93,7 +93,7 @@ There are some things that are not included in this commitment:
 - Other tools and repositories outside of the Conan client
 
 
-Conan needs Python>=3.6 to run. Conan will deprecate support for Python versions 1 year after those versions have been declared End Of Life (EOL).
+Conan needs Python>=3.7 to run. Conan will deprecate support for Python versions 1 year after those versions have been declared End Of Life (EOL).
 
 If you have any question regarding Conan updates, stability, or any clarification about this definition of stability, please report in the documentation issue tracker: https://github.com/conan-io/docs.
 


### PR DESCRIPTION
version policy states: `Conan will deprecate support for Python versions 1 year after those versions have been declared End Of Life (EOL).`
Python 3.6 EOL data is 2021-12-23 (see [PEP 494](https://peps.python.org/pep-0494/)).
so this is already more than one year since Python 3.6 EOL, policy should now mentioned Python 3.7.