### PR TITLE
Document how to preserve PkgConfig data from package method

### DIFF
--- a/reference/tools/gnu/pkgconfig.rst
+++ b/reference/tools/gnu/pkgconfig.rst
@@ -25,8 +25,11 @@ Read a ``pc`` file and access the information:
     print(pkg_config.variables['prefix']) # something like'/usr/local'
 
 
-Use the ``pc`` file information to fill a ``cpp_info`` object:
+Using PkgConfig to fill a ``cpp_info`` object
+---------------------------------------------
 
+The ``PkgConfig`` class can be used to fill a ``CppInfo`` object with the information that will be consumed by ``PkgConfigDeps`` generator later.
+This is a useful feature when packaging a system library that provides a ``.pc`` file, or when a proprietary package has a build system that only outputs ``.pc`` files.
 
 .. code-block:: python
 
@@ -35,6 +38,45 @@ Use the ``pc`` file information to fill a ``cpp_info`` object:
         pkg_config.fill_cpp_info(self.cpp_info, is_system=False, system_libs=["m", "rt"])
 
 
+However, ``PkgConfig`` will invoke the ``pkg-config`` executable to extract the information from the ``.pc`` file.
+The ``pkg-config`` executable must be available in the system path for this case, otherwise, it will fail when installing the consumed package.
+
+
+Using pkg-config from Conan package instead of system
+-----------------------------------------------------
+
+.. include:: ../../../common/experimental_warning.inc
+
+In case not having ``pkg-config`` available in the system, it is possible to use the ``pkg-config`` executable provided by a Conan package:
+
+.. code-block:: python
+
+    import os
+    from conan import ConanFile
+    from conan.tools.gnu import PkgConfig
+    from conan.tools import CppInfo
+
+    class Pkg(ConanFile):
+
+        def tool_requires(self):
+            self.requires("pkgconf/[*]")
+
+        ...
+
+        def package(self):
+            pkg_config = PkgConfig(self, "libastral", pkg_config_path=".")
+            cpp_info = CppInfo(self)
+            pkg_config.fill_cpp_info(cpp_info, is_system=False, system_libs=["m", "rt"])
+            cpp_info.save(os.path.join(self.package_folder, "cpp_info.json"))
+
+        def package_info(self):
+            self.cpp_info = CppInfo(self).load(os.path.join(self.package_folder, "cpp_info.json"))
+
+
+The ``pkg-config`` executable provided by the Conan package ``pkgconf`` will be invoked only when creating the Conan binary package.
+The ``.pc`` information will be extracted from the ``cpp_info.json`` file located in the package folder, it will fill the ``self.cpp_info`` object.
+This way, the ``PkgConfig`` will not need to invoke the ``pkg-config`` executable again to extract the information from the ``.pc`` file,
+when consuming the package.
 
 Reference
 ---------


### PR DESCRIPTION
Hello! 

Originally we have few issues in ConanCenterIndex affected by the scenario where `pkg-config` is not installed installed in the system, so users can not consume those packages that are simple wrappers for system libraries:

- https://github.com/conan-io/conan-center-index/issues/23009
- https://github.com/conan-io/conan-center-index/issues/14909

Indeed I was caught by this error when using a raw docker image to validate a reported bug in Ubuntu 24.04. This is my motivation for writing this PR.

As possible alternative (experimental), we can run `PkgConfig` from `package()` and store its data in a json file, then, restore that information in `self.cpp_info`. This workaround was commented by Memsharded 1 year ago: https://github.com/conan-io/conan/issues/14422#issuecomment-1665166761

This scenario is tested already in Conan client, but not well explored, still, is working in minimal case: https://github.com/conan-io/conan/blob/c55ab23d01f1336c850816e07c68ae19704201d6/test/functional/toolchains/gnu/test_pkg_config.py#L99

Related to https://github.com/conan-io/conan/issues/14422.

Current preview (commit c6c8f72):

![Screenshot 2024-08-13 at 12-15-11 PkgConfig — conan 2 6 0 documentation](https://github.com/user-attachments/assets/5ae872e9-37fd-4c55-98b3-8856d8546735)
