### PR TITLE
Skip PDF regeneration for unchanged versions in docs publish

### DIFF
--- a/.ci/publish.jenkins
+++ b/.ci/publish.jenkins
@@ -26,6 +26,11 @@ try {
         List branches = params.branches.split(',')
         echo "Generating docs for ${branches}"
 
+        // Branches to (re)generate PDF for. Others keep their existing conan.pdf
+        // from gh-pages. Empty means regenerate all (legacy behavior).
+        List pdfBranches = (params.pdf_branches ?: '').split(',').findAll { it }
+        echo "Regenerating PDFs for ${pdfBranches ?: 'ALL branches (default)'}"
+
         checkout scm
 
         stage('Prepare sources as worktrees') {
@@ -54,6 +59,8 @@ try {
                     def conanHome   = "${env.WORKSPACE}/.conan_home_${safeBranch}"
                     echo "Using CONAN_HOME=${conanHome} for ${branch}"
 
+                    def withPdfFlag = (pdfBranches.isEmpty() || pdfBranches.contains(branch)) ? '--with-pdf' : ''
+
                     sh """
                         export CONAN_WORKSPACE_ENABLE=will_break_next
                         mkdir -p "${conanHome}"
@@ -61,7 +68,7 @@ try {
                         python3 -m venv venv_${branch}
                         . venv_${branch}/bin/activate
                         pip install -r requirements.txt
-                        python3 .ci/scripts/generate_documentation.py --sources-folder=${sources_folder} --branch=${branch} --with-pdf
+                        python3 .ci/scripts/generate_documentation.py --sources-folder=${sources_folder} --branch=${branch} ${withPdfFlag}
                     """
                 }
             }

--- a/.ci/scripts/get_branches.py
+++ b/.ci/scripts/get_branches.py
@@ -1,6 +1,7 @@
 import os
+import sys
 
-from common import run, conan_versions
+from common import run, conan_versions, latest_v2_branch
 
 
 """
@@ -10,7 +11,15 @@ from common import run, conan_versions
     branch -> regenerate every branch of the docs.
 
     2. If we did not touch those folders just regenerate the branch we pushed
+
+    With --latest-v2-only, print just the latest v2 branch (used to decide which
+    branches get their PDF regenerated when a global rebuild is triggered).
 """
+
+if "--latest-v2-only" in sys.argv:
+    print(latest_v2_branch)
+    sys.exit(0)
+
 current_branch = os.getenv("BRANCH_NAME")
 
 current_commit = run("git rev-parse HEAD", capture=True).strip()

--- a/.ci/test.jenkins
+++ b/.ci/test.jenkins
@@ -25,8 +25,13 @@ node('LinuxDocs') {
     if (publishDocs) {
         String branches = sh(script: 'python3 .ci/scripts/get_branches.py', returnStdout: true).trim().readLines().join(',')
         echo "Will generate docs for ${branches}"
+        // Only regenerate the PDF for the latest v2 branch. Older versions keep
+        // their existing conan.pdf from gh-pages. Trigger a manual publish with
+        // a custom pdf_branches if you need to rebuild older PDFs.
+        String pdfBranches = sh(script: 'python3 .ci/scripts/get_branches.py --latest-v2-only', returnStdout: true).trim()
         build(job: 'Conan-Docs-Publish', propagate: true, wait: true, parameters: [
             [$class: 'StringParameterValue', name: 'branches', value: branches],
+            [$class: 'StringParameterValue', name: 'pdf_branches', value: pdfBranches],
             [$class: 'BooleanParameterValue', name: 'publish', value: true]
         ])
     }


### PR DESCRIPTION
The docs publish was taking too long because every version's PDF was being regenerated on every run, even when nothing had changed in those older branches.

This optimizes the flow by only (re)building PDFs when they actually need to change. Logic:

- Push to a `release/2.X` branch → regenerate that branch's PDF.
- Push to `master` (including `.ci/` or `_themes/` changes that trigger a global rebuild) → regenerate HTML for all versions but PDF only for the latest v2.
- Manual publish from the Jenkins UI → `pdf_branches` empty rebuilds all PDFs (useful after a LaTeX theme change); a specific list rebuilds only that subset.

Older versions keep their existing `conan.pdf` from `gh-pages` untouched, since `prepare_gh_pages.py` clones `gh-pages` first and only overwrites files produced by the current run.
