### PR TITLE
Order api docs by name so they are easier to find

### DIFF
--- a/reference/extensions/python_api.rst
+++ b/reference/extensions/python_api.rst
@@ -13,16 +13,16 @@ Python API
    :maxdepth: 2
 
    python_api/ConanAPI
-   python_api/RemotesAPI
-   python_api/SearchAPI
-   python_api/ListAPI
-   python_api/ProfilesAPI
-   python_api/InstallAPI
-   python_api/GraphAPI
-   python_api/ExportAPI
-   python_api/RemoveAPI
-   python_api/ConfigAPI
-   python_api/NewAPI
-   python_api/UploadAPI
-   python_api/DownloadAPI
    python_api/CommandAPI
+   python_api/ConfigAPI
+   python_api/DownloadAPI
+   python_api/ExportAPI
+   python_api/GraphAPI
+   python_api/InstallAPI
+   python_api/ListAPI
+   python_api/NewAPI
+   python_api/ProfilesAPI
+   python_api/RemotesAPI
+   python_api/RemoveAPI
+   python_api/SearchAPI
+   python_api/UploadAPI


### PR DESCRIPTION
Misc PR before other changes. This makes it easier to find the subapi from the docs