### PR TITLE
Fix architecture mapping at Apt documentation

### DIFF
--- a/reference/tools/system/package_manager.rst
+++ b/reference/tools/system/package_manager.rst
@@ -171,13 +171,13 @@ The default mapping that Conan uses for *APT* packages architecture is:
 
 ..  code-block:: python
 
-      self._arch_names = {"x86_64": "x86_64",
-                          "x86": "i?86",
+      self._arch_names = {"x86_64": "amd64",
+                          "x86": "i386",
                           "ppc32": "powerpc",
-                          "ppc64le": "ppc64le",
-                          "armv7": "armv7",
-                          "armv7hf": "armv7hl",
-                          "armv8": "aarch64",
+                          "ppc64le": "ppc64el",
+                          "armv7": "arm",
+                          "armv7hf": "armhf",
+                          "armv8": "arm64",
                           "s390x": "s390x"} if arch_names is None else arch_names
 
 .. _conan_tools_system_package_manager_yum:


### PR DESCRIPTION
Just copy the mapping from [`package_manager.py`](https://github.com/conan-io/conan/blob/fdc7bfa41a183ebe015ea03460077959ab62ae16/conan/tools/system/package_manager.py#L235-L242).