### PR TITLE
Colour code like Conan 1 docs, ensure highlight works

### DIFF
--- a/_static/css/conan.css
+++ b/_static/css/conan.css
@@ -25,3 +25,7 @@ h1, h2, .rst-content .toctree-wrapper p.caption, h3, h4, h5, h6, legend {
     text-align: left;
     font-weight: bold;
 }
+
+.highlight .hll {
+    background-color: #bbbbbbbb;
+}

--- a/conf.py
+++ b/conf.py
@@ -143,7 +143,7 @@ exclude_patterns = ['_build', '**/site-packages', 'conan_sources/**.rst']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sas'
+pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
After talking with @memsharded, this colour scheme looks nicer, it's more prominent to the user that they are reading code

![image](https://github.com/conan-io/docs/assets/5364255/74d6bca2-fc4e-4ff0-b5e4-bb756a5c5fc9)

The only thing I'm not completely sold on is the highlight colour. I'm open to suggestions! :)


Also, this will only work for the new 2.5 release. Should we backport this to at least 2.4? 