### PR TITLE
Update Android Studio documentation

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -48,6 +48,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.graphviz',
     'sphinx.ext.todo',
+    'sphinx_tabs.tabs',
     'sphinxcontrib.jquery',
     'sphinxcontrib.youtube',
     'autocommand',

--- a/examples/cross_build/android/android_studio.rst
+++ b/examples/cross_build/android/android_studio.rst
@@ -208,7 +208,7 @@ If we focus on the ``conan install`` task we can see:
             [conf]
             tools.android:ndk_path=/opt/homebrew/share/android-ndk
 
-         .. code-tab:: text Conan Packed NDK
+         .. code-tab:: text Conan NDK package
 
             include(default)
             

--- a/reference/conanfile/methods/finalize.rst
+++ b/reference/conanfile/methods/finalize.rst
@@ -63,7 +63,7 @@ This info is also serialized as part of the graph information in :command:`conan
 
 As this method must have a 1 to 1 correspondence to the generated package id,
 access to ``self.settings``, ``self.options`` and ``self.cpp_info`` is forbidden inside the ``finalize()`` method, 
-and _must_ be done thru the ``self.info`` attribute.
+and **must** be done thru the ``self.info`` attribute.
 
 .. note::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ sphinx==7.2.6
 sphinx-sitemap==2.5.1
 sphinxcontrib-spelling==8.0.0
 sphinx-notfound-page==1.0.0
+sphinx-tabs==3.4.5
 sphinxcontrib-jquery==4.1
 sphinxcontrib-youtube==1.4.1
 docutils==0.20.1


### PR DESCRIPTION
Newer versions of Android Studio, by default select `kotlin` as the `Build configuration language`.

This PR introduces a new sphinex plugin which supports code tabs, used to display both configurations:
- Groovy 
- Kotlin
