### PR TITLE
AutotoolsToolchain: Add note about the new conf tools.gnu:configure_args 

### DIFF
--- a/reference/tools/gnu/autotoolstoolchain.rst
+++ b/reference/tools/gnu/autotoolstoolchain.rst
@@ -236,7 +236,7 @@ For instance:
             })
             at.generate()
 
-The ``AutotoolsToolchain`` will listen to ``tools.gnu:configure_args`` from the :ref:`reference_config_files_global_conf` to extend the
+The ``AutotoolsToolchain`` will listen to ``tools.gnu:extra_configure_args`` from the :ref:`reference_config_files_global_conf` to extend the
 ``configure_args`` attribute.
 
 Reference

--- a/reference/tools/gnu/autotoolstoolchain.rst
+++ b/reference/tools/gnu/autotoolstoolchain.rst
@@ -236,6 +236,8 @@ For instance:
             })
             at.generate()
 
+The ``AutotoolsToolchain`` will listen to ``tools.gnu:configure_args`` from the :ref:`reference_config_files_global_conf` to extend the
+``configure_args`` attribute.
 
 Reference
 ---------

--- a/reference/tools/gnu/autotoolstoolchain.rst
+++ b/reference/tools/gnu/autotoolstoolchain.rst
@@ -236,6 +236,9 @@ For instance:
             })
             at.generate()
 
+The ``AutotoolsToolchain`` will listen to ``tools.gnu:extra_configure_args`` from the
+:ref:`reference_config_files_global_conf` to extend the ``configure_args`` attribute.
+
 
 Reference
 ---------

--- a/reference/tools/gnu/autotoolstoolchain.rst
+++ b/reference/tools/gnu/autotoolstoolchain.rst
@@ -236,6 +236,7 @@ For instance:
             })
             at.generate()
 
+
 Reference
 ---------
 

--- a/reference/tools/gnu/autotoolstoolchain.rst
+++ b/reference/tools/gnu/autotoolstoolchain.rst
@@ -236,9 +236,6 @@ For instance:
             })
             at.generate()
 
-The ``AutotoolsToolchain`` will listen to ``tools.gnu:extra_configure_args`` from the :ref:`reference_config_files_global_conf` to extend the
-``configure_args`` attribute.
-
 Reference
 ---------
 
@@ -269,6 +266,7 @@ conf
 - ``tools.build:compiler_executables`` dict-like Python object which specifies the
   compiler as key and the compiler executable path as value. Those keys will be mapped as
   follows:
+- ``tools.gnu:extra_configure_args`` list of arguments to extend the ``configure_args`` attribute of ``AutotoolsToolchain``.
 
   * ``c``: will set ``CC`` (and ``CC_FOR_BUILD`` if cross-building) in *conanautotoolstoolchain.sh|bat* script.
   * ``cpp``: will set ``CXX`` (and ``CXX_FOR_BUILD`` if cross-building) in *conanautotoolstoolchain.sh|bat* script.


### PR DESCRIPTION
Hello! This PR is related to https://github.com/conan-io/conan/pull/18333

I just added a note to illustrate that configure arguments can be extended via Conan conf. 

Page preview - Commit ae275a4e

![Screenshot 2025-05-23 at 09-45-01 AutotoolsToolchain — conan 2 16 1 documentation](https://github.com/user-attachments/assets/f9deaa81-3c5a-4039-98e5-15e2f734e840)
