### PR TITLE
Register conan_theme as a Sphinx extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,7 @@ sys.path.append(os.path.abspath('./_ext'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'conan_theme',
     'sphinxcontrib.spelling',
     'sphinx_sitemap',
     'notfound.extension',


### PR DESCRIPTION
Adds `'conan_theme'` to `extensions` so its `setup()` runs. Needed for the Pagefind sub-results post-transform added in master to work on this version.

Without this, search results on 2.27 only link to pages, not to H2/H3 sections within them.

to be merged after https://github.com/conan-io/docs/pull/4429

Maybe we should port this to a couple of previous releases, let's see after merging.