### PR TITLE
Emphasize correct line in tutorial

### DIFF
--- a/tutorial/consuming_packages/different_configurations.rst
+++ b/tutorial/consuming_packages/different_configurations.rst
@@ -129,7 +129,7 @@ built in *Debug* configuration:
 
 .. code-block:: bash
     :caption: Windows
-    :emphasize-lines: 8
+    :emphasize-lines: 9
 
     # assuming Visual Studio 15 2017 is your VS version and that it matches your default profile
     $ cd build
@@ -143,7 +143,7 @@ built in *Debug* configuration:
 
 .. code-block:: bash
     :caption: Linux, macOS
-    :emphasize-lines: 7
+    :emphasize-lines: 8
     
     $ cd build
     $ cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
It should emphasize the next line with the Debug message not the version one.

![image](https://github.com/user-attachments/assets/01b383c6-e6c6-426a-990f-8c84ff3533a9)
