### PR TITLE
[cookies] Enable/Disable banner in localhost

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,7 +2,7 @@
 
 {%- block extrahead %}
 
-{% if enable_cookies is true %}
+{% if enable_cookies %}
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -19,7 +19,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% endblock %}
 
 {% block footer %}
-{% if enable_cookies is true %}
+{% if enable_cookies %}
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WK44ZFM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% endif %}
 

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,7 +2,7 @@
 
 {%- block extrahead %}
 
-{% if enable_cookies %}
+{% if enable_cookies is true %}
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -19,7 +19,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% endblock %}
 
 {% block footer %}
-{% if enable_cookies %}
+{% if enable_cookies is true %}
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WK44ZFM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% endif %}
 

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,13 +2,15 @@
 
 {%- block extrahead %}
 
- <!-- Google Tag Manager -->
+{% if enable_cookies is true %}
+<!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-WK44ZFM');</script>
 <!-- End Google Tag Manager -->
+{% endif %}
 {{ super() }}
 
 
@@ -17,9 +19,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% endblock %}
 
 {% block footer %}
-
+{% if enable_cookies is true %}
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WK44ZFM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-
+{% endif %}
 
 {{ super() }}
 {% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -90,7 +90,8 @@ html_context = {
     "github_user": "conan-io", # Username
     "github_repo": "docs", # Repo name
     "github_version": "develop2", # Version
-    "conf_py_path": "/" # Path in the checkout to the docs root
+    "conf_py_path": "/", # Path in the checkout to the docs root
+    "enable_cookies": True  # enable cookies banner
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -430,7 +431,6 @@ notfound_pagename = 'Page Not Found'
 
 # Graphviz output format, one of png, svg
 graphviz_output_format = 'svg'
-
 
 # copy legacy redirects
 def copy_legacy_redirects(app, docname): # Sphinx expects two arguments

--- a/conf.py
+++ b/conf.py
@@ -58,9 +58,9 @@ extensions = [
 add_module_names = False
 autoclass_content = 'both'
 autodoc_member_order = 'bysource'  # To order the methods following the order at the code, not alphabetically
-autodoc_mock_imports = ["PyJWT", "requests", "urllib3", "PyYAML", 
+autodoc_mock_imports = ["PyJWT", "requests", "urllib3", "PyYAML",
                         "patch-ng", "fasteners", "six", "node-semver", "distro",
-                        "pygments", "tqdm", "Jinja2", "MarkupSafe", "Jinja2", 
+                        "pygments", "tqdm", "Jinja2", "MarkupSafe", "Jinja2",
                         "python-dateutil", "configparse", "patch_ng", "yaml", "semver", "dateutil"]
 
 
@@ -91,7 +91,7 @@ html_context = {
     "github_repo": "docs", # Repo name
     "github_version": "develop2", # Version
     "conf_py_path": "/", # Path in the checkout to the docs root
-    "enable_cookies": True  # enable cookies banner
+    "enable_cookies": os.getenv("ENABLE_COOKIES_BANNER", True)  # enable cookies banner
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Changelog: Feature: Use the env variable `ENABLE_COOKIES_BANNER=false` to disable the cookies banner locally.
Close: https://github.com/conan-io/docs/issues/3844
