### PR TITLE
Add subproject_options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Documentation for Conan C/C++ package manager: https://conan.io
 How to build
 ============
 
+- Install host package
+  - graphviz
+  - enchant
+    - Ubuntu: `# apt install graphviz enchant`
+    - Achlinux: `# pacman -Syu graphviz enchant`
+
+
 - Install python and [pip docs](https://pip.pypa.io/en/stable/installing/).
 - Install the requirements (sphinx):
 
@@ -12,9 +19,9 @@ How to build
 
 - Point to the Conan source code folder (``git clone https://github.com/conan-io/conan && cd conan && git checkout develop2``)
 
-  Windows:
+  - Windows:
   `$ set PYTHONPATH=<your/path/to/conan>;%PYTHONPATH%`
-  Linux:
+  - Linux:
   `$ export PYTHONPATH=<your/path/to/conan>:$PYTHONPATH`
 
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,9 @@ Documentation for Conan C/C++ package manager: https://conan.io
 How to build
 ============
 
-- Install host package
-  - graphviz
-  - enchant
-    - Ubuntu: `# apt install graphviz enchant`
-    - Achlinux: `# pacman -Syu graphviz enchant`
-
+- Install prerequisites:
+  - [graphviz](https://graphviz.org/download)
+  - [enchant](https://pyenchant.github.io/pyenchant/install.html)
 
 - Install python and [pip docs](https://pip.pypa.io/en/stable/installing/).
 - Install the requirements (sphinx):

--- a/reference/tools/meson/mesontoolchain.rst
+++ b/reference/tools/meson/mesontoolchain.rst
@@ -151,6 +151,24 @@ The ``wrap_mode: nofallback`` is defined by default as a project option, to make
 
 Note that in this case, Meson might be able to find dependencies in "wraps", it is the responsibility of the user to check the behavior and make sure about the dependencies origin.
 
+subproject_options
+^^^^^^^^^^^^^^^^^^
+
+This attribute allows defining Meson subproject options:
+
+.. code:: python
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.subproject_options["SUBPROJECT"] = [{'MYVAR': 'MyValue'}]
+        tc.generate()
+
+This is translated to:
+
+- One subproject ``SUBPROJECT`` along with options definition for ``MYVAR`` in ``conan_meson_native.ini`` or ``conan_meson_cross.ini`` file.
+
+Note that in contrast to project_options, subproject_options is a dictionary of lists of dictionaries. This is because Meson allows multiple subprojects, and each subproject can have multiple options.
+
 preprocessor_definitions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -209,7 +227,9 @@ values:
     def generate(self):
         tc = MesonToolchain(self) 
         tc.project_options["DYNAMIC"] = bool(self.options.shared)  # shared is bool
-        tc.project_options["GREETINGS"] = str(self.options.with_msg)  # with_msg is str 
+        tc.project_options["GREETINGS"] = str(self.options.with_msg)  # with_msg is str
+        tc.subproject_options["SUBPROJECT"] = [{'MYVAR': str(self.options.with_msg)}]  # with_msg is str
+        tc.subproject_options["SUBPROJECT"].append({'MYVAR': bool(self.options.shared)})  # shared is bool
         tc.generate()
 
 In contrast, directly assigning a Conan option as a Meson value is strongly discouraged:
@@ -223,6 +243,8 @@ In contrast, directly assigning a Conan option as a Meson value is strongly disc
         tc = MesonToolchain(self)
         tc.project_options["DYNAMIC"] = self.options.shared  # == <PackageOption object>
         tc.project_options["GREETINGS"] = self.options.with_msg  # == <PackageOption object>
+        tc.subproject_options["SUBPROJECT"] = [{'MYVAR': self.options.with_msg}]  # == <PackageOption object>
+        tc.subproject_options["SUBPROJECT"].append({'MYVAR': self.options.shared})  # == <PackageOption object>
         tc.generate()
 
 These are not boolean or string values but an internal Conan class representing such

--- a/reference/tools/meson/mesontoolchain.rst
+++ b/reference/tools/meson/mesontoolchain.rst
@@ -165,7 +165,7 @@ This attribute allows defining Meson subproject options:
 
 This is translated to:
 
-- One subproject ``SUBPROJECT`` along with options definition for ``MYVAR`` in ``conan_meson_native.ini`` or ``conan_meson_cross.ini`` file.
+- One subproject ``SUBPROJECT`` and option definition for ``MYVAR`` in the ``conan_meson_native.ini`` or ``conan_meson_cross.ini`` file.
 
 Note that in contrast to project_options, subproject_options is a dictionary of lists of dictionaries. This is because Meson allows multiple subprojects, and each subproject can have multiple options.
 

--- a/reference/tools/meson/mesontoolchain.rst
+++ b/reference/tools/meson/mesontoolchain.rst
@@ -167,7 +167,7 @@ This is translated to:
 
 - One subproject ``SUBPROJECT`` and option definition for ``MYVAR`` in the ``conan_meson_native.ini`` or ``conan_meson_cross.ini`` file.
 
-Note that in contrast to project_options, subproject_options is a dictionary of lists of dictionaries. This is because Meson allows multiple subprojects, and each subproject can have multiple options.
+Note that in contrast to ``project_options``, ``subproject_options`` is a dictionary of lists of dictionaries. This is because Meson allows multiple subprojects, and each subproject can have multiple options.
 
 preprocessor_definitions
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinxcontrib-youtube==1.4.1
 docutils==0.20.1
 jinja2==3.1.3
 watchdog[watchmedo]==2.2.0
+colorama

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ sphinxcontrib-youtube==1.4.1
 docutils==0.20.1
 jinja2==3.1.3
 watchdog[watchmedo]==2.2.0
-colorama


### PR DESCRIPTION
Add documentation for subproject in meson (https://github.com/conan-io/conan/pull/15916)

Add missing requirement in requirements.txt

Add missing information about host package required.

Slip windows and Linux export command on separate line for better readability. 