### PR TITLE
Add runtime_deploy entry

### DIFF
--- a/reference/commands/install.rst
+++ b/reference/commands/install.rst
@@ -130,7 +130,8 @@ There are 3 built-in deployers:
   dependencies.
 - ``runtime_deploy`` deploys all the shared libraries and the executables of the
   dependencies (like ``.so``, ``.dll``, or ``.dylib`` files) into a flat directory
-  structure. The symbolic links of libraries are copied by default and they can be managed through the boolean
+  structure, preserving subdirectories as-is.
+  The symbolic links of libraries are copied by default and they can be managed through the boolean
   configuration ``tools.deployer:symlinks``. (Available since Conan 2.5.0)
 
 Some generators might have the capability of redefining the target "package folder". That means that if some other

--- a/reference/extensions/deployers.rst
+++ b/reference/extensions/deployers.rst
@@ -22,6 +22,12 @@ Use the ``--deployer-folder`` argument to change the base folder output path for
 Built-in deployers
 ------------------
 
+.. warning::
+
+  The built-in deployers are in **preview**.
+  See :ref:`the Conan stability<stability>` section for more information.
+
+
 .. _reference_extensions_deployer_full_deploy:
 
 full_deploy
@@ -50,18 +56,28 @@ This deployer will output your dependencies in a tree folder such as:
 
 ``[OUTPUT_FOLDER]/direct_deploy/dep``
 
-.. warning::
+.. _reference_extensions_deployer_runtime_deploy:
 
-  The built-in deployers are in **preview**.
-  See :ref:`the Conan stability<stability>` section for more information.
+runtime_deploy
+^^^^^^^^^^^^^^
+
+New since `Conan 2.5.0 <https://github.com/conan-io/conan/releases/tag/2.5.0>`__
+
+Copies all shared libraries and executables from dependencies (such as .so, .dll, or .dylib files)
+into a flattened directory structure. Library symbolic links are copied by default, with behavior
+controllable via the ``tools.deployer:symlinks`` boolean setting.
+
+Since Conan 2.20.0, subdirectories are maintained and preserved as-is.
+Files are only included in environment generators when correctly specified through ``cpp_info.bindirs``
+and ``cpp_info.libdirs`` configuration.
 
 
 configuration
 ^^^^^^^^^^^^^
 
-Both the ``full_deploy`` and the ``direct_deploy`` understand when the conf ``tools.deployer:symlinks`` is set to ``False``
-to disable deployers copying symlinks. This can be convenient in systems that do not support symlinks and could fail
-if deploying packages that contain symlinks.
+Both the ``full_deploy``, ``direct_deploy`` and ``runtime_deploy`` understand when the conf ``tools.deployer:symlinks``
+is set to ``False`` to disable deployers copying symlinks. This can be convenient in systems that do not support
+symlinks and could fail if deploying packages that contain symlinks.
 
 
 Custom deployers


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/pull/17848

- Add a new entry for `runtime_deploy` in the deployers page.
- Update install reference about preserving subfolders.
- Moved the warning message from deployers to the top, so it will be more visible.