### PR TITLE
Add information about global cpp_info not forwarding build information to components

### DIFF
--- a/examples/conanfile/package_info/components.rst
+++ b/examples/conanfile/package_info/components.rst
@@ -116,6 +116,10 @@ There are a couple of relevant things:
   tutorial we will set the component target names just with the component names omitting
   the ``::``.
 
+- When ``cpp_info`` has global build information (e.g. ``cpp_info.defines``), it does not inherit
+  to the components. If you want to share this information with the components, you need to set it
+  explicitly for each component.
+
 You can have a look at the consumer part by checking the *test_package* folder. First the
 *conanfile.py*:
 


### PR DESCRIPTION
Hello!

In case the package info has a global build information, the same is not passed to components: 

```python
def package_info(self):
    self.cpp_info.defines = ["FOOBAR"]
    self.cpp_info.components["qux"].libs = ["qux"]
```

It would need to move that `defines` to qux component instead. This information is not present in the documentation (or I did not find at least). This PR adds this information to the example of the components to clarify this rule.