### PR TITLE
Remove CPT from Conan 1.x docs

### DIFF
--- a/creating_packages/package_tools.rst
+++ b/creating_packages/package_tools.rst
@@ -19,7 +19,7 @@ following script in the package root folder. Name it *build.py*:
 
     if __name__ == "__main__":
         params = " ".join(sys.argv[1:])
-   
+
         if platform.system() == "Windows":
             system('conan create . demo/testing -s compiler="Visual Studio" -s compiler.version=14 %s' % params)
             system('conan create . demo/testing -s compiler="Visual Studio" -s compiler.version=12 %s' % params)
@@ -32,35 +32,3 @@ This is a pure Python script, not related to Conan, and should be run as such:
 .. code:: bash
 
    $ python build.py
-
-
-Conan Package Tools
--------------------
-
-.. caution::
-
-    According to the project's README, there is no planned support for the upcoming *Conan 2.0 release*.
-
-We have developed another FOSS tool for package creators, the **Conan Package Tools** to help you generate multiple binary packages from a package recipe.
-It offers a simple way to define the different configurations and to call :command:`conan test`.
-In addition to offering CI integration like **Travis CI, Appveyor and Bamboo**, for cloud-based automated
-binary package creation, testing, and uploading.
-
-This tool enables the creation of hundreds of binary packages in the cloud with a simple
-``$ git push`` and supports:
-
-- Easy **generation of multiple Conan packages** with different configurations.
-- Automated/remote package generation in **Travis/Appveyor** server with distributed builds in CI
-  jobs for big/slow builds.
-- **Docker**: Automatic generation of packages for several versions of ``gcc`` and ``clang`` in
-  Linux, and in Travis CI.
-- Automatic creation of OSX packages with apple-clang, and in Travis-CI.
-- **Visual Studio**: Automatic configuration of the command line environment with detected settings.
-
-It's available in pypi:
-
-.. code-block:: bash
-
-    $ pip install conan_package_tools 
-
-For more information, read the README.md in the `Conan Package Tools repository <https://github.com/conan-io/conan-package-tools>`_.


### PR DESCRIPTION
The Conan Package Tools should be avoided and will be marked as deprecated soon.

Meanwhile, users reading Conan 1.x could have a different understanding about the project, because it's listed in the official Conan documentation and shows how to use.

This PR removes all mentions of CPT from Conan 1.x documentation. The Conan 2.x does not have any reference already. 