### PR TITLE
Update creating_backup_sources_repo.rst

### DIFF
--- a/devops/backup_sources/repositories/artifactory/creating_backup_sources_repo.rst
+++ b/devops/backup_sources/repositories/artifactory/creating_backup_sources_repo.rst
@@ -14,7 +14,7 @@ The URL of the remote should now be added to the :ref:`global.conf<reference_con
 .. code-block:: text
    :caption: global.conf
 
-   core.sources:upload_url="https://myteam.myorg.com/artifactory/backup-sources/"
+   core.sources:upload_url=https://myteam.myorg.com/artifactory/backup-sources/
 
 
 Next, as we want this to be a public read repo, we'll allow anonymous read access to our repo.


### PR DESCRIPTION
remove double quotation mark, which cause fail to upload source.
```
Uploading file '93a91544e3d88f3bc4c405bad3dbc916ba951cdaadd5fcec1139af6fa56e6bfc.json' to backup sources server                                                                                                                                                               WARN: network: No connection adapters were found for '"https://xxx/artifactory/xxx/"/93a91544e3d88f3bc4c405bad3dbc916ba951cdaadd5fcec1139af6fa56e6bfc.json'                                                                          Waiting 5 seconds to retry...                                                                                                                                                                                                                                                 ERROR: No connection adapters were found for '"https://xxx/artifactory/xxx/"/93a91544e3d88f3bc4c405bad3dbc916ba951cdaadd5fcec1139af6fa56e6bfc.json'
```