### PR TITLE
options patterns clarifications

### DIFF
--- a/reference/commands/graph/explain.rst
+++ b/reference/commands/graph/explain.rst
@@ -36,7 +36,7 @@ In the same way, it can report when a package has a different option value and t
 
 .. code-block:: text
 
-    $conan graph explain --requires=lib/1.0.0 -o shared=True --format=json
+    $conan graph explain --requires=lib/1.0.0 -o lib/*:shared=True --format=json
     ...
     {
         "closest_binaries": {

--- a/reference/config_files/profiles.rst
+++ b/reference/config_files/profiles.rst
@@ -20,7 +20,7 @@ They have this structure:
     os=Macos
 
     [options]
-    MyLib:shared=True
+    mylib/*:shared=True
 
     [tool_requires]
     tool1/0.1@user/channel
@@ -204,8 +204,8 @@ List of options available from your recipe and its dependencies:
     :caption: *myprofile*
 
     [options]
-    my_pkg_option=True
-    shared=True
+    mypkg/*:my_pkg_option=True
+    *:shared=True
 
 
 .. _reference_config_files_profiles_tool_requires:

--- a/tutorial/consuming_packages/different_configurations.rst
+++ b/tutorial/consuming_packages/different_configurations.rst
@@ -173,7 +173,17 @@ using the ``--options`` argument. To do so, please run:
 
 Doing this, Conan will install the *Zlib* shared libraries, generate the files to build with
 them and, also the necessary files to locate those dynamic libraries when running the
-application. Let's build the application again after configuring it to link *Zlib* as a
+application.
+
+.. note::
+
+    Options are defined per-package. In this case we were defining that we wanted that specific
+    version of zlib/1.2.11 as a shared library. If we had other dependencies and we want all of
+    our dependencies (whenever possible) as shared libraries, we would use ``-o *:shared=True``,
+    with the ``*`` pattern that matches all package references.
+
+
+Let's build the application again after configuring it to link *Zlib* as a
 shared library:
 
 .. code-block:: bash


### PR DESCRIPTION
We keep getting reports of users doing `-o shared=True` and expecting the dependencies to be shared, that only applies to the consumer.

I will try to add a warning in the client side too.