### PR TITLE
docs: add 'conan-docs-l10n' in community_resources

### DIFF
--- a/knowledge/community_resources.rst
+++ b/knowledge/community_resources.rst
@@ -9,3 +9,4 @@ If you have your own resources that you believe could help the community grow,
 don’t hesitate to share them with us on our `GitHub <https://github.com/conan-io/conan>`_.
 
 * `The Conan Cookbook <https://gitlab.com/batteriesincluded/conan-cookbook>`_
+* `Localization of Conan Documentation <https://github.com/localizethedocs/conan-docs-l10n>`_


### PR DESCRIPTION
Added [conan-docs-l10n](https://github.com/localizethedocs/conan-docs-l10n) project link in the community_resources page.

Invited by @memsharded on: https://github.com/conan-io/docs/issues/4228#issuecomment-3294744682