### PR TITLE
clarifying usage of --build-require

### DIFF
--- a/examples/cross_build/toolchain_packages.rst
+++ b/examples/cross_build/toolchain_packages.rst
@@ -447,11 +447,22 @@ Having detailed the toolchain recipe, it's time to proceed with package creation
     ...
 
 
-We employ two profiles for the *build* and *host* contexts, but the most important
-detail is the use of the `--build-require` argument. This informs Conan that the package
-is intended as a build requirement, situating it within the build context. Consequently,
-`settings` match those from the build profile, while `settings_target` aligns with the
-host profile's settings.
+.. important::
+    
+    Use ``--build-require`` argument.
+
+    The ``conan create`` command by default creates packages for the "host" context, using
+    the "host" profile. But if the package we are created is intended to be used as a tool,
+    that is, as a ``tool_requires``, then it needs to be built for the "build" context.
+    The ``--build-require`` argument specifies this. When this argument is provided, the 
+    current recipe binary will be built to run in the "build" context, using the ``default``
+    profile, and it will receive the ``raspberry-64`` "host" profile settings as ``settings_target``.
+    Because the ``arm-toolchain/13.2`` package is a package which executables run in the
+    current "build" machine, not in the RaspberryPI, but it is a tool that targets the RaspberryPI.
+
+    The ``--build-require`` argument is necessary to build the ``arm-toolchain`` package correctly
+    as a build tool.
+
 
 With the toolchain package prepared, we proceed to build an actual application. This will
 be the same application previously cross-compiled in the

--- a/tutorial/creating_packages/other_types_of_packages/tool_requires_packages.rst
+++ b/tutorial/creating_packages/other_types_of_packages/tool_requires_packages.rst
@@ -91,13 +91,30 @@ Let's create a binary package for the ``tool_require``:
 
 .. code-block:: bash
 
-    $ conan create .
+    $ conan create . --build-require
     ...
     secure_scanner/1.0: Calling package()
     secure_scanner/1.0: Copied 1 file: secure_scanner
     secure_scanner/1.0 package(): Packaged 1 file: secure_scanner
     ...
     Security Scanner: The path 'mypath' is secure!
+
+
+.. important::
+    
+    Use ``--build-require`` argument.
+
+    The ``conan create`` command by default creates packages for the "host" context, using
+    the "host" profile. But if the package we are created is intended to be used as a tool,
+    that is, as a ``tool_requires``, then it needs to be built for the "build" context.
+    The ``--build-require`` argument specifies this. When this argument is provided, the 
+    current recipe binary will be built to run in the "build" context.
+    Because the ``secure_scanner/1.0`` package is a package which executables run in the
+    current "build" machine, not necessarily in the final "host" machine, that could be 
+    different to the build one, for example in the case of a cross-build.
+
+    The ``--build-require`` argument is necessary to build the ``secure_scanner`` package correctly
+    as a build tool.
 
 
 Let's review the ``test_package/conanfile.py``:


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/issues/18909

it is a recurring question when the ``--build-require`` argument is missing.