### PR TITLE
Add Fish shell as virtualenv

### DIFF
--- a/reference/tools/env/envvars.rst
+++ b/reference/tools/env/envvars.rst
@@ -31,13 +31,16 @@ It will generate automatically a ``my_env_file.bat`` for Windows systems or ``my
 In Windows, it is possible to opt-in to generate Powershell ``.ps1`` scripts instead of ``.bat`` ones, using the
 conf ``tools.env.virtualenv:powershell=True``.
 
+In Macos and Linux, it is possible to opt-in to generate Fish ``.fish`` scripts instead of ``.sh`` ones, using the
+conf ``tools.env.virtualenv:fish=True``.
+
 Also, by default, Conan will automatically append that launcher file path to a list that will be used to
-create a ``conanbuild.bat|sh|ps1`` file aggregating all the launchers in order. The ``conanbuild.sh|bat|ps1`` launcher
+create a ``conanbuild.bat|sh|ps1|fish`` file aggregating all the launchers in order. The ``conanbuild.sh|bat|ps1|fish`` launcher
 will be created after the execution of the ``generate()`` method.
 
 The ``scope`` argument (``"build"`` by default) can be used to define different scope of environment files, to
 aggregate them separately. For example, using a ``scope="run"``, like the ``VirtualRunEnv`` generator does, will
-aggregate and create a ``conanrun.bat|sh|ps1`` script:
+aggregate and create a ``conanrun.bat|sh|ps1|fish`` script:
 
 .. code:: python
 
@@ -45,17 +48,17 @@ aggregate and create a ``conanrun.bat|sh|ps1`` script:
         env1 = Environment()
         env1.define("foo", "var")
         envvars = env1.vars(self, scope="run")
-        # Will append "my_env_file" to "conanrun.bat|sh|ps1"
+        # Will append "my_env_file" to "conanrun.bat|sh|ps1|fish"
         envvars.save_script("my_env_file")
 
 
-You can also use ``scope=None`` argument to avoid appending the script to the aggregated ``conanbuild.bat|sh|ps1``:
+You can also use ``scope=None`` argument to avoid appending the script to the aggregated ``conanbuild.bat|sh|ps1|fish``:
 
 .. code:: python
 
     env1 = Environment()
     env1.define("foo", "var")
-    # Will not append "my_env_file" to "conanbuild.bat|sh|ps1"
+    # Will not append "my_env_file" to "conanbuild.bat|sh|ps1|fish"
     envvars = env1.vars(self, scope=None)
     envvars.save_script("my_env_file")
 
@@ -63,7 +66,7 @@ You can also use ``scope=None`` argument to avoid appending the script to the ag
 Running with environment files
 ++++++++++++++++++++++++++++++
 
-The ``conanbuild.bat|sh|ps1`` launcher will be executed by default before calling every ``self.run()`` command. This
+The ``conanbuild.bat|sh|ps1|fish`` launcher will be executed by default before calling every ``self.run()`` command. This
 would be typically done in the ``build()`` method.
 
 You can change the default launcher with the ``env`` argument of ``self.run()``:
@@ -74,6 +77,7 @@ You can change the default launcher with the ``env`` argument of ``self.run()``:
     def build(self):
         # This will automatically wrap the "foo" command with the correct environment:
         # source my_env_file.sh && foo
+        # source my_env_file.fish and foo
         # my_env_file.bat && foo
         # powershell my_env_file.ps1 ; cmd c/ foo
         self.run("foo", env=["my_env_file"])

--- a/reference/tools/env/virtualbuildenv.rst
+++ b/reference/tools/env/virtualbuildenv.rst
@@ -3,7 +3,7 @@
 VirtualBuildEnv
 ===============
 
-VirtualBuildEnv is a generator that produces a *conanbuildenv* .bat, .ps1 or .sh script containing the environment variables
+VirtualBuildEnv is a generator that produces a *conanbuildenv* .bat, .ps1, fish or .sh script containing the environment variables
 of the build time context:
 
     - From the ``self.buildenv_info`` of the direct ``tool_requires`` in "build" context.
@@ -49,23 +49,29 @@ Generated files
 This generator (for example the invocation of ``conan install --tool-require=cmake/3.20.0@ -g VirtualBuildEnv``)
 will create the following files:
 
-- conanbuildenv-release-x86_64.(bat|ps1|sh): This file contains the actual definition of environment variables
+- conanbuildenv-release-x86_64.(bat|ps1|sh|fish): This file contains the actual definition of environment variables
   like PATH, LD_LIBRARY_PATH, etc, and any other variable defined in the dependencies ``buildenv_info``
   corresponding to the ``build`` context, and to the current installed
   configuration. If a repeated call is done with other settings, a different file will be created.
   After the execution or sourcing of this file, a new deactivation script will be generated, capturing the current
   environment, so the environment can be restored when desired. The file will be named also following the
   current active configuration, like ``deactivate_conanbuildenv-release-x86_64.bat``.
-- conanbuild.(bat|ps1|sh): Accumulates the calls to one or more other scripts, in case there are multiple tools
+- conanbuild.(bat|ps1|sh|fish): Accumulates the calls to one or more other scripts, in case there are multiple tools
   in the generate process that create files, to give one single convenient file for all. This only calls
   the latest specific configuration one, that is, if ``conan install`` is called first for Release build type,
-  and then for Debug, ``conanbuild.(bat|ps1|sh)`` script will call the Debug one.
+  and then for Debug, ``conanbuild.(bat|ps1|sh|fish)`` script will call the Debug one.
 - deactivate_conanbuild.(bat|ps1|sh): Accumulates the deactivation calls defined in the above ``conanbuild.(bat|ps1|sh)``.
   This file should only be called after the accumulated activate has been called first.
 
 .. note::
 
     To create ``.ps1`` files required for Powershell it is necessary to set to True the following conf: ``tools.env.virtualenv:powershell``.
+
+.. note::
+
+    To create ``.fish`` files required for Fish shell it is necessary to set to True the following conf: ``tools.env.virtualenv:fish``.
+
+    When using fish shell, ``deactivate`` files are not generated, instead a function is exported in the environment.
 
 Reference
 ---------

--- a/reference/tools/env/virtualrunenv.rst
+++ b/reference/tools/env/virtualrunenv.rst
@@ -3,7 +3,7 @@
 VirtualRunEnv
 =============
 
-``VirtualRunEnv`` is a generator that produces a launcher *conanrunenv* .bat, .ps1 or .sh script containing environment variables
+``VirtualRunEnv`` is a generator that produces a launcher *conanrunenv* .bat, .ps1, fish or .sh script containing environment variables
 of the run time environment.
 
 The launcher contains the runtime environment information, anything that is necessary in the environment to actually run
@@ -49,12 +49,12 @@ And it can also be fully instantiated in the conanfile ``generate()`` method:
 Generated files
 ---------------
 
-- conanrunenv-release-x86_64.(bat|ps1|sh): This file contains the actual definition of environment variables
+- conanrunenv-release-x86_64.(bat|ps1|sh|fish): This file contains the actual definition of environment variables
   like PATH, LD_LIBRARY_PATH, etc, and ``runenv_info`` of dependencies corresponding to the ``host`` context,
   and to the current installed configuration. If a repeated call is done with other settings, a different file will be created.
-- conanrun.(bat|ps1|sh): Accumulates the calls to one or more other scripts to give one single convenient file
+- conanrun.(bat|ps1|sh|fish): Accumulates the calls to one or more other scripts to give one single convenient file
   for all. This only calls the latest specific configuration one, that is, if ``conan install`` is called first for Release build type,
-  and then for Debug, ``conanrun.(bat|ps1|sh)`` script will call the Debug one.
+  and then for Debug, ``conanrun.(bat|ps1|sh|fish)`` script will call the Debug one.
 
 After the execution of one of those files, a new deactivation script will be generated, capturing the current
 environment, so the environment can be restored when desired. The file will be named also following the
@@ -63,6 +63,12 @@ current active configuration, like ``deactivate_conanrunenv-release-x86_64.bat``
 .. note::
 
     To create ``.ps1`` files required for Powershell it is necessary to set to True the following conf: ``tools.env.virtualenv:powershell``.
+
+.. note::
+
+    To create ``.fish`` files required for Fish shell it is necessary to set to True the following conf: ``tools.env.virtualenv:fish``.
+
+    When using fish shell, ``deactivate`` files are not generated, instead a function is exported in the environment.
 
 Reference
 ---------


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/pull/15503

Add Fish shell as alternative virtualenv. 

I listed only Linux and MacOS support, because in Windows actually needs Cygwin or WSL. Better keeping only well tested environments.

Using Fish as virtualenv will not produce `deactivate_conanbuild.fish`, but will embed the function `deactivate_conanbuildenv` in the terminal, so we don't use extra file.

