### PR TITLE
Fix #4398: Clarify replace_tool_requires vs replace_requires context …

### DIFF
--- a/reference/config_files/profiles.rst
+++ b/reference/config_files/profiles.rst
@@ -504,8 +504,8 @@ In this case, whatever version of ``cmake`` declared in recipes, will be replace
 
    * This section should be added to the profile whose context is the one that requires the tool, i.e., if the
      tool is required in the host context, then it should be added to the host profile, so that the requirement
-     itself can be replaced.
-
+     itself can be replaced. For example, if a ``zlib`` recipe in the host context has a ``tool_requires("cmake/xxx")``, a ``replace_tool_requires`` in the **host profile** will replace it.
+   * If what you want to replace are transitive dependencies of the tools that live inside ``tool_requires`` packages, those live in the **build context**. To replace them, you must add the replacements to the **build profile**. Both ``[replace_requires]`` and ``[replace_tool_requires]`` in the build profile will affect the build context in the same way, replacing ``requires`` and ``tool_requires`` of the tools themselves.
 
 .. _reference_config_files_profiles_platform_requires:
 


### PR DESCRIPTION
…behavior

Issue Addressed: #4398 - Users were confused about why [replace_tool_requires] in their host profile was not replacing the transitive dependencies inside tools (which inherently exist in the build context). File Modified: reference/config_files/profiles.rst

What was changed: I updated the .. note:: section under [replace_tool_requires] to explicitly detail how contextual replacements work:

Host Context Clarification: Added an example stating that a replace_tool_requires in the host profile only overrides tool_requires called by packages residing in the host context (like a standard zlib package needing CMake).
Build Context & Transitive Dependencies: Detailed that transitive dependencies of tools live in the build context. Therefore, any replacements meant to solve conflicts within those dependencies (using either replace_requires or replace_tool_requires) must be specified in the build profile.
