### PR TITLE
Fix global config zlib example pattern

### DIFF
--- a/reference/config_files/global_conf.rst
+++ b/reference/config_files/global_conf.rst
@@ -243,7 +243,7 @@ You can use package patterns to apply the configuration in those dependencies wh
 .. code-block:: text
 
     *:tools.cmake.cmaketoolchain:generator=Ninja
-    zlib:tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019
+    zlib/*:tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019
 
 This example shows you how to specify a general `generator` for all your packages, but for `zlib` one. `zlib` is defining
 `Visual Studio 16 2019` as its own generator.
@@ -253,7 +253,7 @@ configuration lines above:
 
 .. code-block:: text
 
-    zlib:tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019
+    zlib/*:tools.cmake.cmaketoolchain:generator=Visual Studio 16 2019
     *:tools.cmake.cmaketoolchain:generator=Ninja
 
 The result is that you're specifying a general `generator` for all your packages, and that's it. The `zlib` line has no


### PR DESCRIPTION
I am trying to use `Xcode` CMake generator as default, but `Unix Makefiles` CMake generator for zlib package.

The old example config (`zlib:tools.cmake...`) didn't work for me using Conan client 1.64.1 on MacOS. Conan kept using the Xcode generator for build.

I had to use the new example pattern using star sign for the version of the zlib package (`zlib/*:tools.cmake...`).

This the `global.conf` that works for me:

```
tools.cmake.cmaketoolchain:generator=Xcode
zlib/*:tools.cmake.cmaketoolchain:generator=Unix Makefiles
```

So I think the documentation should be updated for other users to not have to deal with this issue.

I am using Conan 1 and don't know how this behaves in Conan 2.

I guess it might also be a bug in the Conan client? Not sure...