### PR TITLE
fix syntax of `conan config install --args` example

### DIFF
--- a/reference/commands/consumer/config.rst
+++ b/reference/commands/consumer/config.rst
@@ -204,7 +204,7 @@ Conan runs it based on *config_install.json*, including the timestamp of the las
 
   .. code-block:: bash
 
-      $ conan config install http://github.com/user/conan_config/.git --args "--recursive"
+      $ conan config install http://github.com/user/conan_config/.git --args="--recursive"
 
   You can also force the git download by using :command:`--type git` (in case it is not deduced from the URL automatically):
 


### PR DESCRIPTION
Passing an argument to "--args" as a separate string generates:

    conan config install: error: argument -a/--args: expected one argument

if the argument looks like a separate option. Which pretty much anything you want to pass to "git clone" will.