### PR TITLE
Add conan.tools.build.architecture_bits in tools reference

### DIFF
--- a/reference/tools/build.rst
+++ b/reference/tools/build.rst
@@ -34,6 +34,13 @@ conan.tools.build.can_run()
 .. autofunction:: can_run
 
 
+conan.tools.build.architecture_bits()
+"""""""""""""""""""""""""""""""""""""
+
+.. currentmodule:: conan.tools.build.flags
+
+.. autofunction:: architecture_bits
+
 
 Cppstd
 ^^^^^^
@@ -163,4 +170,3 @@ conan.tools.build.check_min_compiler_version()
 .. currentmodule:: conan.tools.build.compiler
 
 .. autofunction:: check_min_compiler_version
-


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/pull/20246

Preview:

<img width="3438" height="1944" alt="Screenshot 2026-08-14 at 12-55-02 conan tools build — conan 2 31 2 documentation" src="https://github.com/user-attachments/assets/e5b0fe06-4790-46ad-b96d-2e6bb6e06844" />
