### PR TITLE
Modern in-page search on Conan 2.x docs via Pagefind

### DIFF
--- a/.ci/scripts/generate_documentation.py
+++ b/.ci/scripts/generate_documentation.py
@@ -111,8 +111,31 @@ with chdir(f"{sources_folder}"):
         # run('pip3 install colorama')
 
     # generate html
-    sitemap_opts = " -D html_baseurl=https://docs.conan.io/2/ -D sitemap_url_scheme={link}" if branch_folder.startswith("2") else ""
-    run(f"sphinx-build -W -b html -d {branch_folder}/_build/.doctrees {branch_folder}/ {output_folder}/{branch_folder}{sitemap_opts}")
+    is_v2 = branch_folder.startswith("2")
+    is_latest_v2 = (branch == latest_v2_branch)
+    sitemap_opts = " -D html_baseurl=https://docs.conan.io/2/ -D sitemap_url_scheme={link}" if is_v2 else ""
+    # Every 2.x version gets Pagefind (modern as-you-type search, per-version
+    # index). 1.x (legacy) keeps the classic Sphinx form — rendered by the theme
+    # when use_pagefind is not set. is_latest_v2 toggles the "old version"
+    # warning banner inside the modal for non-latest 2.x builds.
+    pagefind_opts = " -A use_pagefind=1" if is_v2 else ""
+    if is_latest_v2:
+        pagefind_opts += " -A is_latest_v2=1"
+    run(f"sphinx-build -W -b html -d {branch_folder}/_build/.doctrees {branch_folder}/ {output_folder}/{branch_folder}{sitemap_opts}{pagefind_opts}")
+
+    # Build a Pagefind search index for every 2.x version (each one searches
+    # its own docs). We keep Sphinx's search.html/genindex.html around — they
+    # are still linked from prepare_gh_pages' rewritten 404 and from
+    # <link rel="search">, so removing them would yield broken references.
+    # They contain near-empty markup, so Pagefind will not rank them high.
+    if is_v2:
+        pagefind_exclude = ".headerlink,.wy-breadcrumbs,.rst-versions,.wy-nav-side,.wy-nav-top,.rst-footer-buttons,#conan-banners"
+        run(
+            f"python3 -m pagefind "
+            f"--site {output_folder}/{branch_folder} "
+            f"--root-selector '[role=\"main\"]' "
+            f"--exclude-selectors '{pagefind_exclude}'"
+        )
 
     # generate markdown mirrors for LLM consumption (llms.txt spec)
     # only for the latest 2.x version — mirrors are served under /2/ (latest alias)

--- a/.ci/scripts/generate_documentation.py
+++ b/.ci/scripts/generate_documentation.py
@@ -114,20 +114,12 @@ with chdir(f"{sources_folder}"):
     is_v2 = branch_folder.startswith("2")
     is_latest_v2 = (branch == latest_v2_branch)
     sitemap_opts = " -D html_baseurl=https://docs.conan.io/2/ -D sitemap_url_scheme={link}" if is_v2 else ""
-    # Every 2.x version gets Pagefind (modern as-you-type search, per-version
-    # index). 1.x (legacy) keeps the classic Sphinx form — rendered by the theme
-    # when use_pagefind is not set. is_latest_v2 toggles the "old version"
-    # warning banner inside the modal for non-latest 2.x builds.
+    # Pagefind search enabled on all 2.x; 1.x keeps the classic Sphinx form.
     pagefind_opts = " -A use_pagefind=1" if is_v2 else ""
     if is_latest_v2:
         pagefind_opts += " -A is_latest_v2=1"
     run(f"sphinx-build -W -b html -d {branch_folder}/_build/.doctrees {branch_folder}/ {output_folder}/{branch_folder}{sitemap_opts}{pagefind_opts}")
 
-    # Build a Pagefind search index for every 2.x version (each one searches
-    # its own docs). We keep Sphinx's search.html/genindex.html around — they
-    # are still linked from prepare_gh_pages' rewritten 404 and from
-    # <link rel="search">, so removing them would yield broken references.
-    # They contain near-empty markup, so Pagefind will not rank them high.
     if is_v2:
         pagefind_exclude = ".headerlink,.wy-breadcrumbs,.rst-versions,.wy-nav-side,.wy-nav-top,.rst-footer-buttons,#conan-banners"
         run(

--- a/.ci/scripts/prepare_gh_pages.py
+++ b/.ci/scripts/prepare_gh_pages.py
@@ -58,8 +58,17 @@ if path_latest_v2.exists():
     contents_404 = contents_404.replace('"search.html"', f"\"{prefix_latest}/search.html\"")
     contents_404 = contents_404.replace('"genindex.html"', f"\"{prefix_latest}/genindex.html\"")
 
+    # The global 404.html is served for ANY not-found URL. Pagefind's bundle
+    # path in the searchbox template resolves relative to document.baseURI,
+    # so at an arbitrary URL (docs.conan.io/random-path/) it'd resolve to
+    # docs.conan.io/random-path/pagefind/ → 404. Pin it to the latest 2.x.
+    contents_404 = contents_404.replace(
+        'new URL("pagefind/", document.baseURI).href',
+        f'"{prefix_latest}/pagefind/"',
+    )
+
     with open(path_404, 'w') as file:
-        file.write(contents_404)        
+        file.write(contents_404)
 
 run(f"cp -R {output_folder}/* {pages_folder}")
 

--- a/.ci/scripts/prepare_gh_pages.py
+++ b/.ci/scripts/prepare_gh_pages.py
@@ -58,10 +58,8 @@ if path_latest_v2.exists():
     contents_404 = contents_404.replace('"search.html"', f"\"{prefix_latest}/search.html\"")
     contents_404 = contents_404.replace('"genindex.html"', f"\"{prefix_latest}/genindex.html\"")
 
-    # The global 404.html is served for ANY not-found URL. Pagefind's bundle
-    # path in the searchbox template resolves relative to document.baseURI,
-    # so at an arbitrary URL (docs.conan.io/random-path/) it'd resolve to
-    # docs.conan.io/random-path/pagefind/ → 404. Pin it to the latest 2.x.
+    # The global 404.html is served for any URL, so document.baseURI varies
+    # and the relative bundle path breaks. Pin it to the latest 2.x absolute.
     contents_404 = contents_404.replace(
         'new URL("pagefind/", document.baseURI).href',
         f'"{prefix_latest}/pagefind/"',

--- a/_themes/conan_theme/layout.html
+++ b/_themes/conan_theme/layout.html
@@ -125,6 +125,10 @@
     <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
     {%- endif %}
   {%- endblock %}
+  {%- if use_pagefind %}
+  <link rel="stylesheet" href="{{ pathto('_static/css/pagefind-search.css', 1) }}" type="text/css" />
+  {%- endif %}
+
   {%- block extrahead %} {% endblock %}
 </head>
 

--- a/_themes/conan_theme/searchbox.html
+++ b/_themes/conan_theme/searchbox.html
@@ -32,9 +32,8 @@
   var modal = document.getElementById('pagefind-modal');
   var trigger = document.getElementById('pagefind-trigger');
   var mountedUi = null;
-  // bundlePath must be absolute — Pagefind's internal dynamic import() of
-  // pagefind.js resolves relative paths against the module URL, not the
-  // document, so a plain "pagefind/" ends up looking for pagefind/pagefind/...
+  // bundlePath must be absolute — Pagefind's dynamic import() resolves relative
+  // paths against the module URL, not the document.
   var bundlePath = new URL("{{ _pf_bundle }}", document.baseURI).href;
   var uiScriptLoaded = false;
 
@@ -104,8 +103,8 @@
     if (e.target.hasAttribute('data-pagefind-close')) closeModal();
   });
 
-  // Append the current query to result links so the landing page highlights
-  // the term. PagefindUI 1.5's highlightOnClick option is not implemented.
+  // Rewrite result links to include the query so the landing page can
+  // highlight it; PagefindUI 1.5's highlightOnClick is not implemented.
   document.getElementById('pagefind-search').addEventListener('click', function (e) {
     var link = e.target.closest && e.target.closest('a[href]');
     if (!link) return;
@@ -121,7 +120,7 @@
 })();
 </script>
 
-{#- Apply highlight + scroll when a page is opened from a search result. #}
+{#- Highlight + scroll when the page was opened from a search result. #}
 <script type="module">
   (async () => {
     var params = new URLSearchParams(window.location.search);

--- a/_themes/conan_theme/searchbox.html
+++ b/_themes/conan_theme/searchbox.html
@@ -1,4 +1,147 @@
 {%- if 'singlehtml' not in builder %}
+{%- if use_pagefind %}
+{%- set _pf_bundle = pathto('pagefind/', 1) %}
+<div role="search" class="pagefind-search-wrapper">
+  <button type="button" id="pagefind-trigger" class="pagefind-trigger" aria-label="{{ _('Search docs') }}">
+    <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+    <span>{{ _('Search docs') }}</span>
+    <kbd class="pagefind-kbd">⌘K</kbd>
+  </button>
+</div>
+
+<div id="pagefind-modal" class="pagefind-modal" role="dialog" aria-modal="true" aria-label="{{ _('Search docs') }}" hidden>
+  <div class="pagefind-modal-backdrop" data-pagefind-close></div>
+  <div class="pagefind-modal-panel">
+    <button type="button" class="pagefind-modal-close" aria-label="{{ _('Close search') }}" data-pagefind-close>&times;</button>
+    {%- if not is_latest_v2 %}
+    <div class="pagefind-stale-warning" role="note">
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+      <span>
+        You are searching the docs for Conan <strong>{{ release }}</strong>, which is not the latest release.
+        Results below reflect this version only.
+        <a href="https://docs.conan.io/2/">Switch to the latest docs →</a>
+      </span>
+    </div>
+    {%- endif %}
+    <div id="pagefind-search"></div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var modal = document.getElementById('pagefind-modal');
+  var trigger = document.getElementById('pagefind-trigger');
+  var mountedUi = null;
+  // bundlePath must be absolute — Pagefind's internal dynamic import() of
+  // pagefind.js resolves relative paths against the module URL, not the
+  // document, so a plain "pagefind/" ends up looking for pagefind/pagefind/...
+  var bundlePath = new URL("{{ _pf_bundle }}", document.baseURI).href;
+  var uiScriptLoaded = false;
+
+  function ensureUiScript(cb) {
+    if (window.PagefindUI) return cb();
+    if (uiScriptLoaded) {
+      var wait = setInterval(function () {
+        if (window.PagefindUI) { clearInterval(wait); cb(); }
+      }, 30);
+      return;
+    }
+    uiScriptLoaded = true;
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = bundlePath + 'pagefind-ui.css';
+    document.head.appendChild(link);
+    var s = document.createElement('script');
+    s.src = bundlePath + 'pagefind-ui.js';
+    s.onload = cb;
+    document.head.appendChild(s);
+  }
+
+  function openModal() {
+    modal.hidden = false;
+    document.body.classList.add('pagefind-modal-open');
+    ensureUiScript(function () {
+      if (!mountedUi) {
+        mountedUi = new window.PagefindUI({
+          element: "#pagefind-search",
+          bundlePath: bundlePath,
+          showSubResults: true,
+          resetStyles: false,
+          autofocus: true
+        });
+      }
+      setTimeout(function () {
+        var input = modal.querySelector('.pagefind-ui__search-input');
+        if (input) input.focus();
+      }, 50);
+    });
+  }
+
+  function closeModal() {
+    modal.hidden = true;
+    document.body.classList.remove('pagefind-modal-open');
+  }
+
+  if (trigger) trigger.addEventListener('click', openModal);
+
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+      e.preventDefault();
+      openModal();
+    } else if (e.key === 'Escape' && !modal.hidden) {
+      e.preventDefault();
+      closeModal();
+    } else if (e.key === '/' && modal.hidden) {
+      var tag = (e.target && e.target.tagName) || '';
+      if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !e.target.isContentEditable) {
+        e.preventDefault();
+        openModal();
+      }
+    }
+  });
+
+  modal.addEventListener('click', function (e) {
+    if (e.target.hasAttribute('data-pagefind-close')) closeModal();
+  });
+
+  // Append the current query to result links so the landing page highlights
+  // the term. PagefindUI 1.5's highlightOnClick option is not implemented.
+  document.getElementById('pagefind-search').addEventListener('click', function (e) {
+    var link = e.target.closest && e.target.closest('a[href]');
+    if (!link) return;
+    var input = modal.querySelector('.pagefind-ui__search-input');
+    var q = input && input.value && input.value.trim();
+    if (!q) return;
+    try {
+      var url = new URL(link.href, document.baseURI);
+      url.searchParams.set('pagefind-highlight', q);
+      link.href = url.toString();
+    } catch (err) { /* ignore */ }
+  }, true);
+})();
+</script>
+
+{#- Apply highlight + scroll when a page is opened from a search result. #}
+<script type="module">
+  (async () => {
+    var params = new URLSearchParams(window.location.search);
+    if (!params.has('pagefind-highlight')) return;
+    var base = new URL("{{ _pf_bundle }}", document.baseURI).href;
+    try {
+      var mod = await import(base + "pagefind-highlight.js");
+      new mod.default({
+        highlightParam: "pagefind-highlight",
+        className: "pagefind-highlight"
+      });
+      requestAnimationFrame(function () {
+        if (window.location.hash) return;
+        var first = document.querySelector('mark.pagefind-highlight');
+        if (first) first.scrollIntoView({ block: 'center' });
+      });
+    } catch (err) { /* fail silently */ }
+  })();
+</script>
+{%- else %}
 <div role="search">
   <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
     <input type="text" name="q" placeholder="{{ _('Search docs') }}" aria-label="{{ _('Search docs') }}" />
@@ -6,4 +149,5 @@
     <input type="hidden" name="area" value="default" />
   </form>
 </div>
+{%- endif %}
 {%- endif %}

--- a/_themes/conan_theme/static/css/pagefind-search.css
+++ b/_themes/conan_theme/static/css/pagefind-search.css
@@ -1,8 +1,5 @@
-/* ==========================================================================
-   Pagefind search — Conan theme, modern compact look
-   All Pagefind-ui rules prefixed with #pagefind-search to beat Svelte-scoped
-   selectors (e.g. .pagefind-ui__x.svelte-XXXX.svelte-XXXX).
-   ========================================================================== */
+/* Pagefind-ui overrides prefixed with #pagefind-search to win specificity
+   against Svelte-scoped selectors (.pagefind-ui__x.svelte-XXXX.svelte-XXXX). */
 
 /* ---------- Sidebar trigger ---------- */
 .pagefind-search-wrapper { margin: 0 0 10px 0; }
@@ -109,8 +106,7 @@ body.pagefind-modal-open { overflow: hidden; }
     align-items: flex-start;
     gap: 10px;
     margin: 0;
-    /* right padding reserves space for the absolute-positioned close button (28px + 10px margin + 8px breathing) */
-    padding: 10px 48px 10px 14px;
+    padding: 10px 48px 10px 14px;   /* right padding clears the close button */
     background: #fff7ed;
     border-bottom: 1px solid #fde68a;
     color: #7c2d12;
@@ -146,7 +142,7 @@ body.pagefind-modal-open { overflow: hidden; }
     --pagefind-ui-font: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
 }
 
-/* ---------- Kill Pagefind's built-in magnifier ---------- */
+/* Suppress Pagefind's built-in magnifier — we draw our own on the input. */
 #pagefind-search .pagefind-ui__form { position: relative !important; margin: 0 !important; padding: 0 !important; border: 0 !important; }
 #pagefind-search .pagefind-ui__form::before,
 #pagefind-search .pagefind-ui__form:before {
@@ -185,7 +181,7 @@ body.pagefind-modal-open { overflow: hidden; }
 }
 #pagefind-search .pagefind-ui__search-input::placeholder { color: #9aa4af !important; opacity: 1 !important; }
 
-/* ---------- Clear button (reset the big rounded Pagefind default) ---------- */
+/* Clear button — override Pagefind's 58px pill default. */
 #pagefind-search .pagefind-ui__search-clear {
     position: absolute !important;
     top: 50% !important;
@@ -234,7 +230,6 @@ body.pagefind-modal-open { overflow: hidden; }
     gap: 2px !important;
 }
 
-/* Each result — block layout, no thumb offset */
 #pagefind-search .pagefind-ui__result {
     display: block !important;
     padding: 10px 12px !important;
@@ -252,7 +247,6 @@ body.pagefind-modal-open { overflow: hidden; }
     background: #f5f8fb !important;
 }
 
-/* Inner wrapper — force block, no flex, no offset */
 #pagefind-search .pagefind-ui__result-inner {
     display: block !important;
     flex: unset !important;
@@ -378,8 +372,7 @@ body.pagefind-modal-open { overflow: hidden; }
 #pagefind-search::-webkit-scrollbar-thumb { background: #d9dee4; border-radius: 5px; }
 #pagefind-search::-webkit-scrollbar-thumb:hover { background: #bfc5cc; }
 
-/* ---------- In-page highlight (when arriving from a search result) ---------- */
-/* Pagefind-highlight.js wraps matches in <mark class="pagefind-highlight"> */
+/* In-page highlight applied by pagefind-highlight.js when landing from search. */
 mark.pagefind-highlight,
 mark.pagefind__highlight {
     background: #fff3b0;
@@ -401,7 +394,7 @@ mark.pagefind__highlight {
     opacity: 1 !important;
 }
 
-/* ---------- Mobile: fullscreen modal, bigger tap targets ---------- */
+/* Mobile: fullscreen modal, bigger tap targets. */
 @media (max-width: 640px) {
     .pagefind-modal {
         padding: 0;
@@ -410,7 +403,7 @@ mark.pagefind__highlight {
     .pagefind-modal-panel {
         max-width: 100%;
         max-height: 100vh;
-        max-height: 100dvh;               /* dynamic viewport, avoids iOS keyboard chrome */
+        max-height: 100dvh;               /* dodges iOS keyboard chrome */
         height: 100%;
         border-radius: 0;
         box-shadow: none;
@@ -423,11 +416,11 @@ mark.pagefind__highlight {
     }
     #pagefind-search { padding: 12px; }
     #pagefind-search .pagefind-ui__search-input {
-        font-size: 16px !important;        /* avoids iOS zoom-on-focus */
+        font-size: 16px !important;        /* prevents iOS zoom-on-focus */
         padding: 14px 60px 14px 42px !important;
     }
     #pagefind-search .pagefind-ui__result {
-        padding: 12px 10px !important;     /* larger tap area */
+        padding: 12px 10px !important;
     }
     .pagefind-stale-warning {
         padding: 10px 48px 10px 12px;

--- a/_themes/conan_theme/static/css/pagefind-search.css
+++ b/_themes/conan_theme/static/css/pagefind-search.css
@@ -1,0 +1,436 @@
+/* ==========================================================================
+   Pagefind search — Conan theme, modern compact look
+   All Pagefind-ui rules prefixed with #pagefind-search to beat Svelte-scoped
+   selectors (e.g. .pagefind-ui__x.svelte-XXXX.svelte-XXXX).
+   ========================================================================== */
+
+/* ---------- Sidebar trigger ---------- */
+.pagefind-search-wrapper { margin: 0 0 10px 0; }
+
+.pagefind-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    background: #fff;
+    color: #555;
+    border: 1px solid #d9d9d9;
+    border-radius: 6px;
+    font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+    font-size: 13px;
+    cursor: pointer;
+    transition: border-color .15s ease, box-shadow .15s ease;
+    text-align: left;
+}
+.pagefind-trigger:hover {
+    border-color: #3e8dbf;
+    box-shadow: 0 0 0 2px rgba(62, 141, 191, 0.15);
+}
+.pagefind-trigger svg { flex-shrink: 0; color: #888; }
+.pagefind-trigger > span {
+    flex: 1; color: #666;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.pagefind-kbd {
+    display: inline-block;
+    padding: 1px 6px;
+    border: 1px solid #ccc;
+    border-bottom-width: 2px;
+    border-radius: 4px;
+    background: #f4f4f4;
+    color: #555;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    line-height: 1.3;
+}
+@media (max-width: 768px) { .pagefind-kbd { display: none; } }
+
+/* ---------- Modal shell ---------- */
+.pagefind-modal {
+    position: fixed;
+    top: 0; right: 0; bottom: 0; left: 0;
+    z-index: 10000;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 8vh 16px 16px 16px;
+    font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+}
+.pagefind-modal[hidden] { display: none; }
+body.pagefind-modal-open { overflow: hidden; }
+
+.pagefind-modal-backdrop {
+    position: absolute; inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+}
+
+.pagefind-modal-panel {
+    position: relative;
+    width: 100%;
+    max-width: 620px;
+    max-height: 80vh;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.pagefind-modal-close {
+    position: absolute;
+    top: 10px; right: 10px;
+    width: 28px; height: 28px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    font-size: 20px;
+    line-height: 28px;
+    color: #9aa4af;
+    cursor: pointer;
+    z-index: 2;
+    border-radius: 6px;
+    transition: background .15s ease, color .15s ease;
+}
+.pagefind-modal-close:hover { background: #f1f5f9; color: #222; }
+
+#pagefind-search {
+    padding: 14px 14px 10px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+/* ---------- "You are searching an older version" warning ---------- */
+.pagefind-stale-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin: 0;
+    /* right padding reserves space for the absolute-positioned close button (28px + 10px margin + 8px breathing) */
+    padding: 10px 48px 10px 14px;
+    background: #fff7ed;
+    border-bottom: 1px solid #fde68a;
+    color: #7c2d12;
+    font-size: 12.5px;
+    line-height: 1.45;
+}
+.pagefind-stale-warning svg {
+    flex-shrink: 0;
+    margin-top: 1px;
+    color: #d97706;
+}
+.pagefind-stale-warning strong { color: #7c2d12; font-weight: 600; }
+.pagefind-stale-warning a {
+    color: #b45309;
+    font-weight: 600;
+    text-decoration: underline;
+    white-space: nowrap;
+}
+.pagefind-stale-warning a:hover { color: #7c2d12; }
+
+/* ---------- Pagefind UI variable overrides ---------- */
+:root {
+    --pagefind-ui-scale: 0.85;
+    --pagefind-ui-primary: #3e8dbf;
+    --pagefind-ui-text: #1f2937;
+    --pagefind-ui-background: #fff;
+    --pagefind-ui-border: #e6e9ee;
+    --pagefind-ui-tag: #f2f4f7;
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 8px;
+    --pagefind-ui-image-border-radius: 6px;
+    --pagefind-ui-image-box-ratio: 3 / 2;
+    --pagefind-ui-font: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+}
+
+/* ---------- Kill Pagefind's built-in magnifier ---------- */
+#pagefind-search .pagefind-ui__form { position: relative !important; margin: 0 !important; padding: 0 !important; border: 0 !important; }
+#pagefind-search .pagefind-ui__form::before,
+#pagefind-search .pagefind-ui__form:before {
+    display: none !important;
+    content: none !important;
+    background: none !important;
+    -webkit-mask-image: none !important;
+    mask-image: none !important;
+    width: 0 !important;
+    height: 0 !important;
+}
+
+/* ---------- Search input ---------- */
+#pagefind-search .pagefind-ui__search-input {
+    width: 100% !important;
+    box-sizing: border-box !important;
+    height: auto !important;
+    padding: 12px 70px 12px 42px !important;
+    font-size: 15px !important;
+    font-weight: 500 !important;
+    border: 1px solid #d9dee4 !important;
+    border-radius: 10px !important;
+    background-color: #fff !important;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='7'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>") !important;
+    background-repeat: no-repeat !important;
+    background-position: 14px 50% !important;
+    background-size: 16px 16px !important;
+    color: #1f2937 !important;
+    font-family: inherit !important;
+    display: block !important;
+}
+#pagefind-search .pagefind-ui__search-input:focus {
+    outline: none !important;
+    border-color: #3e8dbf !important;
+    box-shadow: 0 0 0 3px rgba(62, 141, 191, 0.18) !important;
+}
+#pagefind-search .pagefind-ui__search-input::placeholder { color: #9aa4af !important; opacity: 1 !important; }
+
+/* ---------- Clear button (reset the big rounded Pagefind default) ---------- */
+#pagefind-search .pagefind-ui__search-clear {
+    position: absolute !important;
+    top: 50% !important;
+    right: 8px !important;
+    transform: translateY(-50%) !important;
+    width: auto !important;
+    height: auto !important;
+    padding: 4px 10px !important;
+    background: transparent !important;
+    background-color: transparent !important;
+    border: 0 !important;
+    border-radius: 6px !important;
+    color: #6b7280 !important;
+    font-size: 12px !important;
+    font-weight: 500 !important;
+    box-shadow: none !important;
+    cursor: pointer;
+    transition: background-color .12s ease, color .12s ease;
+}
+#pagefind-search .pagefind-ui__search-clear:hover {
+    background: #f1f5f9 !important;
+    background-color: #f1f5f9 !important;
+    color: #1f2937 !important;
+}
+
+/* ---------- Meta row ("N results for…") ---------- */
+#pagefind-search .pagefind-ui__message {
+    padding: 10px 4px 6px !important;
+    margin: 0 !important;
+    font-size: 11px !important;
+    color: #6b7280 !important;
+    text-align: left !important;
+    font-weight: 600 !important;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* ---------- Results list ---------- */
+#pagefind-search .pagefind-ui__results,
+#pagefind-search .pagefind-ui__results-area {
+    list-style: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 2px !important;
+}
+
+/* Each result — block layout, no thumb offset */
+#pagefind-search .pagefind-ui__result {
+    display: block !important;
+    padding: 10px 12px !important;
+    margin: 0 !important;
+    border: none !important;
+    border-top: none !important;
+    border-bottom: none !important;
+    border-radius: 8px !important;
+    text-align: left !important;
+    transition: background-color .12s ease;
+    list-style: none !important;
+    gap: 0 !important;
+}
+#pagefind-search .pagefind-ui__result:hover {
+    background: #f5f8fb !important;
+}
+
+/* Inner wrapper — force block, no flex, no offset */
+#pagefind-search .pagefind-ui__result-inner {
+    display: block !important;
+    flex: unset !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    align-items: initial !important;
+    text-align: left !important;
+    width: 100% !important;
+    min-width: 0 !important;
+}
+
+/* Hide thumb entirely */
+#pagefind-search .pagefind-ui__result-thumb,
+#pagefind-search .pagefind-ui__result-image {
+    display: none !important;
+    width: 0 !important;
+    height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    flex: 0 !important;
+}
+
+/* Title */
+#pagefind-search .pagefind-ui__result-title,
+#pagefind-search .pagefind-ui__result-title a,
+#pagefind-search .pagefind-ui__result-link {
+    display: block !important;
+    text-align: left !important;
+    font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif !important;
+    font-size: 14px !important;
+    font-weight: 600 !important;
+    color: #1f2937 !important;
+    line-height: 1.3 !important;
+    text-decoration: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    min-width: 0 !important;
+}
+#pagefind-search .pagefind-ui__result:hover .pagefind-ui__result-title,
+#pagefind-search .pagefind-ui__result:hover .pagefind-ui__result-link {
+    color: #3e8dbf !important;
+}
+
+/* Excerpt */
+#pagefind-search .pagefind-ui__result-excerpt {
+    display: -webkit-box !important;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-align: left !important;
+    font-size: 12.5px !important;
+    font-weight: 400 !important;
+    color: #6b7280 !important;
+    line-height: 1.5 !important;
+    margin: 3px 0 0 !important;
+    padding: 0 !important;
+    min-width: 0 !important;
+    width: 100% !important;
+}
+#pagefind-search .pagefind-ui__result-excerpt mark {
+    background: #fff3b0 !important;
+    color: #1f2937 !important;
+    font-style: normal !important;
+    font-weight: 600 !important;
+    padding: 0 2px !important;
+    border-radius: 2px !important;
+}
+
+/* Sub-results */
+#pagefind-search .pagefind-ui__result-nested {
+    display: block !important;
+    margin: 6px 0 0 !important;
+    padding: 6px 10px !important;
+    border-left: 2px solid #e6e9ee !important;
+    background: transparent !important;
+    border-radius: 0 6px 6px 0 !important;
+    text-align: left !important;
+}
+#pagefind-search .pagefind-ui__result-nested:hover {
+    background: #f5f8fb !important;
+    border-left-color: #3e8dbf !important;
+}
+#pagefind-search .pagefind-ui__result-nested .pagefind-ui__result-link {
+    font-size: 13px !important;
+    font-weight: 500 !important;
+    color: #3e8dbf !important;
+}
+#pagefind-search .pagefind-ui__result-nested .pagefind-ui__result-excerpt {
+    font-size: 12px !important;
+    color: #6b7280 !important;
+    -webkit-line-clamp: 1 !important;
+    margin: 2px 0 0 !important;
+}
+
+/* "Load more" button */
+#pagefind-search .pagefind-ui__button,
+#pagefind-search button.pagefind-ui__button {
+    display: block !important;
+    width: 100% !important;
+    height: auto !important;
+    margin: 8px 0 4px !important;
+    padding: 9px 12px !important;
+    background: #f5f8fb !important;
+    background-color: #f5f8fb !important;
+    color: #3e8dbf !important;
+    border: 1px solid #e6e9ee !important;
+    border-radius: 8px !important;
+    font-size: 13px !important;
+    font-weight: 600 !important;
+    text-align: center !important;
+    cursor: pointer;
+    transition: background-color .12s ease, border-color .12s ease;
+}
+#pagefind-search button.pagefind-ui__button:hover {
+    background: #e9f1f8 !important;
+    background-color: #e9f1f8 !important;
+    border-color: #3e8dbf !important;
+}
+
+/* Scrollbar */
+#pagefind-search::-webkit-scrollbar { width: 10px; }
+#pagefind-search::-webkit-scrollbar-thumb { background: #d9dee4; border-radius: 5px; }
+#pagefind-search::-webkit-scrollbar-thumb:hover { background: #bfc5cc; }
+
+/* ---------- In-page highlight (when arriving from a search result) ---------- */
+/* Pagefind-highlight.js wraps matches in <mark class="pagefind-highlight"> */
+mark.pagefind-highlight,
+mark.pagefind__highlight {
+    background: #fff3b0;
+    color: inherit;
+    padding: 0 2px;
+    border-radius: 2px;
+    box-shadow: 0 0 0 1px rgba(241, 196, 15, 0.4);
+    font-weight: inherit;
+}
+
+/* Empty / loading */
+#pagefind-search .pagefind-ui__loading,
+#pagefind-search .pagefind-ui__no-results {
+    padding: 24px 8px !important;
+    color: #6b7280 !important;
+    font-size: 13px !important;
+    text-align: center !important;
+    background: transparent !important;
+    opacity: 1 !important;
+}
+
+/* ---------- Mobile: fullscreen modal, bigger tap targets ---------- */
+@media (max-width: 640px) {
+    .pagefind-modal {
+        padding: 0;
+        align-items: stretch;
+    }
+    .pagefind-modal-panel {
+        max-width: 100%;
+        max-height: 100vh;
+        max-height: 100dvh;               /* dynamic viewport, avoids iOS keyboard chrome */
+        height: 100%;
+        border-radius: 0;
+        box-shadow: none;
+    }
+    .pagefind-modal-close {
+        top: 6px; right: 6px;
+        width: 44px; height: 44px;
+        font-size: 26px;
+        line-height: 44px;
+    }
+    #pagefind-search { padding: 12px; }
+    #pagefind-search .pagefind-ui__search-input {
+        font-size: 16px !important;        /* avoids iOS zoom-on-focus */
+        padding: 14px 60px 14px 42px !important;
+    }
+    #pagefind-search .pagefind-ui__result {
+        padding: 12px 10px !important;     /* larger tap area */
+    }
+    .pagefind-stale-warning {
+        padding: 10px 48px 10px 12px;
+        font-size: 12px;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sphinxcontrib-youtube==1.4.1
 docutils==0.20.1
 jinja2==3.1.4
 sphinx-markdown-builder==0.6.10
+pagefind[bin]==1.5.0


### PR DESCRIPTION
Replaces the default Sphinx search on every Conan 2.x docs version with [Pagefind](https://pagefind.app) 
 
- 1.x legacy docs are untouched and keep the classic Sphinx form. 
- Older 2.x versions show an inline banner pointing users to the latest release.

for the latest version:
<img width="642" height="556" alt="latest" src="https://github.com/user-attachments/assets/f4213805-13af-4e71-aef6-ee3a9efdc002" />

if not latest, there's a warning about not searching in the latest.
<img width="642" height="556" alt="not-latest" src="https://github.com/user-attachments/assets/7970006d-3fbc-4a42-8020-759cf608f5c5" />

<img width="1255" height="942" alt="image" src="https://github.com/user-attachments/assets/c2aa1940-3abf-48ee-9986-e611be7c9fcb" />

<img width="1525" height="926" alt="image" src="https://github.com/user-attachments/assets/cb451c81-0ff3-489f-a46a-207ef73b15f6" />
