### PR TITLE
Clarify deploy() docs

### DIFF
--- a/reference/conanfile/methods/deploy.rst
+++ b/reference/conanfile/methods/deploy.rst
@@ -5,7 +5,11 @@ deploy()
 
 .. include:: ../../../common/experimental_warning.inc
 
-The ``deploy()`` method is intended to deploy (copy) artifacts from the current package
+The ``deploy()`` method is intended to deploy (copy) artifacts from the current package.
+It only executes at ``conan install`` time, when the ``--deployer-package`` argument is provided, otherwise ``deploy()`` is ignored.
+
+Artifacts should be deployed to the ``self.deploy_folder``, by default the current folder. A custom destination can be defined with ``--deployer-folder``.
+A basic ``deploy()`` method would copy all files from the package folder to the deploy folder:
 
 .. code-block:: python
 
@@ -18,17 +22,12 @@ The ``deploy()`` method is intended to deploy (copy) artifacts from the current 
             copy(self, "*", src=self.package_folder, dst=self.deploy_folder)
 
 
-The ``deploy()`` method only executes at ``conan install`` time, when the ``--deployer-package`` argument is provided, otherwise it is completely ignored.
-
-Artifacts will be copied to the output folder called ``self.deploy_folder``, by default it is the current folder, but the ``--deployer-folder`` can define a custom folder destinaton too.
-
-
-See the documentation of the :ref:`conan install command<reference_commands_install_generators_deployers>` for mor information.
+Refer to the documentation of the :ref:`conan install command<reference_commands_install_generators_deployers>` for more information.
 
 .. note::
 
     **Best practices**
 
-    - Only "binary" package artifacts can be deployed, copying from the ``self.package_folder``. It is not recommended to try to copy only from the package folder, not other folders.
-    - The ``deploy()`` method is intended for final, production deployment or installation of binaries in the machine, extracting them out of Conan. It is not intended for normal development operations, nor to build Conan packages against deployed binaries. The recommendation is to build against packages in the Conan cache.
-    - The ``self.deploy_folder`` should only be used from the ``deploy()`` method, not any other method should use it.
+    - Only "binary" package artifacts can be deployed, copying from the ``self.package_folder``. It is recommended to copy only from the package folder, not other folders.
+    - The ``deploy()`` method is intended for final production deployments or the installation of binaries on the machine, as it extracts the files from the Conan cache. It is not intended for normal development operations, nor to build Conan packages against deployed binaries. The recommendation is to build against packages in the Conan cache.
+    - The ``self.deploy_folder`` should only be used from within the ``deploy()`` method.


### PR DESCRIPTION
- the deploy method does nothing by default
- the example is denoted as an example and not the default implementation
- a few typos
- order of sentences and example