### PR TITLE
Force conan1 deprecation banner to be in top position

### DIFF
--- a/_themes/conan_theme/layout.html
+++ b/_themes/conan_theme/layout.html
@@ -203,7 +203,7 @@
         {%- else %}
         <div class="rst-content">
         {%- endif %}
-          <div class="admonition warning wy-text-center" style="position:sticky;top:0;background: #fcfcfc;padding: inherit" id="conan-banners">
+          <div class="admonition warning wy-text-center" style="position:sticky;top:0;background: #fcfcfc;padding: inherit;z-index:1" id="conan-banners">
             {% if current_version.startswith("1") %}
             <div style="border: 2px solid #eb8484;background-color: #ffcaca;padding: 3px;margin-bottom: 5px">
               <p>This document is for a <b>"1.X" legacy</b> Conan version, <b>which is no longer recommended</b>. Please update to Conan 2, <a href="https://docs.conan.io/2/">click here to read the <b>Conan 2</b> documentation</a></p>


### PR DESCRIPTION
This aim to fix:

![image](https://github.com/user-attachments/assets/263ed8e6-14e7-4f04-9b1b-7c35e4781d2f)

Live fixed:

![image](https://github.com/user-attachments/assets/506ffa81-e0d5-49b9-89eb-09735dd7c925)
