### PR TITLE
fix preset name used

### DIFF
--- a/examples/tools/cmake/cmake_toolchain/build_project_cmake_presets.rst
+++ b/examples/tools/cmake/cmake_toolchain/build_project_cmake_presets.rst
@@ -50,7 +50,7 @@ If you are using a multi-configuration generator:
 
 .. code:: bash
 
-    $ cmake --preset conan-default
+    $ cmake --preset conan-debug
     $ cmake --build --preset conan-debug
     $ build\Debug\foo.exe
     foo/1.0: Hello World Release!


### PR DESCRIPTION
After following the example I think it should be `conan-debug` here.