### PR TITLE
Fix CMake macro packaged in a dependency example

### DIFF
--- a/examples/graph/requires/consume_cmake_macro.rst
+++ b/examples/graph/requires/consume_cmake_macro.rst
@@ -48,7 +48,7 @@ recipes, for example this application:
     
     class App(ConanFile):
         package_type = "application"
-        generators = "CMakeToolchain"
+        generators = "CMakeToolchain", "CMakeDeps"
         settings = "os", "compiler", "arch", "build_type"
         requires = "pkg/0.1"
 


### PR DESCRIPTION
The app needs CMakeDeps to work, otherwise it won't find the macro.