### PR TITLE
Use apply_conandata_patches in source for patching

### DIFF
--- a/reference/tools/files/patches.rst
+++ b/reference/tools/files/patches.rst
@@ -37,7 +37,7 @@ Usage:
 
     from conan.tools.files import apply_conandata_patches
 
-    def build(self):
+    def source(self):
         apply_conandata_patches(self)
 
 


### PR DESCRIPTION
Hello!

The `apply_conandata_patches` is used in `source()`, and mostly the documentation points there too:

- https://docs.conan.io/2/examples/tools/files/patches/patch_sources.html#patching-using-apply-conandata-patches-tool
- https://docs.conan.io/2/reference/conanfile/methods/export_sources.html#export-sources