### PR TITLE
Add note about settings.os requirement for VirtualRunEnv

### DIFF
--- a/reference/tools/env/virtualrunenv.rst
+++ b/reference/tools/env/virtualrunenv.rst
@@ -10,13 +10,9 @@ The launcher contains the runtime environment information, anything that is nece
 the compiled executables and applications. The information is obtained from:
 
     - The ``self.runenv_info`` of the dependencies corresponding to the ``host`` context.
-    - Also automatically deduced from the ``self.cpp_info`` definition of the package, to define ``PATH``,
-      ``LD_LIBRARY_PATH``, ``DYLD_LIBRARY_PATH`` and ``DYLD_FRAMEWORK_PATH`` environment variables.
-
-.. note::
-
-    ``PATH`` is always set, but ``LD_LIBRARY_PATH``, ``DYLD_LIBRARY_PATH``, and ``DYLD_FRAMEWORK_PATH`` require the
-    ``os`` setting and are only set for non-Windows hosts.
+    - Also automatically deduced from the ``self.cpp_info`` definition of the package to define ``PATH``.
+    - ``LD_LIBRARY_PATH``, ``DYLD_LIBRARY_PATH``, and ``DYLD_FRAMEWORK_PATH`` are similarly deduced on
+      non-Windows hosts if the ``os`` setting is set.
 
 It can be used by name in conanfiles:
 

--- a/reference/tools/env/virtualrunenv.rst
+++ b/reference/tools/env/virtualrunenv.rst
@@ -13,6 +13,11 @@ the compiled executables and applications. The information is obtained from:
     - Also automatically deduced from the ``self.cpp_info`` definition of the package, to define ``PATH``,
       ``LD_LIBRARY_PATH``, ``DYLD_LIBRARY_PATH`` and ``DYLD_FRAMEWORK_PATH`` environment variables.
 
+.. note::
+
+    ``PATH`` is always set, but ``LD_LIBRARY_PATH``, ``DYLD_LIBRARY_PATH``, and ``DYLD_FRAMEWORK_PATH`` require the
+    ``os`` setting and are only set for non-Windows hosts.
+
 It can be used by name in conanfiles:
 
 .. code-block:: python


### PR DESCRIPTION
This commit adds a short note that settings.os must be set properly for LD_LIBRARY_PATH etc. to appear.