### PR TITLE
correct syntax for replace_requires system

### DIFF
--- a/reference/config_files/profiles.rst
+++ b/reference/config_files/profiles.rst
@@ -39,7 +39,7 @@ They have this structure:
     zlib/1.2.12: zlib/[*]
 
     [replace_tool_requires]
-    7zip/*: 7zip/system
+    7zip/*: 7zip/*@system
 
     [platform_requires]
     dlib/1.3.22


### PR DESCRIPTION
I may be wrong but I think `7zip/system` is a typo, it appears further in this document that the syntax should be `@system` and that `/system` is not valid