### PR TITLE
Fix version range syntax in conanfile_txt.rst

### DIFF
--- a/reference/conanfile_txt.rst
+++ b/reference/conanfile_txt.rst
@@ -28,7 +28,7 @@ This section supports references with version-ranges too:
 .. code-block:: text
 
     [requires]
-    poco/[>1.0,<1.9]
+    poco/[>1.0 <1.9]
     zlib/1.2.11
 
 And specific recipe revisions can be pinned too:


### PR DESCRIPTION
I used this page as reference for version ranges, it took me a while to realize it is the only page in the documentation using a comma instead of a space to define a version range. I looked for `,<` in the documentation and this seems to be the only location with the wrong syntax.