### PR TITLE
Improve tools scm Version with properties description

### DIFF
--- a/reference/tools/scm/version.rst
+++ b/reference/tools/scm/version.rst
@@ -3,7 +3,94 @@
 Version
 =======
 
-.. currentmodule:: conan.tools.scm
+This is a helper class to work with semantic versions.
+It exposes all the version components as properties and offers total ordering through compare operators.
 
-.. autoclass:: Version
-    :members:
+.. code-block:: python
+   :caption: Comparing versions
+
+    compiler_lower_than_12 = Version(self.settings.compiler.version) < "12.0"
+
+    is_legacy = Version(self.version) < 2
+
+
+.. autoclass:: conan.tools.scm::Version
+
+
+Attributes
+----------
+
+The ``Version`` class offers ways to access the different parts of the version number:
+
+main
+++++
+
+Get all the main digits.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert [str(i) for i in v.main] == ['1', '2', '3', '4', '5']
+
+major
++++++
+
+Get the major digit.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert str(v.major) == "1"
+
+minor
++++++
+
+Get the minor digit.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert str(v.minor) == "2"
+
+
+patch
++++++
+
+Get the patch digit.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert str(v.patch) == "3"
+
+
+micro
++++++
+
+Get the micro digit.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert str(v.micro) == "4"
+
+
+pre
++++
+
+Get the pre-release digit.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert str(v.pre) == "alpha.3"
+
+build
++++++
+
+Get the build digit.
+
+.. code-block:: python
+
+    v = Version("1.2.3.4-alpha.3+b1")
+    assert str(v.build) == "b1"


### PR DESCRIPTION
Hello!

I targeting release 2.3 branch because we actually have it available since Conan 1.x

To understand the current commit:

First I tried to add docustrings directly to conans.models.version (Conan Client), then expose them via `::members::`. Indeed Sphinx was able to expose, but badly formatted:

![Screenshot 2024-05-29 at 12-49-38 Version — conan 2 3 2 documentation](https://github.com/conan-io/docs/assets/4870173/253109fd-ccb8-451d-a736-0c742e03cb95)

The documentation is not very clear how to fix, only says to use commas and all should be good: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-option-automodule-members

It looks be related to documenting properties, because when using with methods (e.g. MSBuild) it formats correctly.

The second point is adding examples of usage for each property, like we have in Conan 1.x docs. Using docustring, it keeps everything in a single when exposing in Sphinx.

closes #3745 

Current view:

![Screenshot 2024-05-29 at 13-18-28 Version — conan 2 3 2 documentation](https://github.com/conan-io/docs/assets/4870173/513cf20c-3305-4adc-87dc-ee776555d0b5)
