### PR TITLE
Document conan.tools.build.cppstd_flag

### DIFF
--- a/reference/tools/build.rst
+++ b/reference/tools/build.rst
@@ -88,3 +88,11 @@ conan.tools.build.supported_cppstd()
 .. currentmodule:: conan.tools.build.cppstd
 
 .. autofunction:: supported_cppstd
+
+
+conan.tools.build.cppstd_flag()
+""""""""""""""""""""""""""""""""""""
+
+.. currentmodule:: conan.tools.build.cppstd_flag
+
+.. autofunction:: cppstd_flag

--- a/reference/tools/build.rst
+++ b/reference/tools/build.rst
@@ -93,6 +93,6 @@ conan.tools.build.supported_cppstd()
 conan.tools.build.cppstd_flag()
 """"""""""""""""""""""""""""""""""""
 
-.. currentmodule:: conan.tools.build.cppstd_flag
+.. currentmodule:: conan.tools.build.flags
 
 .. autofunction:: cppstd_flag


### PR DESCRIPTION
The method will be documented by the docustring present in the current PR https://github.com/conan-io/conan/pull/15710

In the current commit https://github.com/conan-io/conan/pull/15710/commits/bfbbd77df37e83346736eff1b0a48ed437c3d88f it shows:

![Screenshot 2024-02-21 at 09-20-30 conan tools build — conan 2 1 0 documentation](https://github.com/conan-io/docs/assets/4870173/89c57d9f-9a5a-4d5d-8ceb-9d6362ed9cfe)
