### PR TITLE
Document config tools.build:install_strip

### DIFF
--- a/reference/tools/cmake/cmake.rst
+++ b/reference/tools/cmake/cmake.rst
@@ -6,7 +6,7 @@ CMake
 The ``CMake`` build helper is a wrapper around the command line invocation of cmake. It will abstract the
 calls like ``cmake --build . --config Release`` into Python method calls. It will also add the argument
 ``-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake`` (from the generator ``CMakeToolchain``) to the ``configure()`` call,
-as well as other possible arguments like ``-DCMAKE_BUILD_TYPE=<config>``. The arguments that will be used are obtained from a 
+as well as other possible arguments like ``-DCMAKE_BUILD_TYPE=<config>``. The arguments that will be used are obtained from a
 generated ``CMakePresets.json`` file.
 
 The helper is intended to be used in the ``build()`` method, to call CMake commands automatically
@@ -65,4 +65,4 @@ The ``CMake()`` build helper is affected by these ``[conf]`` variables:
 
 - ``tools.cmake:cmake_program`` specify the location of the CMake executable, instead of using the one found in the ``PATH``.
 
-- ``tools.cmake:install_strip`` will pass ``--strip`` to the ``cmake --install`` call if set to ``True``.
+- ``tools.build:install_strip`` will pass ``--strip`` to the ``cmake --install`` call if set to ``True``.

--- a/reference/tools/cmake/cmake.rst
+++ b/reference/tools/cmake/cmake.rst
@@ -65,4 +65,6 @@ The ``CMake()`` build helper is affected by these ``[conf]`` variables:
 
 - ``tools.cmake:cmake_program`` specify the location of the CMake executable, instead of using the one found in the ``PATH``.
 
-- ``tools.build:install_strip`` will pass ``--strip`` to the ``cmake --install`` call if set to ``True``. This configuration replaces the deprecated ``tools.cmake:install_strip``.
+- ``tools.cmake:install_strip`` (**deprecated** use ``tools.build:install_strip``) will pass ``--strip`` to the ``cmake --install`` call if set to ``True``.
+
+- ``tools.build:install_strip`` (Since Conan 2.18.0) will pass ``--strip`` to the ``cmake --install`` call if set to ``True``.

--- a/reference/tools/cmake/cmake.rst
+++ b/reference/tools/cmake/cmake.rst
@@ -65,4 +65,4 @@ The ``CMake()`` build helper is affected by these ``[conf]`` variables:
 
 - ``tools.cmake:cmake_program`` specify the location of the CMake executable, instead of using the one found in the ``PATH``.
 
-- ``tools.build:install_strip`` will pass ``--strip`` to the ``cmake --install`` call if set to ``True``.
+- ``tools.build:install_strip`` will pass ``--strip`` to the ``cmake --install`` call if set to ``True``. This configuration replaces the deprecated ``tools.cmake:install_strip``.

--- a/reference/tools/meson/meson.rst
+++ b/reference/tools/meson/meson.rst
@@ -46,4 +46,4 @@ The ``Meson`` build helper is affected by these ``[conf]`` variables:
 
 - ``tools.build:verbosity`` which accepts one of ``quiet`` or ``verbose`` and sets the ``--quiet`` flag in ``Meson.install()``
 
-- ``tools.build:install_strip`` will pass ``--strip`` to the ``meson install`` call if set to ``True``.
+- ``tools.build:install_strip`` (Since Conan 2.18.0) will pass ``--strip`` to the ``meson install`` call if set to ``True``.

--- a/reference/tools/meson/meson.rst
+++ b/reference/tools/meson/meson.rst
@@ -45,3 +45,5 @@ The ``Meson`` build helper is affected by these ``[conf]`` variables:
 - ``tools.compilation:verbosity`` which accepts one of ``quiet`` or ``verbose`` and sets the ``--verbose`` flag in ``Meson.build()``
 
 - ``tools.build:verbosity`` which accepts one of ``quiet`` or ``verbose`` and sets the ``--quiet`` flag in ``Meson.install()``
+
+- ``tools.build:install_strip`` will pass ``--strip`` to the ``meson install`` call if set to ``True``.


### PR DESCRIPTION
Hello! 

This PR is related to https://github.com/conan-io/conan/pull/18429.

It replaces `tools.cmake:install_strip` by `tools.build:install_strip`, and add the configuration reference in Meson too.