### PR TITLE
Hide Conan 1 versions in dropdown

### DIFF
--- a/_themes/conan_theme/versions.html
+++ b/_themes/conan_theme/versions.html
@@ -13,11 +13,14 @@
         {% endif %}
     {% endfor %}
     <br>
+        <details>
+            <summary>Conan 1 releases</summary>
     {% for the_version, slug in versions.items() %}
         {% if the_version.startswith("en/1.") or the_version.startswith("1") %}
             <dd><a href="/{{ the_version }}/index.html">{{ the_version.replace("en/", "") }}</a></dd>
         {% endif %}
     {% endfor %}
+        </details>
     </dl>
     <dl>
         <dt>{{ _('Downloads') }}</dt>


### PR DESCRIPTION
From https://github.com/conan-io/docs/pull/4248, this should be pushed to master