### PR TITLE
Mention `ConanFile.conf` validity

### DIFF
--- a/reference/conanfile/attributes.rst
+++ b/reference/conanfile/attributes.rst
@@ -87,6 +87,10 @@ The profile entries have priority.
     The ``conf`` attribute is a **read-only** attribute. It can only be defined in profiles and command lines, but it should never be set by recipes.
     Recipes can only read its value via ``self.conf.get()`` method.
 
+.. note::
+
+    Accessing the ``conf`` attribute is allowed during the ``generate()``, ``build()`` and ``package()`` methods only.
+
 
 Output
 ------


### PR DESCRIPTION
This addresses comments from @memsharded in https://github.com/conan-io/conan/issues/18008 about which methods are allowed to rely on the data in `ConanFile.conf`.

I just added a quick note, but it would be great to discuss some more helpful suggestions for people who need these configuration values elsewhere in their recipe.