### PR TITLE
Update artifactory ce for cpp version

### DIFF
--- a/tutorial/conan_repositories/setting_up_conan_remotes/artifactory/artifactory_ce_cpp.rst
+++ b/tutorial/conan_repositories/setting_up_conan_remotes/artifactory/artifactory_ce_cpp.rst
@@ -21,7 +21,7 @@ There are several ways to run Artifactory CE:
 
 .. code-block:: bash
     
-    $ docker run --name artifactory -d -p 8081:8081 -p 8082:8082 releases-docker.jfrog.io/jfrog/artifactory-cpp-ce:7.63.12
+    $ docker run --name artifactory -d -p 8081:8081 -p 8082:8082 releases-docker.jfrog.io/jfrog/artifactory-cpp-ce:7.84.17
 
 * **Download and run from zip file**. The `Download Page <https://conan.io/downloads.html>`_ has
   a link for you to follow. When the file is unzipped, launch Artifactory by double clicking


### PR DESCRIPTION
Coming from this https://docs.conan.io/2/tutorial/conan_repositories/setting_up_conan_remotes/artifactory/artifactory_ce_cpp.html

The artifactory version is a bit outdated, so here is the latest released and working (tested the docker command) version.