### PR TITLE
direct_deploy doesn't include version in path

### DIFF
--- a/reference/extensions/deployers.rst
+++ b/reference/extensions/deployers.rst
@@ -48,7 +48,7 @@ direct_deploy
 Same as ``full_deploy``, but only processes your recipe's *direct* dependencies.
 This deployer will output your dependencies in a tree folder such as:
 
-``[OUTPUT_FOLDER]/direct_deploy/dep/0.1``
+``[OUTPUT_FOLDER]/direct_deploy/dep``
 
 .. warning::
 


### PR DESCRIPTION
@memsharded says:
> The direct_deploy is intended to deploy one package, without having to deploy its dependencies. Mostly for convenient extraction of some files inside a given package. So the files won't collide with other package files when deployed. The pkg name has been respected, but it could have been dropped too.

This matches the current implementation which, unlike the full deployer, doesn't use `dep.ref.version`:
https://github.com/conan-io/conan/blob/38188da5d8a3f5b0038934f29d67b8a03e0f3531/conan/internal/deploy.py#L118