### PR TITLE
Search fixes: sub-results, keyboard navigation, highlight

### DIFF
--- a/.ci/scripts/generate_documentation.py
+++ b/.ci/scripts/generate_documentation.py
@@ -121,6 +121,12 @@ with chdir(f"{sources_folder}"):
     run(f"sphinx-build -W -b html -d {branch_folder}/_build/.doctrees {branch_folder}/ {output_folder}/{branch_folder}{sitemap_opts}{pagefind_opts}")
 
     if is_v2:
+        # Drop Sphinx utility pages before Pagefind indexes them. They have
+        # near-empty content and would otherwise pollute search results.
+        for stale in ("search.html", "genindex.html", "py-modindex.html"):
+            stale_path = os.path.join(output_folder, branch_folder, stale)
+            if os.path.exists(stale_path):
+                os.remove(stale_path)
         pagefind_exclude = ".headerlink,.wy-breadcrumbs,.rst-versions,.wy-nav-side,.wy-nav-top,.rst-footer-buttons,#conan-banners"
         run(
             f"python3 -m pagefind "

--- a/_themes/conan_theme/__init__.py
+++ b/_themes/conan_theme/__init__.py
@@ -7,8 +7,10 @@ From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 from os import path
 from sys import version_info as python_version
 
+from docutils import nodes
 from sphinx import version_info as sphinx_version
 from sphinx.locale import _
+from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util.logging import getLogger
 
 
@@ -35,6 +37,27 @@ def config_initiated(app, config):
 def extend_html_context(app, pagename, templatename, context, doctree):
      # Add ``sphinx_version_info`` tuple for use in Jinja templates
      context['sphinx_version_info'] = sphinx_version
+
+
+class CopySectionIdsToTitles(SphinxPostTransform):
+    """Mirror each <section id="..."> onto its first inner title node so the
+    HTML writer emits <hN id="..."> too. Pagefind builds sub-results from
+    headings carrying an id; Sphinx places ids only on the wrapping section."""
+    default_priority = 900
+    builders = ('html',)
+
+    def run(self, **kwargs):
+        for section in self.document.findall(nodes.section):
+            section_ids = section.get('ids') or []
+            if not section_ids:
+                continue
+            for child in section.children:
+                if isinstance(child, nodes.title):
+                    existing = set(child.get('ids') or [])
+                    for sid in section_ids:
+                        if sid not in existing:
+                            child['ids'].append(sid)
+                    break
 
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
@@ -73,5 +96,10 @@ def setup(app):
 
     # Extend the default context when rendering the templates.
     app.connect("html-page-context", extend_html_context)
+
+    # Ensure each section's id is also on its heading, so Pagefind can build
+    # sub-results with the heading text as title. Harmless for non-Pagefind
+    # builds. Requires conan_theme to be in conf.py's extensions list.
+    app.add_post_transform(CopySectionIdsToTitles)
 
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/_themes/conan_theme/searchbox.html
+++ b/_themes/conan_theme/searchbox.html
@@ -68,12 +68,31 @@
           resetStyles: false,
           autofocus: true
         });
+        var input = modal.querySelector('.pagefind-ui__search-input');
+        if (input) input.addEventListener('input', function () { selectedIdx = -1; });
       }
       setTimeout(function () {
         var input = modal.querySelector('.pagefind-ui__search-input');
         if (input) input.focus();
       }, 50);
     });
+  }
+
+  // Keyboard navigation across result links.
+  var selectedIdx = -1;
+  function resultLinks() {
+    return Array.prototype.slice.call(
+      modal.querySelectorAll('.pagefind-ui__result-link')
+    );
+  }
+  function setSelected(idx) {
+    var links = resultLinks();
+    resultLinks().forEach(function (a) { a.classList.remove('pagefind-selected'); });
+    if (links.length === 0) { selectedIdx = -1; return; }
+    selectedIdx = ((idx % links.length) + links.length) % links.length;
+    var cur = links[selectedIdx];
+    cur.classList.add('pagefind-selected');
+    cur.scrollIntoView({ block: 'nearest' });
   }
 
   function closeModal() {
@@ -87,15 +106,38 @@
     if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
       e.preventDefault();
       openModal();
-    } else if (e.key === 'Escape' && !modal.hidden) {
+      return;
+    }
+    if (modal.hidden) {
+      if (e.key === '/' ) {
+        var tag = (e.target && e.target.tagName) || '';
+        if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !e.target.isContentEditable) {
+          e.preventDefault();
+          openModal();
+        }
+      }
+      return;
+    }
+    // Modal is open.
+    if (e.key === 'Escape') {
       e.preventDefault();
       closeModal();
-    } else if (e.key === '/' && modal.hidden) {
-      var tag = (e.target && e.target.tagName) || '';
-      if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !e.target.isContentEditable) {
-        e.preventDefault();
-        openModal();
-      }
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelected(selectedIdx + 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelected(selectedIdx - 1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setSelected(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setSelected(resultLinks().length - 1);
+    } else if (e.key === 'Enter') {
+      var links = resultLinks();
+      var target = selectedIdx >= 0 ? links[selectedIdx] : links[0];
+      if (target) { e.preventDefault(); target.click(); }
     }
   });
 
@@ -105,6 +147,8 @@
 
   // Rewrite result links to include the query so the landing page can
   // highlight it; PagefindUI 1.5's highlightOnClick is not implemented.
+  // Each word is a separate param because pagefind-highlight forces
+  // separateWordSearch=false in mark.js (whole-phrase match only).
   document.getElementById('pagefind-search').addEventListener('click', function (e) {
     var link = e.target.closest && e.target.closest('a[href]');
     if (!link) return;
@@ -113,7 +157,10 @@
     if (!q) return;
     try {
       var url = new URL(link.href, document.baseURI);
-      url.searchParams.set('pagefind-highlight', q);
+      url.searchParams.delete('pagefind-highlight');
+      q.split(/\s+/).filter(Boolean).forEach(function (w) {
+        url.searchParams.append('pagefind-highlight', w);
+      });
       link.href = url.toString();
     } catch (err) { /* ignore */ }
   }, true);
@@ -133,9 +180,14 @@
         className: "pagefind-highlight"
       });
       requestAnimationFrame(function () {
-        if (window.location.hash) return;
-        var first = document.querySelector('mark.pagefind-highlight');
-        if (first) first.scrollIntoView({ block: 'center' });
+        if (!window.location.hash) {
+          var first = document.querySelector('mark.pagefind-highlight');
+          if (first) first.scrollIntoView({ block: 'center' });
+        }
+        // Strip pagefind-highlight from the address bar so copy/share is clean.
+        var u = new URL(window.location.href);
+        u.searchParams.delete('pagefind-highlight');
+        window.history.replaceState({}, '', u.toString());
       });
     } catch (err) { /* fail silently */ }
   })();

--- a/_themes/conan_theme/static/css/pagefind-search.css
+++ b/_themes/conan_theme/static/css/pagefind-search.css
@@ -232,26 +232,36 @@ body.pagefind-modal-open { overflow: hidden; }
 
 #pagefind-search .pagefind-ui__result {
     display: block !important;
-    padding: 10px 12px !important;
+    padding: 0 !important;
     margin: 0 !important;
     border: none !important;
-    border-top: none !important;
-    border-bottom: none !important;
-    border-radius: 8px !important;
+    border-top: 1px solid #eef1f4 !important;
+    border-radius: 0 !important;
     text-align: left !important;
-    transition: background-color .12s ease;
     list-style: none !important;
     gap: 0 !important;
 }
-#pagefind-search .pagefind-ui__result:hover {
-    background: #f5f8fb !important;
+#pagefind-search .pagefind-ui__result:first-child {
+    border-top: none !important;
+}
+#pagefind-search a.pagefind-selected {
+    color: #3e8dbf !important;
+    outline: 2px solid rgba(62, 141, 191, 0.35);
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+#pagefind-search a.pagefind-selected {
+    color: #3e8dbf !important;
+    outline: 2px solid rgba(62, 141, 191, 0.35);
+    outline-offset: 2px;
+    border-radius: 4px;
 }
 
 #pagefind-search .pagefind-ui__result-inner {
     display: block !important;
     flex: unset !important;
     margin: 0 !important;
-    padding: 0 !important;
+    padding: 12px 4px 14px 4px !important;
     align-items: initial !important;
     text-align: left !important;
     width: 100% !important;
@@ -276,7 +286,7 @@ body.pagefind-modal-open { overflow: hidden; }
     display: block !important;
     text-align: left !important;
     font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif !important;
-    font-size: 14px !important;
+    font-size: 13.5px !important;
     font-weight: 600 !important;
     color: #1f2937 !important;
     line-height: 1.3 !important;
@@ -286,9 +296,40 @@ body.pagefind-modal-open { overflow: hidden; }
     width: 100% !important;
     min-width: 0 !important;
 }
+
+/* Page-level title styled as a group header with a leading list icon. */
+#pagefind-search .pagefind-ui__result-inner > .pagefind-ui__result-title,
+#pagefind-search .pagefind-ui__result-inner > a.pagefind-ui__result-link {
+    position: relative;
+    padding-left: 22px !important;
+    font-size: 15px !important;
+    font-weight: 700 !important;
+    margin-bottom: 2px !important;
+}
+#pagefind-search .pagefind-ui__result-inner > .pagefind-ui__result-title::before,
+#pagefind-search .pagefind-ui__result-inner > a.pagefind-ui__result-link::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 14px;
+    height: 14px;
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%231f2937' stroke-width='2.5' stroke-linecap='round'><line x1='4' y1='6' x2='20' y2='6'/><line x1='4' y1='12' x2='20' y2='12'/><line x1='4' y1='18' x2='20' y2='18'/></svg>");
+}
 #pagefind-search .pagefind-ui__result:hover .pagefind-ui__result-title,
 #pagefind-search .pagefind-ui__result:hover .pagefind-ui__result-link {
     color: #3e8dbf !important;
+}
+
+/* Hide the page-level excerpt when there are sub-results — the section
+   excerpts below are already contextual. Keep it when the page has no
+   sub-matches (rare but possible). */
+#pagefind-search .pagefind-ui__result:has(.pagefind-ui__result-nested)
+    > .pagefind-ui__result-inner > .pagefind-ui__result-excerpt {
+    display: none !important;
 }
 
 /* Excerpt */
@@ -316,29 +357,38 @@ body.pagefind-modal-open { overflow: hidden; }
     border-radius: 2px !important;
 }
 
-/* Sub-results */
+/* Sub-results — indented list under the page group header. */
 #pagefind-search .pagefind-ui__result-nested {
     display: block !important;
-    margin: 6px 0 0 !important;
-    padding: 6px 10px !important;
-    border-left: 2px solid #e6e9ee !important;
+    margin: 0 !important;
+    padding: 6px 8px 6px 22px !important;  /* aligns with the list icon above */
+    border: none !important;
     background: transparent !important;
-    border-radius: 0 6px 6px 0 !important;
+    border-radius: 6px !important;
     text-align: left !important;
+}
+#pagefind-search .pagefind-ui__result-nested + .pagefind-ui__result-nested {
+    margin-top: 2px !important;
 }
 #pagefind-search .pagefind-ui__result-nested:hover {
     background: #f5f8fb !important;
-    border-left-color: #3e8dbf !important;
 }
 #pagefind-search .pagefind-ui__result-nested .pagefind-ui__result-link {
     font-size: 13px !important;
-    font-weight: 500 !important;
+    font-weight: 600 !important;
+    color: #1f2937 !important;
+    padding-left: 0 !important;
+}
+#pagefind-search .pagefind-ui__result-nested .pagefind-ui__result-link::before {
+    content: none !important;   /* no icon on sub-results */
+}
+#pagefind-search .pagefind-ui__result-nested:hover .pagefind-ui__result-link {
     color: #3e8dbf !important;
 }
 #pagefind-search .pagefind-ui__result-nested .pagefind-ui__result-excerpt {
-    font-size: 12px !important;
+    font-size: 12.5px !important;
     color: #6b7280 !important;
-    -webkit-line-clamp: 1 !important;
+    -webkit-line-clamp: 2 !important;
     margin: 2px 0 0 !important;
 }
 


### PR DESCRIPTION
- **Sub-results per section.** Searching now groups hits by heading (H2/H3) instead of just page-level. Achieved via a Sphinx post-transform in `conan_theme` that mirrors each `<section>`'s id onto its inner `<hN>`, which is what Pagefind needs to detect sub-results.
- **Keyboard navigation.** `↑`/`↓`/`Home`/`End` to move through results, `Enter` to open. Selected result gets an outline.
- **Multi-word highlight.** Clicking a result now highlights every word of the query on the landing page, not just exact phrase matches. 
- **Cleaner results.** `search.html`, `genindex.html`, `py-modindex.html` no longer appear in search

The post-transform only runs on branches that have `conan_theme` in their `conf.py` `extensions` list — today only `master` does. I will open a PR to `release/2.27`, maybe a couple of previous versions, so subsection search will only work for those.

<img width="635" height="790" alt="image" src="https://github.com/user-attachments/assets/5174c1d5-6f52-4578-8927-36c0d709e288" />
<img width="1115" height="915" alt="image" src="https://github.com/user-attachments/assets/ad0d33af-ef81-4f7b-8643-909f896b0f59" />
