### PR TITLE
Fix version mismatch in package_prebuilt_binaries.rst

### DIFF
--- a/tutorial/creating_packages/other_types_of_packages/package_prebuilt_binaries.rst
+++ b/tutorial/creating_packages/other_types_of_packages/package_prebuilt_binaries.rst
@@ -23,7 +23,7 @@ Use the :command:`conan new` command to create a "Hello World" C++ library examp
 
 .. code-block:: bash
 
-    $ conan new cmake_lib -d name=hello -d version=1.0
+    $ conan new cmake_lib -d name=hello -d version=0.1
 
 
 This will create a Conan package project with the following structure.


### PR DESCRIPTION
There was a mismatch between the version provided in the 'conan new ...' command and the rest of the documentation, including the 'conan test ...' command.