### PR TITLE
Document post_build_fail hook

### DIFF
--- a/reference/extensions/hooks.rst
+++ b/reference/extensions/hooks.rst
@@ -117,6 +117,9 @@ Here you can see a complete example of all the hook functions available:
     def post_build(conanfile):
         conanfile.output.info("Running after of executing build() method.")
 
+    def post_build_fail(conanfile):
+        conanfile.output.info("Running after failed execution of build() method.")
+
     def pre_package(conanfile):
         conanfile.output.info("Running before to execute package() method.")
 


### PR DESCRIPTION
This hook came up in https://github.com/conan-io/conan/issues/18165, and I noticed that it has not yet been documented.