### PR TITLE
Clarify that `self.generator_info` is None by default

### DIFF
--- a/reference/conanfile/attributes/consumers.inc
+++ b/reference/conanfile/attributes/consumers.inc
@@ -102,7 +102,7 @@ generator_info
 .. include:: ../../common/experimental_warning.inc
 
 Generators to be passed to the dependant recipes.
-Should be only filled in the ``package_info()`` method.
+Should be only filled in the ``package_info()`` method, ``None`` by default.
 
 .. seealso::
 

--- a/reference/conanfile/methods/package_info.rst
+++ b/reference/conanfile/methods/package_info.rst
@@ -306,7 +306,7 @@ generator_info
 
 
 ``tool_requires`` in the build context can inject generators into the recipe,
-by adding them to the ``generator_info`` list inside the ``package_info`` method.
+by adding them to the ``generator_info`` attribute inside the ``package_info`` method.
 This is useful to inject custom generators into the recipe, that will be used by the consumers of the package,
 just as if they were declared in their ``generators`` attribute.
 
@@ -320,9 +320,10 @@ just as if they were declared in their ``generators`` attribute.
             self.output.info(f"Calling custom generator for {conanfile}")
 
     def package_info(self):
-        self.generator_info.append(MyGenerator)
+        self.generator_info = [MyGenerator]
 
-Note that this only propagates from the immediate, direct ``tool_requires`` of a recipe.
+Note that this only propagates from the immediate, direct ``tool_requires`` of a recipe,
+and that by default ``self.generator_info`` is ``None``.
 
 
 .. note::

--- a/reference/extensions/custom_generators.rst
+++ b/reference/extensions/custom_generators.rst
@@ -110,7 +110,8 @@ Generators from tool_requires
 A direct dependency tool requires can also be used to provide custom generators.
 The following example shows how to create a custom generator that generates a file with the
 dependencies of the package, just like the example above, but using a ``tool_require`` instead of a ``python_require``
-to inject the generator into the recipe, by adding them to the ``self.generator_info`` list inside the ``package_info`` method.
+to inject the generator into the recipe, by adding them to the ``self.generator_info`` attribute inside the ``package_info`` method.
+Note that this attribute is ``None`` by default, so you need to set it explicitly to a list of generators.
 
 .. code-block:: python
     :caption: mygenerator/conanfile.py
@@ -140,7 +141,7 @@ inject the generator into the recipe.
 
 .. note::
 
-    Note that built-in generators can also be injected using tool_requires,
-    by adding them by name: ``self.generator_info.append("CMakeDeps")``.
+    Built-in generators can also be injected using tool_requires,
+    by adding them by name: ``self.generator_info = ["CMakeDeps"]``.
     ``tool_require``ing this package will inject the ``CMakeDeps`` generator into the recipe
     just as if it was declared in its ``generators`` attribute.

--- a/reference/tools/files/patches.rst
+++ b/reference/tools/files/patches.rst
@@ -37,7 +37,7 @@ Usage:
 
     from conan.tools.files import apply_conandata_patches
 
-    def build(self):
+    def source(self):
         apply_conandata_patches(self)
 
 


### PR DESCRIPTION
After https://github.com/conan-io/conan/issues/18499, we've decided to document one of the reported bugs: `self.generator_info` is explicitly None by default, and it has to be given a list value manually