### PR TITLE
Conan 1.x: Add runtime_version v144 to clang compiler

### DIFF
--- a/reference/config_files/settings.yml.rst
+++ b/reference/config_files/settings.yml.rst
@@ -125,7 +125,7 @@ are possible. These are the **default** values, but it is possible to customize 
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
             runtime: [None, MD, MT, MTd, MDd, static, dynamic]
             runtime_type: [None, Debug, Release]
-            runtime_version: [None, v140, v141, v142, v143]
+            runtime_version: [None, v140, v141, v142, v143, v144]
         apple-clang: &apple_clang
             version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1",
                       "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14", "14.0", "15", "15.0"]


### PR DESCRIPTION
Docs for https://github.com/conan-io/conan/pull/16932