### PR TITLE
Add sbom and lockfile references to audit list

### DIFF
--- a/reference/commands/audit.rst
+++ b/reference/commands/audit.rst
@@ -13,25 +13,26 @@ See :ref:`the audit devops page<devops_audit>` to see examples on how to use the
 
 
 conan audit scan
-================
+^^^^^^^^^^^^^^^^
 
 .. autocommand::
     :command: conan audit scan -h
 
-The ``conan audit scan`` checks for vulnerabilities in the given references and their transitive dependencies.
+The ``conan audit scan`` command checks for vulnerabilities in the given references and their transitive dependencies.
 This command receives configuration arguments such as profiles and settings, to control the expansion of the graph.
 
 conan audit list
-================
+^^^^^^^^^^^^^^^^
 
 .. autocommand::
     :command: conan audit list -h
 
 The ``conan audit list`` command lists vulnerabilities for the given references, without checking their transitive dependencies.
-You can pass a single reference, or a pkglist file with multiple references.
+You can pass a single reference, a pkglist file with multiple references,
+a cyclonedx SBOM file generated with the :ref:`conan.tools.sbom <conan_tools_sbom>` module, or a Conan lockfile.
 
 conan audit provider
-====================
+^^^^^^^^^^^^^^^^^^^^
 
 .. autocommand::
     :command: conan audit provider -h
@@ -42,6 +43,7 @@ By default the ``conan audit`` subcommands use the ConanCenter provider, but you
 For now, besides the default ConanCenter provider, only private JFrog Security providers are supported, see :ref:`the audit devops page<devops_audit_private_providers>` for more information.
 
 There are 3 subcommands:
+
 - ``conan audit provider auth``: Authenticates a provider with a token.
 - ``conan audit provider add``: Adds a provider to the list.
 - ``conan audit provider remove``: Removes a provider from the list.


### PR DESCRIPTION
For https://github.com/conan-io/conan/pull/18437/files

Also fixes the audit commands being leaked into the toc